### PR TITLE
Add Enzyme Blue curator metadata

### DIFF
--- a/eth_defi/data/feeds/curators/arc.yaml
+++ b/eth_defi/data/feeds/curators/arc.yaml
@@ -1,0 +1,11 @@
+feeder-id: arc
+name: ARC
+role: curator
+short_description: ARC is the strategy-operator label used for the Gemini, Leo, and Scorpio Enzyme vault family.
+long_description: |
+  The [Leo BTC Bull Run Enzyme Blue listing](https://app.enzyme.finance/vault/0xb99463e453e2a7ce9fcea6df0bf6991cffef13d1?network=arbitrum) states that its signal execution uses ARC's infrastructure and references ARC Supernova. The [Gemini listing](https://app.enzyme.finance/vault/0x11d41452fcd89c3622f20e680ebbec8587483a63?network=arbitrum) calls the product ARC MV Gemini and describes the related Gemini BTC, ETH, and SOL systems. This record retains the published operating brand without inferring an undisclosed legal entity.
+other-links:
+  - title: Enzyme Blue - Leo BTC Bull Run listing
+    url: https://app.enzyme.finance/vault/0xb99463e453e2a7ce9fcea6df0bf6991cffef13d1?network=arbitrum
+  - title: Enzyme Blue - ARC MV Gemini listing
+    url: https://app.enzyme.finance/vault/0x11d41452fcd89c3622f20e680ebbec8587483a63?network=arbitrum

--- a/eth_defi/data/feeds/curators/artemis-trust.yaml
+++ b/eth_defi/data/feeds/curators/artemis-trust.yaml
@@ -1,0 +1,9 @@
+feeder-id: artemis-trust
+name: Artemis Trust
+role: curator
+short_description: Artemis Trust is the community-managed Web3 investment fund named by its Enzyme vault listing.
+long_description: |
+  The [Artemis Trust Enzyme Blue listing](https://app.enzyme.finance/vault/0x62cd97c6900d07a72eb318fdd0dff462b4a3d7e8?network=polygon) describes an invite-only friends-and-family investment fund using DeFi liquidity pools, staking, yield farming, and long-term Web3 allocations. It also states that the vault manager makes allocation decisions with potential community input; no separate manager profile is available from Enzyme.
+other-links:
+  - title: Enzyme Blue - Artemis Trust listing
+    url: https://app.enzyme.finance/vault/0x62cd97c6900d07a72eb318fdd0dff462b4a3d7e8?network=polygon

--- a/eth_defi/data/feeds/curators/asymmetry-crypto-capital.yaml
+++ b/eth_defi/data/feeds/curators/asymmetry-crypto-capital.yaml
@@ -1,0 +1,9 @@
+feeder-id: asymmetry-crypto-capital
+name: Asymmetry Crypto Capital
+role: curator
+short_description: Asymmetry Crypto Capital is the digital-asset manager named for Enzyme's ACC Metaverse Fund.
+long_description: |
+  The [ACC Metaverse Fund listing](https://app.enzyme.finance/vault/0xd618b03c7a1c0f3248ae049954d69e8d96a142c0?network=ethereum) states that the fund was launched by Asymmetry Crypto Capital and is actively managed as a non-custodial crypto-asset portfolio. The listing describes ACC as the fund's governance token; no separate public manager profile was supplied through the Enzyme API.
+other-links:
+  - title: Enzyme Blue - ACC Metaverse Fund listing
+    url: https://app.enzyme.finance/vault/0xd618b03c7a1c0f3248ae049954d69e8d96a142c0?network=ethereum

--- a/eth_defi/data/feeds/curators/bgroup.yaml
+++ b/eth_defi/data/feeds/curators/bgroup.yaml
@@ -1,0 +1,9 @@
+feeder-id: bgroup
+name: Bgroup
+role: curator
+short_description: Bgroup is the manager label used for the B100, BBTC, and BGC Enzyme fund family.
+long_description: |
+  The [B100 Enzyme Blue listing](https://app.enzyme.finance/vault/0xb8f69b26316818db0ea3b6d1639fedf744a2df41?network=ethereum) explicitly presents BBTC and BGC as other Bgroup vaults. The listing provides no separate human-readable manager field or public organisation profile, so this record preserves the manager label used by that vault family without inferring ownership or affiliation.
+other-links:
+  - title: Enzyme Blue - B100 listing naming the Bgroup vault family
+    url: https://app.enzyme.finance/vault/0xb8f69b26316818db0ea3b6d1639fedf744a2df41?network=ethereum

--- a/eth_defi/data/feeds/curators/casphi.yaml
+++ b/eth_defi/data/feeds/curators/casphi.yaml
@@ -1,0 +1,11 @@
+feeder-id: casphi
+name: CASΦ
+role: curator
+short_description: CASΦ is the manager label used for the CASΦBTC and CASΦNexus quantitative crypto strategies.
+long_description: |
+  The [CASΦBTC Enzyme Blue listing](https://app.enzyme.finance/vault/0xd89551d350532d001ad3105968fecb24b1c3cec8?network=ethereum) and its CASΦNexus counterpart use the same “Trade the Cycle. Master the Macro.” positioning and describe macro-quantitative long-short systems. Enzyme does not expose a separate curator name for either vault, so this record retains the shared public strategy-family label rather than asserting a legal entity.
+other-links:
+  - title: Enzyme Blue - CASΦBTC listing
+    url: https://app.enzyme.finance/vault/0xd89551d350532d001ad3105968fecb24b1c3cec8?network=ethereum
+  - title: Enzyme Blue - CASΦNexus listing
+    url: https://app.enzyme.finance/vault/0x2ef704ea3a9976ca32b6ab06584d31e002d6bd7c?network=ethereum

--- a/eth_defi/data/feeds/curators/diva.yaml
+++ b/eth_defi/data/feeds/curators/diva.yaml
@@ -1,0 +1,14 @@
+feeder-id: diva
+name: Diva Staking
+role: curator
+website: https://www.divastaking.com/
+short_description: Diva Staking is an Ethereum liquid-staking protocol governed by the Diva DAO.
+long_description: |
+  [Diva Staking](https://docs.divastaking.com/) describes a liquid-staking protocol using distributed validator technology, while its [DAO documentation](https://docs.divastaking.com/dao/) states that the DAO governs the protocol's launch and operation. The Enzyme Blue Early Stakers vault listings identify the Diva DAO as offering their deposit incentives, so these two vaults are attributed to Diva Staking as protocol-operated products.
+other-links:
+  - title: Diva Staking documentation
+    url: https://docs.divastaking.com/
+  - title: Enzyme Blue - Diva Early Stakers ETH Vault
+    url: https://app.enzyme.finance/vault/0x16770d642e882e1769ce4ac8612b8bc0601506fc?network=ethereum
+  - title: Enzyme Blue - Diva Early Stakers stETH Vault
+    url: https://app.enzyme.finance/vault/0x1ce8aafb51e79f6bdc0ef2ebd6fd34b00620f6db?network=ethereum

--- a/eth_defi/data/feeds/curators/ewpple.yaml
+++ b/eth_defi/data/feeds/curators/ewpple.yaml
@@ -1,0 +1,9 @@
+feeder-id: ewpple
+name: Ewpple
+role: curator
+short_description: Ewpple is the manager label used for the Ewpple DeFi Crypto Index Fund.
+long_description: |
+  The [Ewpple DeFi Crypto Index Fund Enzyme Blue listing](https://app.enzyme.finance/vault/0xc98e070cc35b98a0f8ba7579a68a1796b014c0b9?network=polygon) sets out the EWD fund's market-cap weighted digital-asset and DeFi-token allocation approach. The available Enzyme metadata names no separate human-readable manager, so this curator record retains the distinctive fund-family name rather than inferring an organisation beyond the listing.
+other-links:
+  - title: Enzyme Blue - Ewpple DeFi Crypto Index Fund listing
+    url: https://app.enzyme.finance/vault/0xc98e070cc35b98a0f8ba7579a68a1796b014c0b9?network=polygon

--- a/eth_defi/data/feeds/curators/hexadefi-capital.yaml
+++ b/eth_defi/data/feeds/curators/hexadefi-capital.yaml
@@ -1,0 +1,9 @@
+feeder-id: hexadefi-capital
+name: Hexadefi Capital
+role: curator
+short_description: Hexadefi Capital is the active crypto fund manager named for the HEXADEFI CAPITAL vault.
+long_description: |
+  The [HEXADEFI CAPITAL Enzyme Blue listing](https://app.enzyme.finance/vault/0x7dbfc77b308356a5d90c586c7e3f0e089b8e37ec?network=ethereum) describes active management using liquidity pools and blue-chip swing trading. Enzyme does not provide a separate manager field or verified company website for this listing, so the curator identity follows the manager name published in the vault title and description.
+other-links:
+  - title: Enzyme Blue - HEXADEFI CAPITAL listing
+    url: https://app.enzyme.finance/vault/0x7dbfc77b308356a5d90c586c7e3f0e089b8e37ec?network=ethereum

--- a/eth_defi/data/feeds/curators/niska-capital.yaml
+++ b/eth_defi/data/feeds/curators/niska-capital.yaml
@@ -1,0 +1,9 @@
+feeder-id: niska-capital
+name: Niska Capital
+role: curator
+short_description: Niska Capital is the manager label used for the Niska Capital Fund I crypto portfolio.
+long_description: |
+  The [Niska Capital Fund I Enzyme Blue listing](https://app.enzyme.finance/vault/0x308b02c6a4e346f1f6fb5c7d79d0de2c4f3abb82?network=ethereum) presents the fund's three investment baskets: long-term holdings, momentum investments, and interaction with the Ethereum ecosystem. The Enzyme metadata does not expose a separate manager field, so this record preserves the investment-manager name displayed by the vault.
+other-links:
+  - title: Enzyme Blue - Niska Capital Fund I listing
+    url: https://app.enzyme.finance/vault/0x308b02c6a4e346f1f6fb5c7d79d0de2c4f3abb82?network=ethereum

--- a/eth_defi/data/feeds/curators/olatu-capital.yaml
+++ b/eth_defi/data/feeds/curators/olatu-capital.yaml
@@ -1,0 +1,9 @@
+feeder-id: olatu-capital
+name: Olatu Capital
+role: curator
+short_description: Olatu Capital is the manager label used for a conservative long-term DeFi investment vault.
+long_description: |
+  The [Olatu Capital Enzyme Blue listing](https://app.enzyme.finance/vault/0x1c6a1591d4a25e1ab258e3476bab4c022df79055?network=ethereum) describes a conservative strategy investing in established projects for long-term appreciation while using DeFi policies to optimise returns. No separate Enzyme curator field or independently verified public manager profile is available for this vault.
+other-links:
+  - title: Enzyme Blue - Olatu Capital listing
+    url: https://app.enzyme.finance/vault/0x1c6a1591d4a25e1ab258e3476bab4c022df79055?network=ethereum

--- a/eth_defi/data/feeds/curators/starzfi.yaml
+++ b/eth_defi/data/feeds/curators/starzfi.yaml
@@ -1,0 +1,11 @@
+feeder-id: starzfi
+name: StarzFi
+role: curator
+short_description: StarzFi is the manager label used for its Base savings and digital-asset portfolio vaults.
+long_description: |
+  The [StarzFi Smart Savings Vault listing](https://app.enzyme.finance/vault/0x80dc1c8ad380c8ce9f45c94422b70edc52aa8804?network=base) describes a hands-off DeFi yield product using lending and liquidity provision. Its [Growth Reserve counterpart](https://app.enzyme.finance/vault/0x7c05c4e1a0c35ff7a4b87302029af124a42375cb?network=base) offers long-term BTC and ETH exposure with optional lending, establishing a shared StarzFi vault family without a separate Enzyme manager field.
+other-links:
+  - title: Enzyme Blue - StarzFi Smart Savings Vault listing
+    url: https://app.enzyme.finance/vault/0x80dc1c8ad380c8ce9f45c94422b70edc52aa8804?network=base
+  - title: Enzyme Blue - StarzFi Growth Reserve listing
+    url: https://app.enzyme.finance/vault/0x7c05c4e1a0c35ff7a4b87302029af124a42375cb?network=base

--- a/eth_defi/data/feeds/curators/stratum-finance.yaml
+++ b/eth_defi/data/feeds/curators/stratum-finance.yaml
@@ -1,0 +1,9 @@
+feeder-id: stratum-finance
+name: Stratum Finance
+role: curator
+short_description: Stratum Finance is the manager label used for the Stratum DeFi Yield Vault.
+long_description: |
+  The [Stratum DeFi Yield Vault Enzyme Blue listing](https://app.enzyme.finance/vault/0xc368f3f4f5c1637321091bfa53de694fdf1f6740?network=ethereum) calls the product a Stratum Finance stablecoin yield vault designed to maximise yield within a predefined risk tolerance. The listing supplies no distinct human-readable curator field or verified company profile.
+other-links:
+  - title: Enzyme Blue - Stratum DeFi Yield Vault listing
+    url: https://app.enzyme.finance/vault/0xc368f3f4f5c1637321091bfa53de694fdf1f6740?network=ethereum

--- a/eth_defi/data/feeds/curators/walled-capital.yaml
+++ b/eth_defi/data/feeds/curators/walled-capital.yaml
@@ -1,0 +1,13 @@
+feeder-id: walled-capital
+name: Walled Capital
+role: curator
+short_description: Walled Capital is the manager label used for the Walled Fund crypto and DeFi portfolio family.
+long_description: |
+  The [Walled Fund II Enzyme Blue listing](https://app.enzyme.finance/vault/0x952a00d5fa79af70b28fed5725a86d60b17a3297?network=ethereum) describes the product as a continuation of Walled Fund I and links to its Walled Capital strategy paper. Its other Enzyme listings cover ETH options and a liquid digital-asset portfolio, establishing a shared fund family without claiming a separate legal identity.
+other-links:
+  - title: Enzyme Blue - Walled Fund II listing
+    url: https://app.enzyme.finance/vault/0x952a00d5fa79af70b28fed5725a86d60b17a3297?network=ethereum
+  - title: Enzyme Blue - Walled Fund ETH listing
+    url: https://app.enzyme.finance/vault/0x15ce0ce914f97ed7b0e3fe4da0c696002b3d2964?network=ethereum
+  - title: Enzyme Blue - Walled Fund Liquid listing
+    url: https://app.enzyme.finance/vault/0xd22c061a1ee043c75f642fcfb643f9541997fb85?network=ethereum

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -322,6 +322,17 @@ CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
     # deployed on several chains, so use its distinctive, exact token name
     # instead of a chain-specific address override.
     "edge-capital": ["mEDGE"],
+    # Enzyme Blue listings expose the manager in the manager-authored copy,
+    # while the canonical vault title uses the abbreviated ACC product name.
+    "asymmetry-crypto-capital": ["ACC Metaverse"],
+    # The Unicode Φ and the asset symbol are both regex word characters, so
+    # matching the curator name alone has no trailing word boundary.
+    "casphi": ["CASΦBTC", "CASΦNexus"],
+    "diva": ["Diva Early Stakers"],
+    # Match the public Enzyme vault-family names instead of generic words such
+    # as "Stratum" or "Walled", which would cause unrelated false positives.
+    "stratum-finance": ["Stratum DeFi"],
+    "walled-capital": ["Walled Fund"],
 }
 
 #: Distributor / sponsor curators whose brand is a white-label wrapper.
@@ -366,6 +377,30 @@ PROTOCOL_MANAGER_YAML_FIELDS: dict[str, str] = {
 #: carries a co-branded protocol/issuer name that would otherwise win fuzzy
 #: matching.  Keys are ``(chain_id, lowercase_vault_address)``.
 CURATOR_ADDRESS_OVERRIDES: dict[tuple[int, str], str] = {
+    # Enzyme's manager-authored B100 listing explicitly groups B100, BBTC, and
+    # BGC as Bgroup vaults, but none of the three titles contains Bgroup.
+    # https://app.enzyme.finance/vault/0xb8f69b26316818db0ea3b6d1639fedf744a2df41?network=ethereum
+    (1, "0xb8f69b26316818db0ea3b6d1639fedf744a2df41"): "bgroup",
+    (1, "0x10c4f975d37903cb278e6b531c0979fc1a0e1875"): "bgroup",
+    (1, "0x46593ac12cacd3f89395483288dffd2b550ff85d"): "bgroup",
+    # The ARC Enzyme Blue listings identify the Gemini, Leo, and Scorpio
+    # products as one strategy family, but individual vault titles omit ARC.
+    # https://app.enzyme.finance/vault/0x11d41452fcd89c3622f20e680ebbec8587483a63?network=arbitrum
+    (42161, "0x11d41452fcd89c3622f20e680ebbec8587483a63"): "arc",
+    (42161, "0xd065f37a0ea7f277bf36d93043d20bfb58b93761"): "arc",
+    (42161, "0xfde46c2e43d54bbb94eb21452aac711f9b9d8e0e"): "arc",
+    (42161, "0xc64197bf72d0ead4bd3563c4dab23b849848268c"): "arc",
+    (42161, "0xba6f18dd30f5048177bbb32122d49f91f0909844"): "arc",
+    (42161, "0xb99463e453e2a7ce9fcea6df0bf6991cffef13d1"): "arc",
+    (42161, "0xc0ba7e66631106f5b8e5716b50bd167431b7f6ca"): "arc",
+    (42161, "0xf11ec3070a2288f6a768364ebf8382ba36b9425b"): "arc",
+    (42161, "0xb0960326a94c33e5fdc302832550f8f82c3d31d4"): "arc",
+    (42161, "0xe8ce6ce5b39875321422a67ac5324e5990966c96"): "arc",
+    (42161, "0xd2c89dc816d0d2e9a52ab5124c66a2a731a74a7d"): "arc",
+    # SmarDex's seed-USDN listing explicitly identifies the sUSDN issuer, but
+    # the vault title is a product name and does not contain the curator brand.
+    # https://app.enzyme.finance/vault/0xf67e2dc041b8a3c39d066037d29f500757b1e886?network=ethereum
+    (1, "0xf67e2dc041b8a3c39d066037d29f500757b1e886"): "smardex",
     # Growi's official lending page identifies this HyperEVM Morpho Vault V2
     # as Growi Lending / Growi USDC Core.
     # https://growi.fi/lending/

--- a/tests/erc_4626/test_enzyme_blue_curators.py
+++ b/tests/erc_4626/test_enzyme_blue_curators.py
@@ -1,0 +1,46 @@
+"""Test curator identification inferred from Enzyme Blue listing metadata."""
+
+import pytest
+
+from eth_defi.vault.curator import identify_curator
+
+
+@pytest.mark.parametrize(
+    ("chain_id", "vault_address", "vault_name", "expected_slug"),
+    [
+        (1, "0xd618b03c7a1c0f3248ae049954d69e8d96a142c0", "ACC Metaverse Fund", "asymmetry-crypto-capital"),
+        (1, "0xb8f69b26316818db0ea3b6d1639fedf744a2df41", "B100", "bgroup"),
+        (1, "0xd89551d350532d001ad3105968fecb24b1c3cec8", "CASΦBTC", "casphi"),
+        (1, "0x16770d642e882e1769ce4ac8612b8bc0601506fc", "Diva Early Stakers ETH Vault", "diva"),
+        (1, "0x7dbfc77b308356a5d90c586c7e3f0e089b8e37ec", "HEXADEFI CAPITAL", "hexadefi-capital"),
+        (1, "0x308b02c6a4e346f1f6fb5c7d79d0de2c4f3abb82", "Niska Capital Fund I (Ethereum)", "niska-capital"),
+        (1, "0x1c6a1591d4a25e1ab258e3476bab4c022df79055", "Olatu Capital", "olatu-capital"),
+        (1, "0xc368f3f4f5c1637321091bfa53de694fdf1f6740", "Stratum DeFi Yield Vault", "stratum-finance"),
+        (1, "0x15ce0ce914f97ed7b0e3fe4da0c696002b3d2964", "Walled Fund ETH", "walled-capital"),
+        (137, "0x62cd97c6900d07a72eb318fdd0dff462b4a3d7e8", "Artemis Trust", "artemis-trust"),
+        (137, "0xc98e070cc35b98a0f8ba7579a68a1796b014c0b9", "Ewpple DeFi Crypto Index Fund", "ewpple"),
+        (8453, "0x80dc1c8ad380c8ce9f45c94422b70edc52aa8804", "StarzFi Smart Savings Vault", "starzfi"),
+        (42161, "0xd065f37a0ea7f277bf36d93043d20bfb58b93761", "Gemini BTC", "arc"),
+        (1, "0xf67e2dc041b8a3c39d066037d29f500757b1e886", "seed USDN", "smardex"),
+    ],
+)
+def test_identify_enzyme_blue_curator(
+    chain_id: int,
+    vault_address: str,
+    vault_name: str,
+    expected_slug: str,
+) -> None:
+    """Resolve manager labels inferred from reviewed Enzyme Blue listings.
+
+    The Enzyme API does not provide a manager field for these rows. The
+    maintained mappings consequently use only the published vault title and
+    the few listings whose manager family is documented in the description.
+
+    :param chain_id: Chain where the Enzyme Blue vault is deployed.
+    :param vault_address: Canonical Enzyme VaultProxy address.
+    :param vault_name: Published Enzyme vault title.
+    :param expected_slug: Curator slug established from listing evidence.
+    :return: None after the curator identity has been resolved.
+    """
+
+    assert identify_curator(chain_id, "", vault_name, vault_address, protocol_slug="enzyme") == expected_slug


### PR DESCRIPTION
## Why

Enzyme Blue listings often omit the API curator field even when their manager-authored vault title and description identify a repeatable operator or fund family.

## Lessons learnt

Curator attribution can be recovered conservatively from explicit manager copy and related Enzyme vault links, while generic strategy labels and unverified one-off fund names should remain unmatched.

## Summary

- Added 13 Enzyme Blue curator metadata records with listing evidence.
- Added conservative title patterns and address overrides for brand-less vault titles.
- Attributed the explicitly SmarDex-issued seed USDN vault to the existing SmarDex curator.
- Added no-RPC curator identification coverage.

## Related issues and PRs

Continues #1508, which added Enzyme Blue strategy classifications.