### PR TITLE
fix: avoid DuckDB ART corruption in GMX backfills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,29 @@ removing its flaky history comment.
 - Never write generic `Exception e:` catch but always catch a specific exception if we can
 - Never silently swallow exceptions and th
 
+### DuckDB and Python 3.14
+
+DuckDB 1.5.0 file-backed databases have caused native heap corruption in this
+repository under Python 3.14 when large tables use ART-backed `PRIMARY KEY` or
+`UNIQUE` constraints. The process can abort with allocator errors such as
+`free(): chunks in smallbin corrupted`, so Python cannot catch or recover from
+the failure. See [DuckDB issue #18190](https://github.com/duckdb/duckdb/issues/18190).
+
+- Do not add `PRIMARY KEY` or `UNIQUE` constraints to large, file-backed bulk
+  ingestion tables. Use an unconstrained staging table and hash joins for
+  conflict detection and application-level deduplication.
+- Migrate existing ART-backed tables transactionally, preserving every row,
+  before continuing a backfill. Inspect `duckdb_constraints()` to detect the
+  old schema.
+- For bulk ingestion, set `wal_autocheckpoint = '1TB'` to avoid automatic
+  checkpoints during writes. This is an additional safeguard, not a substitute
+  for removing ART indexes.
+- Test the migration and duplicate-ingestion path with a file-backed database
+  containing production-scale row counts. A small in-memory test does not
+  reproduce this class of crash.
+- Rerunning an unchanged backfill is not a fix: it can reach the same native
+  corruption threshold and abort again.
+
 ### Code comments
 
 - For code comments, Use Sphinx restructured text style

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -308,11 +308,16 @@ owns its own table. The minimal GMX table contains:
 | `raw_value` / `raw_supply` | GMX value and matching share supply |
 | `event_name` | `MarketPoolValueUpdated` or `GlvValueUpdated` |
 
-The primary key is chain, transaction hash and log index. Re-inserting the same
-source observation is ignored; conflicting values for the same source event
-raise an error. Older development caches using the generic JSON envelope are
-migrated transactionally when opened; obsolete rows from the earlier mixed GM
-valuation context are not copied.
+The application-level identity is chain, transaction hash and log index.
+Re-inserting the same source observation is ignored; conflicting values for the
+same source event raise an error. The table deliberately has no DuckDB
+`PRIMARY KEY` or `UNIQUE` constraint: DuckDB 1.5.0 ART indexes can corrupt the
+native heap on large file-backed databases under Python 3.14; see the related
+[DuckDB ART issue](https://github.com/duckdb/duckdb/issues/18190). Batches use
+an unconstrained temporary table and hash joins for conflict detection and
+deduplication. Existing indexed tables and older development caches using the
+generic JSON envelope are migrated transactionally when opened; obsolete rows
+from the earlier mixed GM valuation context are not copied.
 
 Large backfills are split into half-open Hypersync chunks, paginated within
 each chunk, and committed independently. Repeating a complete chain range is

--- a/eth_defi/gmx/historical_context.py
+++ b/eth_defi/gmx/historical_context.py
@@ -98,6 +98,9 @@ class GMXHistoricalContextStore(AbstractContextManager):
 
         self.path = path
         self.connection = duckdb.connect(str(path))
+        # Avoid automatic checkpoints during bulk writes as a second defensive
+        # measure around the DuckDB 1.5.0 file-backed ART corruption issue.
+        self.connection.execute("SET wal_autocheckpoint = '1TB'")
         self._create_schema()
 
     def _create_schema(self) -> None:
@@ -129,6 +132,33 @@ class GMXHistoricalContextStore(AbstractContextManager):
             return
 
         self._create_direct_table("gmx_historical_context")
+        if existing_columns and self._has_art_index("gmx_historical_context"):
+            self._migrate_art_index_schema()
+
+    def _has_art_index(self, table_name: str) -> bool:
+        """Check whether a table has a DuckDB ART-backed constraint.
+
+        DuckDB implements ``PRIMARY KEY`` and ``UNIQUE`` constraints with an
+        Adaptive Radix Tree. DuckDB 1.5.0 can corrupt the native heap for large
+        file-backed ART indexes under Python 3.14, so GMX uses application-level
+        source-event deduplication instead. See the related `DuckDB ART issue
+        <https://github.com/duckdb/duckdb/issues/18190>`__.
+
+        :param table_name:
+            GMX table to inspect.
+        :return:
+            ``True`` when a primary-key or unique constraint exists.
+        """
+
+        count = self.connection.execute(
+            """
+            SELECT count(*)
+            FROM duckdb_constraints()
+            WHERE table_name = ? AND constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+            """,
+            (table_name,),
+        ).fetchone()[0]
+        return count > 0
 
     def _create_direct_table(self, table_name: str) -> None:
         """Create a direct-column GMX observation table.
@@ -156,11 +186,34 @@ class GMXHistoricalContextStore(AbstractContextManager):
                 product_address VARCHAR NOT NULL,
                 raw_value UHUGEINT NOT NULL,
                 raw_supply UHUGEINT NOT NULL,
-                event_name VARCHAR NOT NULL,
-                PRIMARY KEY (chain_id, transaction_hash, log_index)
+                event_name VARCHAR NOT NULL
             )
             """
         )
+
+    def _migrate_art_index_schema(self) -> None:
+        """Remove the legacy ART-backed primary key transactionally.
+
+        Existing rows and columns stay unchanged. Application-level conflict
+        checks retain the ``(chain_id, transaction_hash, log_index)`` source
+        identity contract without the unsafe native index.
+
+        :return:
+            None.
+        """
+
+        self.connection.execute("BEGIN TRANSACTION")
+        try:
+            self.connection.execute("DROP TABLE IF EXISTS gmx_historical_context_direct")
+            self._create_direct_table("gmx_historical_context_direct")
+            self.connection.execute("INSERT INTO gmx_historical_context_direct SELECT * FROM gmx_historical_context")
+            self.connection.execute("DROP TABLE gmx_historical_context")
+            self.connection.execute("ALTER TABLE gmx_historical_context_direct RENAME TO gmx_historical_context")
+        except duckdb.Error:
+            self.connection.execute("ROLLBACK")
+            raise
+        else:
+            self.connection.execute("COMMIT")
 
     def _migrate_legacy_schema(self) -> None:
         """Replace the legacy generic JSON envelope with direct GMX columns.
@@ -213,7 +266,19 @@ class GMXHistoricalContextStore(AbstractContextManager):
             If an existing observation has a different payload.
         """
 
-        values = (
+        return self.insert_share_prices((observation,)) == 1
+
+    @staticmethod
+    def _observation_to_values(observation: GMXHistoricalSharePriceObservation) -> tuple[int, int, int, str, int, str, int, int, str]:
+        """Convert one observation to direct DuckDB column values.
+
+        :param observation:
+            Canonical GMX value-and-supply event.
+        :return:
+            Values in table-column order.
+        """
+
+        return (
             observation.chain_id,
             observation.block_number,
             observation.block_timestamp,
@@ -224,22 +289,71 @@ class GMXHistoricalContextStore(AbstractContextManager):
             observation.raw_supply,
             observation.event_name,
         )
-        existing = self.connection.execute(
-            """
-            SELECT chain_id, block_number, block_timestamp, transaction_hash,
-                   log_index, product_address, raw_value, raw_supply, event_name
-            FROM gmx_historical_context
-            WHERE chain_id = ? AND transaction_hash = ? AND log_index = ?
-            """,
-            (observation.chain_id, observation.transaction_hash.lower(), observation.log_index),
-        ).fetchone()
-        if existing is not None:
-            if tuple(existing) != values:
-                key = (observation.chain_id, observation.transaction_hash.lower(), observation.log_index)
-                raise ValueError(f"GMX historical share-price conflict for {key}")
-            return False
-        self.connection.execute("INSERT INTO gmx_historical_context VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
-        return True
+
+    def insert_share_prices(self, observations: Iterable[GMXHistoricalSharePriceObservation]) -> int:
+        """Persist a batch without using DuckDB ART indexes.
+
+        Rows are staged in an unconstrained temporary table. Hash joins detect
+        conflicting source identities and insert only previously unseen rows.
+        This preserves idempotency without the file-backed ``PRIMARY KEY``
+        index that can corrupt DuckDB 1.5.0 on Python 3.14. See the related
+        `DuckDB ART issue <https://github.com/duckdb/duckdb/issues/18190>`__.
+
+        :param observations:
+            Canonical GMX observations from one source chunk.
+        :return:
+            Number of newly inserted observations.
+        :raises ValueError:
+            If a source identity has different payloads within the batch or in
+            the existing table.
+        """
+
+        values = tuple(self._observation_to_values(observation) for observation in observations)
+        if not values:
+            return 0
+
+        self.connection.execute("DROP TABLE IF EXISTS gmx_historical_context_batch")
+        self.connection.execute("CREATE TEMP TABLE gmx_historical_context_batch AS SELECT * FROM gmx_historical_context LIMIT 0")
+        try:
+            self.connection.executemany("INSERT INTO gmx_historical_context_batch VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", values)
+            conflicting_key = self.connection.execute(
+                """
+                SELECT chain_id, transaction_hash, log_index
+                FROM (
+                    SELECT * FROM gmx_historical_context
+                    UNION ALL
+                    SELECT * FROM gmx_historical_context_batch
+                ) observations
+                GROUP BY chain_id, transaction_hash, log_index
+                HAVING count(DISTINCT (
+                    block_number, block_timestamp, product_address,
+                    raw_value, raw_supply, event_name
+                )) > 1
+                LIMIT 1
+                """
+            ).fetchone()
+            if conflicting_key is not None:
+                raise ValueError(f"GMX historical share-price conflict for {tuple(conflicting_key)}")
+
+            before = self.connection.execute("SELECT count(*) FROM gmx_historical_context").fetchone()[0]
+            self.connection.execute(
+                """
+                INSERT INTO gmx_historical_context
+                SELECT DISTINCT batch.*
+                FROM gmx_historical_context_batch batch
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM gmx_historical_context existing
+                    WHERE existing.chain_id = batch.chain_id
+                      AND existing.transaction_hash = batch.transaction_hash
+                      AND existing.log_index = batch.log_index
+                )
+                """
+            )
+            after = self.connection.execute("SELECT count(*) FROM gmx_historical_context").fetchone()[0]
+            return after - before
+        finally:
+            self.connection.execute("DROP TABLE IF EXISTS gmx_historical_context_batch")
 
     def iter_share_prices(
         self,
@@ -364,7 +478,9 @@ def fetch_and_store_gmx_historical_share_prices(
     observations_inserted = 0
     # Keep the native Hypersync client's asynchronous resources on one event
     # loop throughout the backfill, while each response page remains bounded.
-    with asyncio.Runner() as event_loop_runner, GMXHistoricalContextStore(path) as store:
+    # Release Hypersync resources before the DuckDB connection is checkpointed
+    # and closed.
+    with GMXHistoricalContextStore(path) as store, asyncio.Runner() as event_loop_runner:
         for chunk_start in range(start_block, end_block, source_chunk_size):
             chunk_end = min(chunk_start + source_chunk_size, end_block)
             for attempt in range(1, GMX_HYPERSYNC_RATE_LIMIT_RETRIES + 1):
@@ -395,9 +511,10 @@ def fetch_and_store_gmx_historical_share_prices(
                     )
                     time.sleep(delay)
             observations_fetched += len(observations)
+            chunk_observation_count = len(observations)
             store.connection.execute("BEGIN TRANSACTION")
             try:
-                observations_inserted += sum(store.insert_share_price(observation) for observation in observations)
+                observations_inserted += store.insert_share_prices(observations)
             except (duckdb.Error, ValueError):
                 store.connection.execute("ROLLBACK")
                 raise
@@ -408,7 +525,8 @@ def fetch_and_store_gmx_historical_share_prices(
                 chain_id,
                 chunk_start,
                 chunk_end,
-                len(observations),
+                chunk_observation_count,
                 observations_inserted,
             )
+            del observations
     return GMXHistoricalContextPrefillResult(chain_id, start_block, end_block, observations_fetched, observations_inserted)

--- a/eth_defi/gmx/historical_oracle.py
+++ b/eth_defi/gmx/historical_oracle.py
@@ -288,6 +288,9 @@ async def _fetch_historical_share_price_observations_hypersync_async(
         if not query.from_block < next_block <= end_block:
             raise RuntimeError(f"Hypersync returned invalid GMX pagination boundary {next_block} for range [{query.from_block}, {end_block})")
         query.from_block = next_block
+        # Do not retain the previous native response while awaiting the next
+        # page; this keeps the explicit-pagination memory boundary real.
+        del response
     observations.sort(key=lambda item: (item.block_number, item.log_index))
     return observations
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -543,6 +543,10 @@ GMX source events use bounded Hypersync `get()` pages instead of concurrent
 native streams so dense history does not accumulate native response buffers in
 the scanner container. The shared request limiter applies to every page, so a
 full backfill favours bounded memory over maximum download speed.
+The GMX DuckDB table also avoids `PRIMARY KEY` and `UNIQUE` constraints because
+DuckDB 1.5.0 ART indexes can corrupt the native heap on large file-backed
+databases under Python 3.14. Existing indexed GMX tables are migrated
+transactionally, while application-level batch joins preserve idempotency.
 
 ```shell
 source .local-test.env && \

--- a/tests/gmx/test_historical_context.py
+++ b/tests/gmx/test_historical_context.py
@@ -95,6 +95,62 @@ def test_legacy_context_table_is_migrated_to_direct_columns(tmp_path: Path) -> N
     assert columns == historical_context.GMX_HISTORICAL_CONTEXT_COLUMNS
 
 
+def test_primary_key_table_is_migrated_without_art_index(tmp_path: Path) -> None:
+    """Preserve observations while removing the unsafe DuckDB ART index."""
+
+    path = tmp_path / "vault-historical-context.duckdb"
+    observation = _observation(5)
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE gmx_historical_context (
+                chain_id UINTEGER NOT NULL,
+                block_number UBIGINT NOT NULL,
+                block_timestamp UBIGINT NOT NULL,
+                transaction_hash VARCHAR NOT NULL,
+                log_index UINTEGER NOT NULL,
+                product_address VARCHAR NOT NULL,
+                raw_value UHUGEINT NOT NULL,
+                raw_supply UHUGEINT NOT NULL,
+                event_name VARCHAR NOT NULL,
+                PRIMARY KEY (chain_id, transaction_hash, log_index)
+            )
+            """
+        )
+        connection.execute(
+            "INSERT INTO gmx_historical_context VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            GMXHistoricalContextStore._observation_to_values(observation),
+        )
+    finally:
+        connection.close()
+
+    with GMXHistoricalContextStore(path) as store:
+        assert not store._has_art_index("gmx_historical_context")
+        selected = tuple(store.iter_share_prices(chain_id=42161, product_address=TOKEN, start_block=0, end_block=10, step=10))
+
+    assert selected == (observation,)
+
+
+def test_batch_insert_is_idempotent_without_constraints(tmp_path: Path) -> None:
+    """Deduplicate a complete chunk through application-level hash joins."""
+
+    observations = (_observation(5), _observation(6), _observation(6))
+    with GMXHistoricalContextStore(tmp_path / "vault-historical-context.duckdb") as store:
+        assert store.insert_share_prices(observations) == 2
+        assert store.insert_share_prices(observations) == 0
+        assert not store._has_art_index("gmx_historical_context")
+
+
+def test_batch_insert_rejects_conflict_within_batch(tmp_path: Path) -> None:
+    """Reject two payloads carrying the same source-event identity."""
+
+    observations = (_observation(5), _observation(5, raw_value=2 * 10**30))
+    with GMXHistoricalContextStore(tmp_path / "vault-historical-context.duckdb") as store:
+        with pytest.raises(ValueError, match="conflict"):
+            store.insert_share_prices(observations)
+
+
 def test_share_price_reader_rejects_conflicting_source_event(tmp_path: Path) -> None:
     """Reject different values for the same chain transaction log."""
 


### PR DESCRIPTION
## Why

The full GMX historical backfill still aborted in production with `free(): chunks in smallbin corrupted` after PR #1510 replaced native Hypersync streaming with bounded pagination. It crashed at the same Arbitrum range even when all fetched observations were already cached and `inserted 0`, which ruled out an unbounded response list as the complete explanation.

This matches the repository's earlier DuckDB investigation in PR #1053: DuckDB 1.5.0 file-backed tables can corrupt the native heap under Python 3.14 when `PRIMARY KEY` or `UNIQUE` constraints create large Adaptive Radix Tree (ART) indexes. The GMX context table used exactly such a primary key and had grown to about 73,000 rows. Native allocator corruption cannot be caught by Python, and rerunning the unchanged backfill can simply reach the same failure again.

## Lessons learnt

- Bounded Hypersync pagination reduces response memory, but it does not address native corruption inside a file-backed DuckDB ART index.
- `PRIMARY KEY` and `UNIQUE` constraints in DuckDB are indexes with a materially different failure surface from unconstrained analytical tables.
- Idempotency does not require a native unique index: an unconstrained staging table plus hash-based conflict detection and anti-join insertion provides the same source-event identity contract.
- A small in-memory test is insufficient for this class of failure. Migration and duplicate ingestion need file-backed, production-scale coverage.
- Existing cached observations are valuable production state and must be migrated transactionally, never discarded to recover from a crash.

## Summary

- Remove the ART-backed primary key from `gmx_historical_context`.
- Detect legacy `PRIMARY KEY`/`UNIQUE` constraints through `duckdb_constraints()` and transactionally copy all rows into an unconstrained replacement table on first open.
- Batch observations through an unconstrained temporary table, detect conflicting payloads by source identity, and insert unseen rows with a hash anti-join. This preserves idempotent reruns without an ART index.
- Set `wal_autocheckpoint = '1TB'` during bulk ingestion as a secondary safeguard against checkpoints in the middle of large writes.
- Release each Hypersync response page and close Hypersync resources before DuckDB performs its final checkpoint and close.
- Document the failure mode and safe DuckDB ingestion pattern in `CLAUDE.md` and the GMX operator documentation.
- Add focused coverage for automatic schema migration, row preservation, duplicate batches and conflicting observations.
- Exercise the critical real Arbitrum ranges 210,000,000–230,000,000 against a fresh unconstrained file-backed database: 62,083 observations were stored and the process exited normally. The deterministic unit and script suite passes 18 tests.

## Related issues and PRs

- Continues PR #1510, whose bounded Hypersync pagination was useful but insufficient to stop the production crash.
- Reuses the DuckDB/Python 3.14 ART-index findings and workaround documented in PR #1053.
- Related upstream report: https://github.com/duckdb/duckdb/issues/18190

## Unrelated CI and test fixes

None.