### PR TITLE
perf: accelerate Hyperliquid position scans

### DIFF
--- a/eth_defi/hyperliquid/perp_metrics.py
+++ b/eth_defi/hyperliquid/perp_metrics.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import threading
 import uuid
 from collections.abc import Iterable
 from decimal import InvalidOperation
@@ -28,6 +29,15 @@ from eth_defi.perp_dex.metrics import (
 from eth_defi.perp_dex.storage import write_perp_vault_observation_bundle
 
 logger = logging.getLogger(__name__)
+
+
+#: ``clearinghouseState`` has an API weight of two, compared with the usual
+#: twenty for Hyperliquid ``/info`` endpoints.  Nine requests per second uses
+#: 1,080 of the documented 1,200 weight-per-minute, per-IP allowance and
+#: leaves 10% capacity for unrelated clients.
+#:
+#: See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits-and-user-limits
+CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND = 9.0
 
 
 def build_hyperliquid_vault_observation_bundle(
@@ -149,6 +159,10 @@ def collect_hyperliquid_vault_observations(
     Hyperliquid's public clearinghouse endpoint is read according to its
     `canonical API documentation
     <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals>`__.
+    This endpoint has a lower request weight than the mixed ``/info`` traffic
+    used by the rest of the scanner, so it uses its own bounded 9 RPS limiter.
+    When Webshare proxies are available, each distinct proxy receives one
+    worker and its own limiter; direct-IP scans retain one shared limiter.
 
     :param session:
         Configured public Hyperliquid HTTP session.
@@ -166,8 +180,38 @@ def collect_hyperliquid_vault_observations(
     selected = tuple(summaries)
     if not selected:
         return 0
+
     worker_count = min(max_workers, len(selected))
-    results = Parallel(n_jobs=worker_count, backend="threading")(delayed(_fetch_hyperliquid_vault_bundle)(session, summary, timeout) for summary in selected)
+    if session.proxy_enabled:
+        # Each clone has an independent limiter.  Do not create multiple
+        # clones for one proxy IP, as that would exceed its documented budget.
+        worker_count = min(worker_count, session.proxy_count)
+    else:
+        # The endpoint-specific limiter is independent from the scanner's
+        # mixed-endpoint limiter.  Keep exactly one direct-IP worker so this
+        # special budget cannot be multiplied by MAX_WORKERS.
+        worker_count = 1
+
+    worker_sessions = [
+        session.clone_for_worker(
+            proxy_start_index=worker_index,
+            requests_per_second=CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND,
+        )
+        for worker_index in range(worker_count)
+    ]
+    session_pool = list(worker_sessions)
+    session_lock = threading.Lock()
+
+    def _worker(summary: VaultSummary) -> tuple[PerpVaultObservationBundle, dict[str, Any]]:
+        with session_lock:
+            worker_session = session_pool.pop()
+        try:
+            return _fetch_hyperliquid_vault_bundle(worker_session, summary, timeout)
+        finally:
+            with session_lock:
+                session_pool.append(worker_session)
+
+    results = Parallel(n_jobs=worker_count, backend="threading")(delayed(_worker)(summary) for summary in selected)
     for bundle, payload in results:
         write_perp_vault_observation_bundle(connection, bundle, payload)
     return len(results)

--- a/eth_defi/hyperliquid/session.py
+++ b/eth_defi/hyperliquid/session.py
@@ -372,7 +372,11 @@ class HyperliquidSession(Session):
                     continue
                 raise
 
-    def clone_for_worker(self, proxy_start_index: int = 0) -> "HyperliquidSession":
+    def clone_for_worker(
+        self,
+        proxy_start_index: int = 0,
+        requests_per_second: float | None = None,
+    ) -> "HyperliquidSession":
         """Create a lightweight clone for a worker thread.
 
         The clone shares the same API URL. When proxies are configured, the
@@ -388,13 +392,22 @@ class HyperliquidSession(Session):
         proxy IP's full allowance. Without proxies, clones share the parent
         adapters so all direct workers coordinate through the same limiter.
 
+        Passing *requests_per_second* creates a new, worker-local limiter at
+        that rate even without a proxy.  Callers must use this only for a
+        single bounded worker or an endpoint with a separately justified
+        request budget, otherwise direct-IP workers would multiply the
+        effective API request rate.
+
         :param proxy_start_index:
             Starting proxy index for this worker (typically the worker
             ordinal: 0, 1, 2, ...).
+        :param requests_per_second:
+            Override rate for this clone.  ``None`` preserves the parent
+            limiter behaviour.
         :return:
             A new :py:class:`HyperliquidSession` with worker-local proxy
-            rotation state. The rate limiter is independent only when proxy
-            support is enabled.
+            rotation state. The rate limiter is independent when proxy support
+            is enabled or an override rate is supplied.
         """
         clone = HyperliquidSession(api_url=self.api_url)
 
@@ -402,7 +415,7 @@ class HyperliquidSession(Session):
         # proxy IP. Without proxies, every worker shares the same public IP, so
         # clones must share the parent adapter/rate limiter to avoid multiplying
         # the direct-IP request budget.
-        if self._adapter_config is not None and self.proxy_enabled:
+        if self._adapter_config is not None and (self.proxy_enabled or requests_per_second is not None):
             # Create a fresh adapter with a unique SQLite database for this
             # worker/proxy.
             fd, tmp_path = tempfile.mkstemp(
@@ -413,7 +426,7 @@ class HyperliquidSession(Session):
             os.close(fd)
             worker_db = Path(tmp_path)
             adapter = _create_adapter(
-                requests_per_second=self._adapter_config["requests_per_second"],
+                requests_per_second=requests_per_second or self._adapter_config["requests_per_second"],
                 retries=self._adapter_config["retries"],
                 backoff_factor=self._adapter_config["backoff_factor"],
                 pool_maxsize=self._adapter_config["pool_maxsize"],
@@ -422,7 +435,7 @@ class HyperliquidSession(Session):
             )
             clone.mount("http://", adapter)
             clone.mount("https://", adapter)
-            clone._adapter_config = self._adapter_config
+            clone._adapter_config = self._adapter_config | {"requests_per_second": requests_per_second or self._adapter_config["requests_per_second"]}
         else:
             # Direct-IP mode, or no adapter config stored: share the parent's
             # adapters so all clones coordinate through one limiter.

--- a/tests/hyperliquid/test_perp_metrics.py
+++ b/tests/hyperliquid/test_perp_metrics.py
@@ -1,0 +1,103 @@
+"""Unit tests for Hyperliquid perpetual-position metric collection."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from eth_defi.hyperliquid import perp_metrics
+from eth_defi.hyperliquid.perp_metrics import CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND, collect_hyperliquid_vault_observations
+from eth_defi.hyperliquid.vault import VaultSummary
+
+
+def _make_summary(index: int) -> VaultSummary:
+    """Create a minimal public vault summary for threaded collector tests."""
+    return VaultSummary(
+        name=f"Test vault {index}",
+        vault_address=f"0x{index:040x}",
+        leader=f"0x{index + 100:040x}",
+        tvl=Decimal("10000"),
+        is_closed=False,
+        relationship_type="normal",
+    )
+
+
+def test_collect_positions_uses_one_limiter_per_proxy(monkeypatch) -> None:
+    """Position reads must use the fast endpoint-specific rate limit per proxy IP."""
+    clones: list[tuple[int, float]] = []
+    sessions_seen: list[int] = []
+
+    class DummySession:
+        """Record the clones requested by the collector."""
+
+        proxy_enabled = True
+        proxy_count = 2
+
+        @staticmethod
+        def clone_for_worker(proxy_start_index: int, requests_per_second: float) -> SimpleNamespace:
+            """Return a uniquely identifiable worker session."""
+            clones.append((proxy_start_index, requests_per_second))
+            return SimpleNamespace(worker_index=proxy_start_index)
+
+    def fake_fetch(session: SimpleNamespace, summary: VaultSummary, _timeout: float) -> tuple[object, dict[str, str]]:
+        """Avoid HTTP reads while recording the worker session used."""
+        sessions_seen.append(session.worker_index)
+        return object(), {"vault_address": summary.vault_address}
+
+    monkeypatch.setattr(perp_metrics, "_fetch_hyperliquid_vault_bundle", fake_fetch)
+
+    def fake_write(*_args: object) -> None:
+        """Avoid DuckDB writes in this session-allocation test."""
+
+    monkeypatch.setattr(perp_metrics, "write_perp_vault_observation_bundle", fake_write)
+
+    summaries = [_make_summary(index) for index in range(5)]
+
+    attempts = collect_hyperliquid_vault_observations(
+        DummySession(),
+        object(),
+        summaries,
+        max_workers=10,
+        timeout=30.0,
+    )
+
+    assert attempts == len(summaries)
+    assert clones == [(0, CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND), (1, CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND)]
+    assert len(sessions_seen) == len(summaries)
+
+
+def test_collect_positions_uses_one_limiter_without_proxies(monkeypatch) -> None:
+    """A direct-IP scan must not multiply its endpoint-specific rate limit."""
+    clones: list[tuple[int, float]] = []
+
+    class DummySession:
+        """Record the sole direct-IP worker requested by the collector."""
+
+        proxy_enabled = False
+        proxy_count = 0
+
+        @staticmethod
+        def clone_for_worker(proxy_start_index: int, requests_per_second: float) -> SimpleNamespace:
+            """Return the uniquely identifiable direct-IP worker session."""
+            clones.append((proxy_start_index, requests_per_second))
+            return SimpleNamespace()
+
+    def fake_fetch(_session: SimpleNamespace, _summary: VaultSummary, _timeout: float) -> tuple[object, dict[str, str]]:
+        """Avoid HTTP reads in this direct-IP allocation test."""
+        return object(), {}
+
+    def fake_write(*_args: object) -> None:
+        """Avoid DuckDB writes in this session-allocation test."""
+
+    monkeypatch.setattr(perp_metrics, "_fetch_hyperliquid_vault_bundle", fake_fetch)
+    monkeypatch.setattr(perp_metrics, "write_perp_vault_observation_bundle", fake_write)
+
+    summaries = [_make_summary(index) for index in range(3)]
+    attempts = collect_hyperliquid_vault_observations(
+        DummySession(),
+        object(),
+        summaries,
+        max_workers=10,
+        timeout=30.0,
+    )
+
+    assert attempts == len(summaries)
+    assert clones == [(0, CLEARINGHOUSE_STATE_REQUESTS_PER_SECOND)]

--- a/tests/hyperliquid/test_session.py
+++ b/tests/hyperliquid/test_session.py
@@ -266,6 +266,17 @@ def test_direct_worker_clone_shares_rate_limiter_adapter(tmp_path) -> None:
     assert clone.get_adapter("https://api.hyperliquid.xyz") is session.get_adapter("https://api.hyperliquid.xyz")
 
 
+def test_direct_worker_clone_can_use_a_single_endpoint_specific_rate_limit(tmp_path) -> None:
+    """A separately bounded direct-IP phase can opt into its documented API budget."""
+    session = create_hyperliquid_session(rate_limit_db_path=tmp_path / "direct.sqlite")
+    expected_requests_per_second = 9.0
+
+    clone = session.clone_for_worker(proxy_start_index=0, requests_per_second=expected_requests_per_second)
+
+    assert clone.get_adapter("https://api.hyperliquid.xyz") is not session.get_adapter("https://api.hyperliquid.xyz")
+    assert clone._adapter_config["requests_per_second"] == expected_requests_per_second
+
+
 def test_proxy_worker_clone_uses_independent_rate_limiter_adapter(tmp_path) -> None:
     """Proxy worker clones keep independent limiters for independent IPs."""
     session = create_hyperliquid_session(

--- a/tests/hyperliquid/test_trade_history_integration.py
+++ b/tests/hyperliquid/test_trade_history_integration.py
@@ -51,10 +51,12 @@ ACTIVE_ACCOUNT = "0x1e37a337ed460039d1b15bd3bc489de789768d5e"
 TEST_END = datetime.datetime.now(datetime.UTC).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None) - datetime.timedelta(days=1)
 TEST_START = TEST_END - datetime.timedelta(days=7)
 
-#: Bound the idempotency test's live-data volume. The active Growi vault
-#: generated 22,753 fills across the seven-day window on 2026-08-23, making a
-#: full duplicate re-sync too slow for CI.
-IDEMPOTENCY_TEST_START = TEST_END - datetime.timedelta(hours=1)
+#: Limit the reconstruction test to a one-day live fill window.  The Growi HF
+#: vault produced enough fills over seven days to time out while DuckDB inserted
+#: rows in CI on 2026-08-24, although the API and reconstruction code worked.
+#: The idempotency check shares this recent interval so it does not rely on one
+#: inactive historical hour containing a fill.
+RECONSTRUCTION_TEST_START = TEST_END - datetime.timedelta(days=1)
 
 
 @pytest.fixture(scope="module")
@@ -94,12 +96,12 @@ def test_reconstruct_vault_trade_history(session, tmp_path):
     db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
     try:
         db.add_account(ACTIVE_ACCOUNT, label="Growi HF vault", is_vault=True)
-        db.sync_account_fills(session, ACTIVE_ACCOUNT, start_time=TEST_START, end_time=TEST_END)
+        db.sync_account_fills(session, ACTIVE_ACCOUNT, start_time=RECONSTRUCTION_TEST_START, end_time=TEST_END)
 
         history = fetch_account_trade_history(
             session,
             ACTIVE_ACCOUNT,
-            start_time=TEST_START,
+            start_time=RECONSTRUCTION_TEST_START,
             end_time=TEST_END,
         )
 
@@ -152,11 +154,10 @@ def test_reconstruct_normal_account_trade_history(session, tmp_path):
 def test_sync_fills_idempotent(session, tmp_path):
     """Verify that a persisted fill watermark avoids duplicate rows on a second sync.
 
-    The live Growi vault can exceed Hyperliquid's 2,000-fill response limit
-    within a few hours. Restricting the initial query to one hour retains
-    coverage of live pagination, persistence and duplicate handling, while
-    making the follow-up query begin at the stored fill watermark instead of
-    downloading the complete range a second time.
+    Restricting the initial query to one recent day retains coverage of live
+    pagination, persistence and duplicate handling without scanning the
+    growing seven-day account history.  The follow-up query begins at the
+    stored fill watermark instead of downloading the complete range again.
     """
     db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
     try:
@@ -166,7 +167,7 @@ def test_sync_fills_idempotent(session, tmp_path):
         first_count = db.sync_account_fills(
             session,
             ACTIVE_ACCOUNT,
-            start_time=IDEMPOTENCY_TEST_START,
+            start_time=RECONSTRUCTION_TEST_START,
             end_time=TEST_END,
         )
         db.save()


### PR DESCRIPTION
## Why

Hyperliquid position observations used a shared 1 request/second limiter even though `clearinghouseState` has a lower API weight. This serialised the scanner stage visible in production logs.

## Lessons learnt

`clearinghouseState` costs weight 2 while most `/info` calls cost 20. A dedicated budget is safe only when direct traffic has one bounded worker, or proxy workers are capped to one per proxy IP.

## Summary

- Read position state at a conservative 9 requests/second per IP.
- Distribute proxy workers across distinct proxy IPs and retain one direct-IP worker.
- Add unit coverage for both allocation paths and the endpoint-specific limiter.
- Verified with the live `test_live_hyperliquid_perp_metrics_reach_cleaned_parquet_and_json` test on 2026-08-24 against the public Hyperliquid API.

## Related issues and PRs

None.

## Unrelated CI and test fixes

- Restrict live trade-history reconstruction and idempotency coverage to a recent one-day fill window. The seven-day insert timed out, while an inactive one-hour window returned no fills in CI on 2026-08-24. Both focused real API tests pass locally.