### PR TITLE
fix: bound GMX Hypersync backfill memory

### DIFF
--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -276,6 +276,13 @@ timestamps with the logs, decodes only the fields needed for valuation, rejects
 non-positive value or supply pairs and non-deposit GM updates, and sorts
 observations by block and log index.
 
+GMX uses Hypersync's explicit `get()` pagination rather than its native
+streaming engine. Dense full-history streams can retain large native response
+buffers, so the reader fetches and releases one server page at a time. This is
+slower than concurrent streaming but keeps memory bounded in the production
+scanner container. Each page is covered by the shared Hypersync request-rate
+limiter.
+
 This reader does not replay GMX's signed price oracle and does not reconstruct
 historical GMX state with archive RPC calls. The emitted value-and-supply pair
 is the source observation.
@@ -307,12 +314,12 @@ raise an error. Older development caches using the generic JSON envelope are
 migrated transactionally when opened; obsolete rows from the earlier mixed GM
 valuation context are not copied.
 
-Large backfills are split into half-open Hypersync chunks and each chunk is
-committed independently. Repeating a complete chain range is safe because
-source observations are inserted idempotently. The script always fetches the
-full replacement range from block 1 to one snapshotted safe head; it does not
-accept an unverified resume cursor that could leave the rebuilt Parquet
-interval incomplete.
+Large backfills are split into half-open Hypersync chunks, paginated within
+each chunk, and committed independently. Repeating a complete chain range is
+safe because source observations are inserted idempotently. The script always
+fetches the full replacement range from block 1 to one snapshotted safe head;
+it does not accept an unverified resume cursor that could leave the rebuilt
+Parquet interval incomplete.
 
 ## Contextual historical reader
 

--- a/eth_defi/gmx/historical_context.py
+++ b/eth_defi/gmx/historical_context.py
@@ -24,6 +24,7 @@ from web3 import Web3
 from eth_defi.gmx.constants import GMX_EVENT_EMITTER_ADDRESS
 from eth_defi.gmx.historical_oracle import GMXHistoricalSharePriceObservation, fetch_historical_share_price_observations_hypersync
 from eth_defi.gmx.vault_catalog import GMX_CHAIN_NAMES_BY_ID
+from eth_defi.hypersync.hypersync_timestamp import is_hypersync_rate_limit_error
 from eth_defi.hypersync.session import ThrottledHypersyncClient
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
 
@@ -361,9 +362,8 @@ def fetch_and_store_gmx_historical_share_prices(
     path.parent.mkdir(parents=True, exist_ok=True)
     observations_fetched = 0
     observations_inserted = 0
-    # One native Hypersync client must stay on one event loop throughout the
-    # backfill. Repeated ``asyncio.run()`` calls can destroy Rust-backed stream
-    # resources on a different loop between chunks.
+    # Keep the native Hypersync client's asynchronous resources on one event
+    # loop throughout the backfill, while each response page remains bounded.
     with asyncio.Runner() as event_loop_runner, GMXHistoricalContextStore(path) as store:
         for chunk_start in range(start_block, end_block, source_chunk_size):
             chunk_end = min(chunk_start + source_chunk_size, end_block)
@@ -381,7 +381,7 @@ def fetch_and_store_gmx_historical_share_prices(
                     )
                     break
                 except RuntimeError as error:
-                    if "rate limited by server" not in str(error) or attempt == GMX_HYPERSYNC_RATE_LIMIT_RETRIES:
+                    if not is_hypersync_rate_limit_error(error) or attempt == GMX_HYPERSYNC_RATE_LIMIT_RETRIES:
                         raise
                     match = re.search(r"resets_in=(\d+)s", str(error))
                     delay = min(60, int(match.group(1)) + 2) if match else 35

--- a/eth_defi/gmx/historical_oracle.py
+++ b/eth_defi/gmx/historical_oracle.py
@@ -20,7 +20,7 @@ from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_defi.gmx.events import EVENT_LOG1_SIGNATURE, GMXEventData
-from eth_defi.hypersync.session import ThrottledHypersyncClient, open_hypersync_stream
+from eth_defi.hypersync.session import ThrottledHypersyncClient
 from eth_defi.vault.flow_events import decode_hypersync_int
 
 try:
@@ -218,7 +218,31 @@ async def _fetch_historical_share_price_observations_hypersync_async(
     end_block: int,
     product_addresses: Iterable[HexAddress] | None = None,
 ) -> list[GMXHistoricalSharePriceObservation]:
-    """Fetch GM and GLV value events from one half-open block range."""
+    """Fetch GM and GLV value events from one half-open block range.
+
+    GMX uses explicit ``get()`` pagination because the native Hypersync 1.1
+    streaming engine retains large buffers for dense GMX event ranges and can
+    corrupt its native heap during a full-chain backfill. One response page at
+    a time keeps native memory bounded while preserving the same server-side
+    query semantics.
+
+    :param hypersync_client:
+        Configured throttle-aware Hypersync client for the chain.
+    :param web3:
+        Web3 instance used to decode GMX EventEmitter payloads.
+    :param chain_id:
+        Chain represented by the query.
+    :param event_emitter_address:
+        GMX EventEmitter deployment.
+    :param start_block:
+        Inclusive block boundary.
+    :param end_block:
+        Exclusive block boundary.
+    :param product_addresses:
+        Optional GM and GLV addresses selected at the indexed-log level.
+    :return:
+        Chronologically ordered observations.
+    """
 
     assert hypersync is not None, "hypersync package is required to fetch GMX historical value events"
     assert 0 <= start_block < end_block, f"Bad half-open block range: [{start_block}, {end_block})"
@@ -241,29 +265,29 @@ async def _fetch_historical_share_price_observations_hypersync_async(
         ),
     )
     observations: list[GMXHistoricalSharePriceObservation] = []
-    receiver = await open_hypersync_stream(hypersync_client, query)
-    try:
-        while response := await receiver.recv():
-            block_timestamps = {decode_hypersync_int(block.number): decode_hypersync_int(block.timestamp) for block in response.data.blocks or [] if block.number is not None and block.timestamp is not None}
-            for log in response.data.logs or []:
-                block_number = decode_hypersync_int(log.block_number)
-                block_timestamp = block_timestamps.get(block_number)
-                if block_timestamp is None:
-                    raise ValueError(f"Hypersync did not return a timestamp for GMX value block {block_number}")
-                observation = extract_historical_share_price_observation(
-                    decode_historical_share_price_event_data(web3, log.data, log.topics[2]),
-                    chain_id=chain_id,
-                    block_number=block_number,
-                    block_timestamp=block_timestamp,
-                    transaction_hash=log.transaction_hash,
-                    log_index=decode_hypersync_int(log.log_index),
-                )
-                if observation is not None:
-                    observations.append(observation)
-    finally:
-        # :class:`hypersync.QueryResponseStream` owns native Rust buffers.
-        # Release them on their creating event loop before the next chunk.
-        receiver.close()
+    while query.from_block < end_block:
+        response = await hypersync_client.get(query)
+        block_timestamps = {decode_hypersync_int(block.number): decode_hypersync_int(block.timestamp) for block in response.data.blocks or [] if block.number is not None and block.timestamp is not None}
+        for log in response.data.logs or []:
+            block_number = decode_hypersync_int(log.block_number)
+            block_timestamp = block_timestamps.get(block_number)
+            if block_timestamp is None:
+                raise ValueError(f"Hypersync did not return a timestamp for GMX value block {block_number}")
+            observation = extract_historical_share_price_observation(
+                decode_historical_share_price_event_data(web3, log.data, log.topics[2]),
+                chain_id=chain_id,
+                block_number=block_number,
+                block_timestamp=block_timestamp,
+                transaction_hash=log.transaction_hash,
+                log_index=decode_hypersync_int(log.log_index),
+            )
+            if observation is not None:
+                observations.append(observation)
+
+        next_block = int(response.next_block)
+        if not query.from_block < next_block <= end_block:
+            raise RuntimeError(f"Hypersync returned invalid GMX pagination boundary {next_block} for range [{query.from_block}, {end_block})")
+        query.from_block = next_block
     observations.sort(key=lambda item: (item.block_number, item.log_index))
     return observations
 
@@ -286,7 +310,7 @@ def fetch_historical_share_price_observations_hypersync(
     :param web3:
         Web3 instance used to decode GMX EventEmitter payloads.
     :param chain_id:
-        Chain represented by the stream.
+        Chain represented by the query.
     :param event_emitter_address:
         GMX EventEmitter deployment.
     :param start_block:
@@ -297,8 +321,8 @@ def fetch_historical_share_price_observations_hypersync(
         Optional GM and GLV addresses selected at the indexed-log level.
     :param event_loop_runner:
         Optional long-lived event-loop runner. Full-chain backfills must reuse
-        one runner across chunks because the native Hypersync client and stream
-        resources must not be moved between short-lived event loops.
+        one runner across chunks so the native Hypersync client's asynchronous
+        resources stay on their creating loop.
     :return:
         Chronologically ordered observations.
     """

--- a/eth_defi/hypersync/session.py
+++ b/eth_defi/hypersync/session.py
@@ -1,7 +1,7 @@
 """Throttle-aware Hypersync client wrapper with stream tuning.
 
 Provides a drop-in replacement for :py:class:`hypersync.HypersyncClient`
-that rate-limits every API call (``stream``, ``recv``, ``get_chain_id``,
+that rate-limits every API call (``stream``, ``get``, ``get_chain_id``,
 ``get_height``) through a shared SQLite-backed token bucket, and allows
 centralised configuration of Hypersync ``StreamConfig`` tuning parameters
 (concurrency, batch sizes, response byte limits).
@@ -114,7 +114,7 @@ class ThrottledHypersyncClient:
     """Drop-in wrapper for :py:class:`hypersync.HypersyncClient` with
     built-in rate limiting and stream tuning.
 
-    Throttles one-shot API calls (``stream``, ``get_chain_id``,
+    Throttles one-shot API calls (``stream``, ``get``, ``get_chain_id``,
     ``get_height``) through a shared :py:class:`pyrate_limiter.Limiter`
     with an SQLite-backed token bucket.
 
@@ -246,6 +246,22 @@ class ThrottledHypersyncClient:
             logger.info("Hypersync stream config: %s", ", ".join(f"{k}={v}" for k, v in active.items()))
         await _acquire_async(self._limiter, "stream-setup")
         return await self._client.stream(query, config)
+
+    async def get(self, query: hypersync.Query) -> hypersync.QueryResponse:
+        """Fetch one paginated Hypersync response.
+
+        Unlike :py:meth:`stream`, each call represents one HTTP request and
+        therefore acquires its own rate-limit slot. The caller advances
+        ``query.from_block`` using ``response.next_block`` until its requested
+        half-open range is complete.
+
+        :param query:
+            Query for the next response page.
+        :return:
+            One response page and its next block boundary.
+        """
+        await _acquire_async(self._limiter, "get")
+        return await self._client.get(query)
 
     async def get_chain_id(self):
         """Get chain ID, throttled."""

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -828,6 +828,9 @@ def scan_prices_for_chain(
                 raise ValueError("vault_addresses cannot be empty")
             vault_addresses = {address.lower() for address in vault_addresses}
             chain_vaults = [row for row in chain_vaults if row["_detection_data"].address.lower() in vault_addresses]
+        # Keep only this chain's rows during network reads and price scanning;
+        # the all-chain metadata database otherwise needlessly raises peak RSS.
+        del vault_db
 
         if len(chain_vaults) == 0:
             logger.info("No vaults on chain %d, skipping price scan", chain_id)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -539,6 +539,10 @@ parameters: it processes Arbitrum and Avalanche sequentially, snapshots one
 safe head per chain, and scans the half-open range from block 1 to that head
 using hourly buckets. Cache insertion is idempotent, and repeating the command
 rebuilds the same complete GMX ranges without modifying scheduled reader state.
+GMX source events use bounded Hypersync `get()` pages instead of concurrent
+native streams so dense history does not accumulate native response buffers in
+the scanner container. The shared request limiter applies to every page, so a
+full backfill favours bounded memory over maximum download speed.
 
 ```shell
 source .local-test.env && \

--- a/scripts/erc-4626/backfill-gmx-vault-prices.py
+++ b/scripts/erc-4626/backfill-gmx-vault-prices.py
@@ -99,6 +99,9 @@ def _run_backfill(
     detections = [row["_detection_data"] for row in vault_db.rows.values() if row["_detection_data"].chain == chain_id and row["_detection_data"].features & GMX_FEATURES]
     if not detections:
         raise RuntimeError(f"No seeded GMX V2 products found for {chain_name}")
+    # The full metadata database is large and is not needed during context
+    # collection; retain only the selected GMX detection records.
+    del vault_db
 
     prefill = fetch_and_store_gmx_historical_share_prices(
         web3=web3,

--- a/tests/gmx/test_historical_context.py
+++ b/tests/gmx/test_historical_context.py
@@ -137,3 +137,34 @@ def test_prefill_chunks_and_commits_completed_ranges(tmp_path: Path, monkeypatch
     with GMXHistoricalContextStore(context_path) as store:
         persisted = tuple(store.iter_share_prices(chain_id=42161, product_address=TOKEN, start_block=0, end_block=10, step=10))
     assert persisted == (_observation(5),)
+
+
+def test_prefill_retries_http_429(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry the HTTP error form returned by explicit Hypersync pages."""
+
+    attempts = 0
+    delays: list[float] = []
+
+    def fetch_observations(**_kwargs: object) -> list[GMXHistoricalSharePriceObservation]:
+        """Fail once with the direct-request rate-limit wording."""
+
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            message = "429 Too Many Requests"
+            raise RuntimeError(message)
+        return []
+
+    monkeypatch.setattr(historical_context, "fetch_historical_share_price_observations_hypersync", fetch_observations)
+    monkeypatch.setattr(historical_context.time, "sleep", delays.append)
+
+    fetch_and_store_gmx_historical_share_prices(
+        web3=SimpleNamespace(eth=SimpleNamespace(chain_id=42161)),
+        hypersync_client=object(),
+        start_block=0,
+        end_block=10,
+        context_path=tmp_path / "vault-historical-context.duckdb",
+    )
+
+    assert attempts == 2
+    assert delays == [35]

--- a/tests/gmx/test_historical_oracle.py
+++ b/tests/gmx/test_historical_oracle.py
@@ -1,6 +1,7 @@
 """Unit tests for GMX historical liquidity-provider observations."""
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from eth_utils import to_checksum_address
@@ -41,44 +42,61 @@ def test_historical_fetch_reuses_supplied_event_loop(monkeypatch: pytest.MonkeyP
     assert event_loops[0] is event_loops[1]
 
 
-def test_historical_fetch_closes_native_stream(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Release native stream buffers deterministically after end-of-stream."""
+def test_historical_fetch_uses_bounded_pagination() -> None:
+    """Advance through explicit response pages without a native stream."""
 
-    class Receiver:
-        """Minimal native-stream substitute."""
+    class Client:
+        """Return two controlled response pages."""
 
-        closed = False
+        def __init__(self):
+            self.from_blocks: list[int] = []
 
-        async def recv(self) -> None:  # noqa: PLR6301
-            """Return end-of-stream immediately."""
+        async def get(self, query: object) -> SimpleNamespace:
+            """Record and advance the requested range."""
 
-            await asyncio.sleep(0)
+            self.from_blocks.append(query.from_block)
+            return SimpleNamespace(
+                next_block=5 if query.from_block == 1 else 10,
+                data=SimpleNamespace(blocks=[], logs=[]),
+            )
 
-        def close(self) -> None:
-            """Record deterministic resource release."""
-
-            self.closed = True
-
-    receiver = Receiver()
-
-    async def open_stream(*_args: object) -> Receiver:
-        """Return the controlled stream substitute."""
-
-        await asyncio.sleep(0)
-        return receiver
-
-    monkeypatch.setattr(historical_oracle, "open_hypersync_stream", open_stream)
+    client = Client()
     observations = fetch_historical_share_price_observations_hypersync(
-        hypersync_client=object(),
+        hypersync_client=client,
         web3=Web3(),
         chain_id=42161,
         event_emitter_address=TOKEN,
         start_block=1,
-        end_block=2,
+        end_block=10,
     )
 
     assert observations == []
-    assert receiver.closed
+    assert client.from_blocks == [1, 5]
+
+
+def test_historical_fetch_rejects_stalled_pagination() -> None:
+    """Abort instead of looping when a server page makes no progress."""
+
+    class Client:
+        """Return an invalid response boundary."""
+
+        async def get(self, query: object) -> SimpleNamespace:  # noqa: PLR6301
+            """Return the requested start block unchanged."""
+
+            return SimpleNamespace(
+                next_block=query.from_block,
+                data=SimpleNamespace(blocks=[], logs=[]),
+            )
+
+    with pytest.raises(RuntimeError, match="invalid GMX pagination boundary"):
+        fetch_historical_share_price_observations_hypersync(
+            hypersync_client=Client(),
+            web3=Web3(),
+            chain_id=42161,
+            event_emitter_address=TOKEN,
+            start_block=1,
+            end_block=10,
+        )
 
 
 def test_encode_product_address_as_event_topic() -> None:

--- a/tests/hypersync/test_hypersync_session.py
+++ b/tests/hypersync/test_hypersync_session.py
@@ -91,6 +91,22 @@ def test_open_hypersync_stream_native_and_throttled(
     asyncio.run(_run())
 
 
+def test_throttled_get_acquires_rate_limit(
+    mock_native_client: AsyncMock,
+    mock_limiter: MagicMock,
+) -> None:
+    """Rate-limit each explicit Hypersync response page."""
+
+    query = MagicMock(spec=hypersync.Query)
+    response = MagicMock(spec=hypersync.QueryResponse)
+    mock_native_client.get.return_value = response
+    client = ThrottledHypersyncClient(mock_native_client, mock_limiter)
+
+    assert asyncio.run(client.get(query)) is response
+    mock_limiter.try_acquire.assert_called_once_with("hypersync")
+    mock_native_client.get.assert_awaited_once_with(query)
+
+
 def test_create_stream_config_overrides(throttled_client: ThrottledHypersyncClient):
     """Verify create_stream_config applies stored params and allows overrides.
 


### PR DESCRIPTION
## Why

The production GMX full-history backfill repeatedly aborted after successfully committing the Arbitrum `210,000,001–220,000,001` chunk. The next Hypersync stream failed inside the native allocator with:

```text
free(): chunks in smallbin corrupted
Aborted (core dumped)
```

This is glibc detecting native heap corruption, not a Docker Compose orphan-container problem and not the normal signature of the kernel OOM killer. The same failure was reproduced locally with Hypersync 1.1.0, all 138 Arbitrum GM/GLV products, ten consecutive 10-million-block ranges, and forced Python garbage collection between chunks.

| Implementation | 210m–220m | 220m–230m | Process result |
|---|---:|---:|---|
| Native `QueryResponseStream` | 32,765 observations | Aborted while entering the range | Exit 134, `free(): corrupted unsorted chunks` |
| Explicit bounded `get()` pagination | 32,765 observations | 29,318 observations | Exit 0 |

During the failing stream run RSS moved between roughly 528 MiB and 779 MiB rather than being reclaimed deterministically, and Python garbage collection did not prevent the abort. Reusing one `asyncio.Runner` and explicitly closing every `QueryResponseStream` also did not prevent it.

### Likely root cause

The evidence isolates the problem to the native Hypersync streaming path:

- The same selected events, Web3 decoder and block ranges complete when fetched through `HypersyncClient.get()`.
- Only the `QueryResponseStream` scheduler and its native buffering/lifecycle are removed by this change.
- The crash is emitted by the native allocator, outside Python exception handling.
- DuckDB successfully committed the preceding chunk. It may trigger the allocation that detects already-corrupted heap metadata, but it is not the likely origin of the corruption.

Hypersync Python 1.1.0 introduced Rust client 1.3.0 and streaming engine v2. Its adaptive native reorder buffer is a plausible source of the retained allocations or lifetime error, but the precise defective Rust allocation is not proven by this repository-level reproduction.

Upgrading does not currently provide a known fix. [Python 1.2.0](https://github.com/enviodev/hypersync-client-python/blob/v1.2.0/CHANGELOG.md) only changes the user agent and still embeds Rust client 1.3.0. [Rust client 1.4.0](https://github.com/enviodev/hypersync-client-rust/compare/hypersync-client/v1.3.0...hypersync-client/v1.4.0) contains no relevant streaming-memory correction, while the proposed [graceful stream shutdown](https://github.com/enviodev/hypersync-client-rust/pull/53) remains open and unmerged.

## Lessons learnt

- A native allocator may detect heap corruption later than the operation that caused it, so the DuckDB allocation at the crash boundary was not sufficient evidence that DuckDB was responsible.
- Python `gc.collect()`, event-loop reuse and `QueryResponseStream.close()` cannot repair a native streaming-engine lifetime defect.
- Explicit server pagination gives GMX bounded ownership: one response page is decoded and released before requesting the next page.
- The all-chain vault metadata pickle was another avoidable source of memory pressure. Loading it raised local RSS from 230.3 MiB to 520.5 MiB; retaining only the 138 selected GMX detection records reduced RSS to 308.0 MiB.
- Existing GMX context observations remain valid and idempotent. A restarted backfill can reuse them even though the complete-range script intentionally verifies the source range again.

## Summary

- Replace GMX native Hypersync streams with explicit, sequential `get()` pagination.
- Rate-limit every response-page request through `ThrottledHypersyncClient`.
- Validate every `next_block` boundary to prevent stalled or out-of-range pagination loops.
- Recognise both stream-style rate-limit messages and direct HTTP 429 errors.
- Release unrelated all-chain vault metadata before GMX context collection and ordinary per-chain price scanning.
- Document the bounded-memory behaviour and its throughput trade-off in both GMX and vault-script documentation.
- Add pagination, stalled-boundary, request-throttling and HTTP 429 retry coverage.
- Pass 29 focused tests, including the live GMX context → common Parquet → `calculate_lifetime_metrics()` integration test.

## Related issues and PRs

- Continues the GMX historical-equity-curve integration from #1502.
- Relevant upstream work: [streaming engine v2](https://github.com/enviodev/hypersync-client-rust/pull/131) and the unmerged [graceful shutdown PR](https://github.com/enviodev/hypersync-client-rust/pull/53).

## Unrelated CI and test fixes

None.