### PR TITLE
fix: wait for transaction visibility between sequential broadcasts

### DIFF
--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -4,6 +4,23 @@ Troubleshooting
 In this document there are troubleshooting
 instructions for common errors.
 
+Sequential transaction broadcasts
+---------------------------------
+
+``wait_and_broadcast_multiple_nodes()`` broadcasts transactions with sequential
+nonces one at a time. Before broadcasting the following nonce, it polls each
+configured read provider with ``eth_getTransactionByHash`` for the preceding
+transaction. This avoids a fixed inter-transaction sleep and proceeds as soon
+as every provider can return the transaction.
+
+``inter_node_delay`` remains the maximum visibility wait for compatibility. If
+it expires, the batch proceeds when at least one read provider can see the
+transaction, so one failed or lagging read provider does not block execution.
+If no provider responds, the gate logs a warning and normal confirmation and
+rebroadcast handling continues. Transaction visibility is not receipt
+confirmation; receipt confirmation still happens after the complete batch is
+broadcast.
+
 Limits exceeded
 ---------------
 
@@ -34,4 +51,3 @@ You can do the following:
             --data-raw '{"jsonrpc": "2.0", "method": "eth_getLogs", "params": [{"topics": [["0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1"]], "fromBlock": "0xd59f80", "toBlock": "0xd59fe3", "address": "0x58F876857a02D6762E0101bb5C46A8c1ED44Dc16"}], "id": 10}'
 
 See also `bnb-chain-get-logs-test.py` script.
-

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -30,6 +30,7 @@ from eth_defi.provider.anvil import is_anvil, mine
 from eth_defi.provider.fallback import FallbackProvider, get_fallback_provider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
 from eth_defi.provider.named import get_provider_name
+from eth_defi.provider.receipt import TransactionVisibilityTimedOut, wait_for_transaction_visibility
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.timestamp import get_latest_block_timestamp
 from eth_defi.tx import DecodeFailure, decode_signed_transaction, get_tx_broadcast_data
@@ -855,7 +856,14 @@ def wait_and_broadcast_multiple_nodes(
     :param inter_node_delay:
         Work around bad JSON-RPC SaaS providers.
 
-        Sleep this time between multiple tx broadcasts.
+        Wait up to this time between multiple tx broadcasts for all read
+        providers to see the preceding transaction. Progress immediately once
+        they do. At timeout, progress when at least one read provider sees it.
+        If no provider sees it, continue with normal confirmation and rebroadcast
+        handling.
+
+        This checks transaction visibility only; normal receipt confirmation
+        follows after the complete batch has been broadcast.
 
         See https://github.com/ethereum/go-ethereum/issues/26890
 
@@ -905,8 +913,7 @@ def wait_and_broadcast_multiple_nodes(
     anviled = is_anvil(web3)
 
     if anviled:
-        # Anvil is buggy piece of crap when you hit it with multiple RPC/broadcast requests,
-        # so try to sleep and pray it works
+        # Keep the visibility deadline short on Anvil so unit tests remain fast.
         inter_node_delay = datetime.timedelta(seconds=0.5)
 
     for tx in txs:
@@ -937,7 +944,7 @@ def wait_and_broadcast_multiple_nodes(
         logger.info("No MEV blocker enable, Anvil is %s", anviled)
 
     logger.info(
-        "Broadcasting %d transactions using %s to confirm in %d blocks, timeout is %s, inter node delay is %s",
+        "Broadcasting %d transactions using %s to confirm in %d blocks, timeout is %s, inter-node visibility timeout is %s",
         len(txs),
         ", ".join([get_provider_name(p) for p in providers]),
         confirmation_block_count,
@@ -968,8 +975,9 @@ def wait_and_broadcast_multiple_nodes(
 
     last_exception: Exception | None = None
 
-    # Initial broadcast of txs
-    for tx in txs:
+    # Initial broadcast of txs. Wait for read-provider visibility before the
+    # following sequential nonce, using the former sleep as a maximum budget.
+    for tx_index, tx in enumerate(txs):
         try:
             _broadcast_multiple_nodes(providers, tx)
             last_exception = None
@@ -979,18 +987,45 @@ def wait_and_broadcast_multiple_nodes(
         except Exception as e:
             last_exception = e
 
-        if len(txs) >= 2:
+        if tx_index < len(txs) - 1:
             # https://github.com/ethereum/go-ethereum/issues/26890
-            logger.info("Broadcasting multiple transactions, using inter node delay %s to sleep to ensure poor-quality nodes like Alchemy work", inter_node_delay)
-            time.sleep(inter_node_delay.total_seconds())
-
-            if anviled:
-                mine(web3)
-
-            # logger.info("Sleep done")
+            visibility_timeout = inter_node_delay.total_seconds()
+            if visibility_timeout > 0:
+                visibility_poll_delay = min(1.0, visibility_timeout / 2)
+                try:
+                    wait_for_transaction_visibility(
+                        web3,
+                        tx.hash,
+                        timeout=visibility_timeout,
+                        poll_delay=visibility_poll_delay,
+                        max_poll_delay=max(visibility_poll_delay, min(5.0, visibility_timeout / 2)),
+                    )
+                except TransactionVisibilityTimedOut as e:
+                    # A private or unhealthy read provider can hide a broadcast
+                    # temporarily. Let the existing confirmation/rebroadcast
+                    # loop handle this just as it did after the former sleep.
+                    logger.warning(
+                        "Transaction visibility gate timed out, continuing with broadcast batch, tx_hash=%s, error=%s",
+                        tx.hash.hex(),
+                        e,
+                    )
+                except Exception as e:
+                    # Provider implementations can raise exceptions outside the
+                    # normal JSON-RPC hierarchy. Visibility is only a best-effort
+                    # sequencing optimisation and must not interrupt the batch.
+                    logger.warning(
+                        "Transaction visibility gate failed, continuing with broadcast batch, tx_hash=%s, error=%s",
+                        tx.hash.hex(),
+                        e,
+                    )
+            else:
+                logger.info(
+                    "Transaction visibility wait disabled, tx_hash=%s",
+                    tx.hash.hex(),
+                )
         else:
             logger.info(
-                "Internode sleep skipped",
+                "Transaction visibility wait skipped after final transaction",
             )
 
     while len(unconfirmed_txs) > 0:

--- a/eth_defi/provider/receipt.py
+++ b/eth_defi/provider/receipt.py
@@ -86,6 +86,10 @@ class ReceiptVisibilityTimedOut(TimeoutError):
     """Timed out before all read providers could see a transaction receipt."""
 
 
+class TransactionVisibilityTimedOut(TimeoutError):
+    """Timed out before enough read providers could see a transaction."""
+
+
 class ReceiptVisibilityMismatch(RuntimeError):
     """Read providers returned conflicting receipt data for the same transaction."""
 
@@ -139,6 +143,12 @@ def _get_provider_label(index: int, provider: BaseProvider) -> str:
 def _fetch_raw_receipt(provider: BaseProvider, tx_hash_hex: str) -> dict | None:
     """Fetch raw JSON-RPC receipt data from a provider."""
     response = provider.make_request("eth_getTransactionReceipt", [tx_hash_hex])
+    return response.get("result")
+
+
+def _fetch_raw_transaction(provider: BaseProvider, tx_hash_hex: str) -> dict | None:
+    """Fetch raw JSON-RPC transaction data from a provider."""
+    response = provider.make_request("eth_getTransactionByHash", [tx_hash_hex])
     return response.get("result")
 
 
@@ -239,6 +249,131 @@ def _get_insufficient_confirmations(
             insufficient.append(f"{label} ({confirmations}/{confirmation_block_count})")
 
     return insufficient
+
+
+def wait_for_transaction_visibility(
+    web3: Web3,
+    tx_hash: HexBytes | str,
+    timeout: float,
+    poll_delay: float = 1.0,
+    max_poll_delay: float = 5.0,
+    allow_partial_visibility_after_timeout: bool = True,
+) -> dict:
+    """Wait for a transaction to become visible through read RPC providers.
+
+    Unlike :py:func:`wait_for_transaction_receipt_robust`, this checks a pending
+    transaction with ``eth_getTransactionByHash``. It gates sequential nonce
+    broadcasts: the following transaction is sent as soon as every configured
+    read provider can return the preceding transaction.
+
+    At timeout, one visible transaction response is enough to proceed by
+    default. This prevents a failed or lagging read provider from unnecessarily
+    blocking the batch. It does not confirm that the transaction was mined.
+
+    :param timeout:
+        Maximum seconds to wait for all read providers to see the transaction.
+    :param poll_delay:
+        Initial delay between visibility polls.
+    :param max_poll_delay:
+        Maximum adaptive delay between visibility polls.
+    :param allow_partial_visibility_after_timeout:
+        Proceed at timeout when at least one read provider sees the transaction.
+    :return:
+        Raw JSON-RPC transaction data from one provider that sees the hash.
+    :raise TransactionVisibilityTimedOut:
+        No read provider saw the transaction before the timeout, or all-provider
+        visibility was required and did not happen.
+    """
+    assert timeout > 0, f"timeout must be positive, got {timeout}"
+    assert poll_delay > 0, f"poll_delay must be positive, got {poll_delay}"
+    assert max_poll_delay >= poll_delay, f"max_poll_delay must be >= poll_delay, got {max_poll_delay} < {poll_delay}"
+
+    tx_hash_bytes = HexBytes(tx_hash)
+    tx_hash_hex = tx_hash_bytes.to_0x_hex()
+    provider_entries = list(enumerate(get_read_providers(web3)))
+    assert provider_entries, "No read providers configured"
+    provider_labels = [_get_provider_label(index, provider) for index, provider in provider_entries]
+    deadline = time.monotonic() + timeout
+    current_delay = poll_delay
+    last_missing: list[str] = []
+    last_errors: dict[str, str] = {}
+    seen_transactions: dict[str, dict] = {}
+
+    logger.info(
+        "Waiting for transaction visibility on all read providers, tx_hash=%s, providers=%s, timeout=%s, poll_delay=%s, max_poll_delay=%s",
+        tx_hash_hex,
+        provider_labels,
+        timeout,
+        poll_delay,
+        max_poll_delay,
+    )
+
+    while time.monotonic() < deadline:
+        transactions: dict[str, dict] = {}
+        missing = []
+        errors = {}
+
+        for index, provider in provider_entries:
+            label = _get_provider_label(index, provider)
+            try:
+                transaction = _fetch_raw_transaction(provider, tx_hash_hex)
+            except PROVIDER_READ_EXCEPTIONS as e:
+                errors[label] = str(e)
+                missing.append(label)
+                logger.warning(
+                    "Could not fetch transaction from read provider, tx_hash=%s, provider=%s",
+                    tx_hash_hex,
+                    label,
+                    exc_info=True,
+                )
+                continue
+
+            if transaction is None:
+                missing.append(label)
+                logger.debug(
+                    "Read provider does not yet see transaction, tx_hash=%s, provider=%s",
+                    tx_hash_hex,
+                    label,
+                )
+            else:
+                transactions[label] = transaction
+                seen_transactions[label] = transaction
+                logger.debug(
+                    "Read provider sees transaction, tx_hash=%s, provider=%s",
+                    tx_hash_hex,
+                    label,
+                )
+
+        if not missing and len(transactions) == len(provider_entries):
+            logger.info(
+                "Transaction is visible on all read providers, tx_hash=%s",
+                tx_hash_hex,
+            )
+            return next(iter(transactions.values()))
+
+        last_missing = missing
+        last_errors = errors
+        sleep_for = min(current_delay, max(0, deadline - time.monotonic()))
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+        current_delay = min(max_poll_delay, current_delay * 1.5)
+
+    if allow_partial_visibility_after_timeout and seen_transactions:
+        logger.warning(
+            "Proceeding after transaction visibility timeout because transaction is visible on %d/%d read providers, tx_hash=%s, responding_providers=%s, missing_providers=%s, provider_errors=%s",
+            len(seen_transactions),
+            len(provider_entries),
+            tx_hash_hex,
+            list(seen_transactions),
+            last_missing,
+            last_errors,
+        )
+        return next(iter(seen_transactions.values()))
+
+    detail = ", ".join(last_missing) if last_missing else "none"
+    error_detail = "; ".join(f"{label}: {error}" for label, error in last_errors.items())
+    extra = f" Last errors: {error_detail}." if error_detail else ""
+    raise TransactionVisibilityTimedOut(f"Timed out after {timeout} seconds waiting for transaction {tx_hash_hex} on all read providers. Missing providers: {detail}.{extra}")
 
 
 def wait_for_transaction_receipt_robust(

--- a/tests/rpc/test_confirmation_timeout_diagnostics.py
+++ b/tests/rpc/test_confirmation_timeout_diagnostics.py
@@ -1,5 +1,7 @@
 """Test transaction confirmation timeout gas-price diagnostics."""
 
+import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,7 +15,7 @@ from eth_defi.hotwallet import SignedTransactionWithNonce
 from eth_defi.provider.fallback import FallbackProvider
 
 
-def _create_signed_transaction(source: dict, hash_byte: str = "12") -> SignedTransactionWithNonce:
+def _create_signed_transaction(source: dict, hash_byte: str = "12", nonce: int = 7) -> SignedTransactionWithNonce:
     """Create a minimal signed transaction carrying diagnostic source fields."""
     return SignedTransactionWithNonce(
         rawTransaction=HexBytes("0x01"),
@@ -21,7 +23,7 @@ def _create_signed_transaction(source: dict, hash_byte: str = "12") -> SignedTra
         r=0,
         s=0,
         v=0,
-        nonce=7,
+        nonce=nonce,
         address="0x" + "34" * 20,
         source=source,
     )
@@ -160,6 +162,63 @@ def test_confirmation_timeout_uses_single_provider_for_diagnostics() -> None:
     fallback_provider.get_active_provider.return_value = active_provider
 
     assert confirmation._get_single_attempt_provider(web3) is active_provider
+
+
+def test_multi_node_broadcast_continues_when_transaction_visibility_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Continue sequential broadcasts when the visibility gate fails.
+
+    1. Arrange three sequential transactions and successful receipt responses.
+    2. Make the first gate time out and the second raise an unexpected provider error.
+    3. Check every transaction is still broadcast for normal confirmation/rebroadcast handling.
+    """
+
+    # 1. Arrange three sequential transactions and successful receipt responses.
+    provider = MagicMock(spec=BaseProvider)
+    provider.endpoint_uri = "https://read-provider.example"
+    web3 = MagicMock()
+    web3.provider = provider
+    web3.eth.chain_id = 1
+    web3.eth.block_number = 1
+    web3.eth.get_transaction_receipt.return_value = {"blockNumber": 1}
+    tx_1 = _create_signed_transaction({}, hash_byte="12", nonce=7)
+    tx_2 = _create_signed_transaction({}, hash_byte="34", nonce=8)
+    tx_3 = _create_signed_transaction({}, hash_byte="56", nonce=9)
+    events = []
+    monkeypatch.setattr(confirmation, "is_anvil", lambda web3: False)
+    monkeypatch.setattr(confirmation, "get_fallback_provider", lambda web3: SimpleNamespace(providers=[provider]))
+    monkeypatch.setattr(confirmation, "_broadcast_multiple_nodes", lambda providers, tx: events.append(("broadcast", tx.nonce)))
+
+    visibility_errors = iter(
+        [
+            confirmation.TransactionVisibilityTimedOut("transaction unavailable to readers"),
+            RuntimeError("unexpected provider error"),
+        ]
+    )
+
+    def fail_visibility(web3, tx_hash, **kwargs) -> None:
+        """Simulate a timed-out and an unexpected read-provider failure."""
+        events.append(("visibility", tx_hash))
+        raise next(visibility_errors)
+
+    monkeypatch.setattr(confirmation, "wait_for_transaction_visibility", fail_visibility)
+
+    # 2. Make the visibility gate fail after the first two broadcasts.
+    confirmation.wait_and_broadcast_multiple_nodes(
+        web3,
+        [tx_1, tx_2, tx_3],
+        check_nonce_validity=False,
+        max_timeout=datetime.timedelta(seconds=1),
+        inter_node_delay=datetime.timedelta(seconds=1),
+    )
+
+    # 3. Check every transaction is still broadcast for normal confirmation/rebroadcast handling.
+    assert events == [
+        ("broadcast", 7),
+        ("visibility", tx_1.hash),
+        ("broadcast", 8),
+        ("visibility", tx_2.hash),
+        ("broadcast", 9),
+    ]
 
 
 def test_confirmation_timeout_reports_priority_fee_when_network_price_is_unavailable() -> None:

--- a/tests/rpc/test_receipt.py
+++ b/tests/rpc/test_receipt.py
@@ -15,7 +15,9 @@ from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.provider.receipt import (
     ReceiptVisibilityMismatch,
     ReceiptVisibilityTimedOut,
+    TransactionVisibilityTimedOut,
     get_read_providers,
+    wait_for_transaction_visibility,
     wait_for_transaction_receipt_robust,
 )
 
@@ -37,6 +39,11 @@ def _raw_receipt(
     }
 
 
+def _raw_transaction(tx_hash: str = TX_HASH) -> dict:
+    """Create a minimal raw JSON-RPC transaction response."""
+    return {"hash": tx_hash}
+
+
 class FakeProvider:
     """Minimal provider supporting direct raw JSON-RPC calls."""
 
@@ -44,20 +51,32 @@ class FakeProvider:
         self,
         name: str,
         receipts: list[dict | None] | None = None,
+        transactions: list[dict | None | BaseException] | None = None,
         block_number: str | list[str | BaseException] = "0x2",
     ):
         self.endpoint_uri = f"https://{name}.example"
         self.receipts = receipts or [_raw_receipt()]
+        self.transactions = transactions or [_raw_transaction()]
         self.block_numbers = block_number if isinstance(block_number, list) else [block_number]
         self.calls: list[str] = []
+        self.request_params: list[tuple[str, list]] = []
 
     def make_request(self, method: str, params: list) -> dict:
         self.calls.append(method)
+        self.request_params.append((method, params))
         if method == "eth_getTransactionReceipt":
             if len(self.receipts) > 1:
                 result = self.receipts.pop(0)
             else:
                 result = self.receipts[0]
+            if isinstance(result, BaseException):
+                raise result
+            return {"jsonrpc": "2.0", "id": 1, "result": result}
+        if method == "eth_getTransactionByHash":
+            if len(self.transactions) > 1:
+                result = self.transactions.pop(0)
+            else:
+                result = self.transactions[0]
             if isinstance(result, BaseException):
                 raise result
             return {"jsonrpc": "2.0", "id": 1, "result": result}
@@ -205,6 +224,120 @@ def test_get_read_providers_anvil_active_only(monkeypatch: pytest.MonkeyPatch):
 
     # 3. Check only the active provider is returned.
     assert get_read_providers(web3) == [provider_2]
+
+
+def test_wait_for_transaction_visibility_immediate(monkeypatch: pytest.MonkeyPatch):
+    """Continue immediately when every read provider has the transaction.
+
+    1. Create two read providers that both have the pending transaction.
+    2. Wait for transaction visibility.
+    3. Check each provider was queried once and its transaction is returned.
+    """
+
+    # 1. Create two read providers that both have the pending transaction.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for transaction visibility.
+    transaction = wait_for_transaction_visibility(
+        web3,
+        TX_HASH,
+        timeout=1,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+    )
+
+    # 3. Check each provider was queried once and its transaction is returned.
+    assert transaction == _raw_transaction()
+    assert provider_1.calls == ["eth_getTransactionByHash"]
+    assert provider_2.calls == ["eth_getTransactionByHash"]
+    assert provider_1.request_params == [("eth_getTransactionByHash", [TX_HASH])]
+
+
+def test_wait_for_transaction_visibility_polls_again_before_short_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Poll again before a sub-second visibility deadline expires.
+
+    1. Create a provider that sees the transaction on its second request.
+    2. Wait with a short visibility timeout.
+    3. Check the second poll returned the transaction.
+    """
+
+    # 1. Create a provider that sees the transaction on its second request.
+    provider = FakeProvider("read-1", transactions=[None, _raw_transaction()])
+    web3 = FakeWeb3(FallbackProvider([provider]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait with a short visibility timeout.
+    transaction = wait_for_transaction_visibility(
+        web3,
+        TX_HASH,
+        timeout=0.01,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+    )
+
+    # 3. Check the second poll returned the transaction.
+    assert transaction == _raw_transaction()
+    assert provider.calls.count("eth_getTransactionByHash") == 2
+
+
+def test_wait_for_transaction_visibility_allows_partial_after_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Progress when one read provider fails after the visibility deadline.
+
+    1. Create one provider with the transaction and one failing provider.
+    2. Wait through a short all-provider visibility deadline.
+    3. Check the visible transaction is returned instead of raising an error.
+    """
+
+    # 1. Create one provider with the transaction and one failing provider.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2", transactions=[ProviderConnectionError("permanent RPC failure")])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait through a short all-provider visibility deadline.
+    transaction = wait_for_transaction_visibility(
+        web3,
+        TX_HASH,
+        timeout=0.01,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+    )
+
+    # 3. Check the visible transaction is returned instead of raising an error.
+    assert transaction == _raw_transaction()
+    assert provider_2.calls.count("eth_getTransactionByHash") > 1
+
+
+def test_wait_for_transaction_visibility_times_out_without_any_response(monkeypatch: pytest.MonkeyPatch):
+    """Fail when no read provider sees the transaction before the deadline.
+
+    1. Create two providers that never return the pending transaction.
+    2. Wait with a short visibility deadline.
+    3. Check the error reports both missing providers.
+    """
+
+    # 1. Create two providers that never return the pending transaction.
+    provider_1 = FakeProvider("read-1", transactions=[None])
+    provider_2 = FakeProvider("read-2", transactions=[None])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait with a short visibility deadline.
+    with pytest.raises(TransactionVisibilityTimedOut) as exc_info:
+        wait_for_transaction_visibility(
+            web3,
+            TX_HASH,
+            timeout=0.01,
+            poll_delay=0.001,
+            max_poll_delay=0.002,
+        )
+
+    # 3. Check the error reports both missing providers.
+    assert "read-1.example" in str(exc_info.value)
+    assert "read-2.example" in str(exc_info.value)
 
 
 def test_wait_for_transaction_receipt_robust_immediate(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Why

Sequential transaction broadcasts used a fixed 60-second delay to avoid nodes receiving a higher nonce before the preceding transaction. This added unnecessary latency whenever read RPCs had already propagated the transaction.

## Lessons learnt

Transaction visibility through a read provider is a useful sequencing signal, but it is not a receipt or proof of inclusion. Visibility failure must retain the existing confirmation and rebroadcast recovery path.

## Summary

- Wait for `eth_getTransactionByHash` visibility before broadcasting the following nonce.
- Proceed early when every read provider responds, or at the deadline when at least one does.
- Preserve the normal batch and confirmation flow when no read provider sees the transaction.
- Document the behaviour and add focused visibility and broadcast-sequencing coverage.