### PR TITLE
fix: shorten GMX vault display names

### DIFF
--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -431,7 +431,7 @@ imports and local verification:
 
 | Script | Purpose |
 |--------|---------|
-| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names, direct GMX links and the USDC display denomination |
+| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names, direct GMX links, no short description and the USDC display denomination |
 | [`backfill-gmx-vault-prices.py`](../../scripts/erc-4626/backfill-gmx-vault-prices.py) | Prefill complete Arbitrum and Avalanche context ranges and run the common hourly Parquet writer without modifying production reader state |
 | [`examine-gmx-vault-backfill.py`](../../scripts/erc-4626/examine-gmx-vault-backfill.py) | Check duplicates, positive values, source linkage, asset identity and sparse-threshold behaviour |
 | [`examine-gmx-vault-performance.py`](../../scripts/erc-4626/examine-gmx-vault-performance.py) | Run common lifetime metrics and display TVL, lifetime CAGR, three-month CAGR, approximate three-month volatility and Sharpe |

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -428,7 +428,7 @@ imports and local verification:
 
 | Script | Purpose |
 |--------|---------|
-| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including unique names and the USDC display denomination |
+| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including trading-pair display names and the USDC display denomination |
 | [`backfill-gmx-vault-prices.py`](../../scripts/erc-4626/backfill-gmx-vault-prices.py) | Prefill complete Arbitrum and Avalanche context ranges and run the common hourly Parquet writer without modifying production reader state |
 | [`examine-gmx-vault-backfill.py`](../../scripts/erc-4626/examine-gmx-vault-backfill.py) | Check duplicates, positive values, source linkage, asset identity and sparse-threshold behaviour |
 | [`examine-gmx-vault-performance.py`](../../scripts/erc-4626/examine-gmx-vault-performance.py) | Run common lifetime metrics and display TVL, lifetime CAGR, three-month CAGR, approximate three-month volatility and Sharpe |

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -125,12 +125,12 @@ This ratio measures the USD value attributable to one GM or GLV share. It lets
 GMX products use the same equity-curve, return, CAGR, volatility, Sharpe and
 drawdown code as vaults that publish a conventional share price.
 
-The vault performance originates as a USD-valued GMX share curve. The catalogue
+The vault performance approximates the single-sided USDC deposit value. GMX
+vaults hold exposure to all underlying tokens they market make. The catalogue
 uses native USDC as its display denomination for comparison, but this does not
 mean every pool accepts USDC, is backed solely by USDC, or has an onchain USDC
-NAV. It approximates a single-sided USDC deposit only where USDC is accepted
-and does not model the deposit transaction. Accepted deposit tokens are
-product-specific, and some products have no stablecoin side.
+NAV. Accepted deposit tokens are product-specific, and some products have no
+stablecoin side.
 
 This is a comparison convention, not a transaction simulator. The curve does
 not model the execution fee, price impact, token spread, deposit or withdrawal

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -243,6 +243,9 @@ history, are marked deposit-closed and are excluded from vault rankings.
 Both inherit from `GMXVaultBase`, which in turn implements `VaultBase` directly.
 They deliberately do not pretend to be ERC-4626 contracts.
 
+Each adapter's `get_link()` returns the direct GMX pool-details page for that
+GM or GLV share token, including its deployment chain and the GMX deposit view.
+
 The adapter provides the common read-only metadata surface and declares a
 synthetic USD denomination. It also classifies the strategy as market making
 and liquidity provision. GMX is classified as low technical protocol risk in
@@ -428,7 +431,7 @@ imports and local verification:
 
 | Script | Purpose |
 |--------|---------|
-| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names and the USDC display denomination |
+| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names, direct GMX links and the USDC display denomination |
 | [`backfill-gmx-vault-prices.py`](../../scripts/erc-4626/backfill-gmx-vault-prices.py) | Prefill complete Arbitrum and Avalanche context ranges and run the common hourly Parquet writer without modifying production reader state |
 | [`examine-gmx-vault-backfill.py`](../../scripts/erc-4626/examine-gmx-vault-backfill.py) | Check duplicates, positive values, source linkage, asset identity and sparse-threshold behaviour |
 | [`examine-gmx-vault-performance.py`](../../scripts/erc-4626/examine-gmx-vault-performance.py) | Run common lifetime metrics and display TVL, lifetime CAGR, three-month CAGR, approximate three-month volatility and Sharpe |

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -431,7 +431,7 @@ imports and local verification:
 
 | Script | Purpose |
 |--------|---------|
-| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names, direct GMX links, no short description and the USDC display denomination |
+| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh the GMX fields maintained by the migration: product-type-prefixed trading-pair display names, USDC display denomination, direct GMX links, performance note, deposit availability and no short description |
 | [`backfill-gmx-vault-prices.py`](../../scripts/erc-4626/backfill-gmx-vault-prices.py) | Prefill complete Arbitrum and Avalanche context ranges and run the common hourly Parquet writer without modifying production reader state |
 | [`examine-gmx-vault-backfill.py`](../../scripts/erc-4626/examine-gmx-vault-backfill.py) | Check duplicates, positive values, source linkage, asset identity and sparse-threshold behaviour |
 | [`examine-gmx-vault-performance.py`](../../scripts/erc-4626/examine-gmx-vault-performance.py) | Run common lifetime metrics and display TVL, lifetime CAGR, three-month CAGR, approximate three-month volatility and Sharpe |

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -428,7 +428,7 @@ imports and local verification:
 
 | Script | Purpose |
 |--------|---------|
-| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including trading-pair display names and the USDC display denomination |
+| [`migrate-gmx-vaults-metadata.py`](../../scripts/erc-4626/migrate-gmx-vaults-metadata.py) | Idempotently refresh GM/GLV metadata, including product-type-prefixed trading-pair display names and the USDC display denomination |
 | [`backfill-gmx-vault-prices.py`](../../scripts/erc-4626/backfill-gmx-vault-prices.py) | Prefill complete Arbitrum and Avalanche context ranges and run the common hourly Parquet writer without modifying production reader state |
 | [`examine-gmx-vault-backfill.py`](../../scripts/erc-4626/examine-gmx-vault-backfill.py) | Check duplicates, positive values, source linkage, asset identity and sparse-threshold behaviour |
 | [`examine-gmx-vault-performance.py`](../../scripts/erc-4626/examine-gmx-vault-performance.py) | Run common lifetime metrics and display TVL, lifetime CAGR, three-month CAGR, approximate three-month volatility and Sharpe |

--- a/eth_defi/gmx/links.py
+++ b/eth_defi/gmx/links.py
@@ -1,0 +1,26 @@
+"""GMX user-interface links for liquidity-provider products."""
+
+from eth_typing import HexAddress
+
+
+def get_gmx_pool_details_link(chain_id: int, product_address: HexAddress) -> str:
+    """Build GMX's direct pool-details link for one GM or GLV product.
+
+    The GMX interface identifies both GM and GLV pool detail pages through the
+    product address in its ``market`` query parameter. The ``chainId`` query
+    parameter switches the interface to the product's deployment chain before
+    it resolves that address.
+
+    :param chain_id:
+        EVM deployment chain ID of the GM or GLV product.
+    :param product_address:
+        GM market-token or GLV share-token address.
+    :return:
+        Direct GMX pool-details URL with the deposit view selected.
+
+    .. seealso::
+
+        `GMX interface pool-details route <https://github.com/gmx-io/gmx-interface/blob/release/src/pages/PoolsDetails/PoolsDetails.tsx>`__.
+    """
+
+    return f"https://app.gmx.io/#/pools/details?market={product_address.lower()}&operation=Deposit&chainId={chain_id}"

--- a/eth_defi/gmx/vault.py
+++ b/eth_defi/gmx/vault.py
@@ -199,10 +199,8 @@ class GMXVaultBase(VaultBase):
         return self.share_token.symbol
 
     @property
-    def short_description(self) -> str:
-        """Return a compact product description."""
-
-        return "GMX V2 liquidity-provider share valued from supply-normalised onchain pool value and supply events"
+    def short_description(self) -> None:
+        return None
 
     def fetch_share_token(self) -> TokenDetails:
         """Fetch GM or GLV ERC-20 metadata."""

--- a/eth_defi/gmx/vault.py
+++ b/eth_defi/gmx/vault.py
@@ -24,6 +24,7 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.gmx.historical_context import GMXHistoricalContextStore, get_gmx_historical_context_path
 from eth_defi.gmx.historical_oracle import GMXHistoricalSharePriceObservation
+from eth_defi.gmx.links import get_gmx_pool_details_link
 from eth_defi.gmx.vault_catalog import GMX_CHAIN_NAMES_BY_ID
 from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
@@ -369,9 +370,24 @@ class GMXVaultBase(VaultBase):
         return None
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return the GMX liquidity markets page."""
+        """Return the direct GMX pool-details page for this share token.
 
-        return "https://app.gmx.io/#/pools"
+        Both GM and GLV products use GMX's ``market`` URL query parameter. The
+        link includes the deployment chain so the GMX interface selects the
+        correct network before resolving the product address.
+
+        :param referral:
+            Ignored because GMX's pool-details route does not accept the
+            common vault referral parameter.
+        :return:
+            Direct GMX pool-details URL with the deposit view selected.
+
+        .. seealso::
+
+            `GMX interface pool-details route <https://github.com/gmx-io/gmx-interface/blob/release/src/pages/PoolsDetails/PoolsDetails.tsx>`__.
+        """
+
+        return get_gmx_pool_details_link(self.chain_id, self.address)
 
     def is_whitelisted_deposit(self) -> bool:
         """Return whether GMX LP access is allowlisted."""

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -15,6 +15,7 @@ from eth_defi.gmx.links import get_gmx_pool_details_link
 from eth_defi.gmx.vault_catalog import GMXVaultProduct, fetch_gmx_v2_vault_products
 from eth_defi.token import TokenDiskCache, fetch_erc20_details
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import GMX_SINGLE_SIDED_USDC_NOTE
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -85,11 +86,11 @@ def _normalise_gmx_row(row: VaultRow, *, product: GMXVaultProduct, name: str) ->
     row["Protocol"] = "GMX"
     row["Denomination"] = "USDC"
     row["Link"] = get_gmx_pool_details_link(product.chain_id, product.token_address)
+    row["_notes"] = GMX_SINGLE_SIDED_USDC_NOTE
     row["_short_description"] = None
     row["_synthetic_usd_denomination"] = False
     row["_gmx_product_type"] = product.product_type
-    if not product.is_enabled:
-        row["_deposits_open"] = False
+    row["_deposits_open"] = None if product.is_enabled else False
     return row
 
 
@@ -182,8 +183,10 @@ def fetch_and_sync_gmx_vault_catalogue(
                         "Protocol",
                         "Denomination",
                         "Link",
+                        "_notes",
                         "_short_description",
                         "_synthetic_usd_denomination",
+                        "_deposits_open",
                         "_deposits_open",
                     )
                     if key in row

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -11,6 +11,7 @@ from web3 import Web3
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.gmx.links import get_gmx_pool_details_link
 from eth_defi.gmx.vault_catalog import GMXVaultProduct, fetch_gmx_v2_vault_products
 from eth_defi.token import TokenDiskCache, fetch_erc20_details
 from eth_defi.vault.base import VaultSpec
@@ -83,6 +84,7 @@ def _normalise_gmx_row(row: VaultRow, *, product: GMXVaultProduct, name: str) ->
     row["Name"] = name
     row["Protocol"] = "GMX"
     row["Denomination"] = "USDC"
+    row["Link"] = get_gmx_pool_details_link(product.chain_id, product.token_address)
     row["_synthetic_usd_denomination"] = False
     row["_gmx_product_type"] = product.product_type
     if not product.is_enabled:
@@ -178,6 +180,7 @@ def fetch_and_sync_gmx_vault_catalogue(
                         "Name",
                         "Protocol",
                         "Denomination",
+                        "Link",
                         "_synthetic_usd_denomination",
                         "_deposits_open",
                     )

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -11,7 +11,7 @@ from web3 import Web3
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.scan import create_vault_scan_record
-from eth_defi.gmx.vault_catalog import GMX_CHAIN_NAMES_BY_ID, GMXVaultProduct, fetch_gmx_v2_vault_products
+from eth_defi.gmx.vault_catalog import GMXVaultProduct, fetch_gmx_v2_vault_products
 from eth_defi.token import TokenDiskCache, fetch_erc20_details
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
@@ -54,13 +54,25 @@ def _fetch_token_symbol(web3: Web3, chain_id: int, address: HexAddress, token_ca
 
 
 def _format_gmx_product_name(web3: Web3, product: GMXVaultProduct, token_cache: TokenDiskCache) -> str:
-    """Build a stable globally unique GMX product name."""
+    """Build the concise GMX trading-pair display name.
+
+    The common vault database identifies a product by its chain ID and share
+    token address, not its display name. Keeping only the long-short token
+    pair makes the public catalogue scannable while the migration can safely
+    update existing rows without a name-derived key.
+
+    :param web3:
+        Product-chain Web3 connection used to resolve token symbols.
+    :param product:
+        Current GM or GLV product definition.
+    :param token_cache:
+        Shared ERC-20 metadata cache.
+    :return:
+        Long-short token-pair label, for example ``"WBTC-USDC"``.
+    """
 
     symbols = tuple(_fetch_token_symbol(web3, product.chain_id, address, token_cache) for address in product.accepted_deposit_tokens)
-    token_pair = "-".join(symbols)
-    prefix = "GMX Market" if product.product_type == "gm" else "GMX Liquidity Vault"
-    chain_name = GMX_CHAIN_NAMES_BY_ID[product.chain_id].title()
-    return f"{prefix} [{token_pair}] ({chain_name}, {product.token_address})"
+    return "-".join(symbols)
 
 
 def _normalise_gmx_row(row: VaultRow, *, product: GMXVaultProduct, name: str) -> VaultRow:

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -85,6 +85,7 @@ def _normalise_gmx_row(row: VaultRow, *, product: GMXVaultProduct, name: str) ->
     row["Protocol"] = "GMX"
     row["Denomination"] = "USDC"
     row["Link"] = get_gmx_pool_details_link(product.chain_id, product.token_address)
+    row["_short_description"] = None
     row["_synthetic_usd_denomination"] = False
     row["_gmx_product_type"] = product.product_type
     if not product.is_enabled:
@@ -181,6 +182,7 @@ def fetch_and_sync_gmx_vault_catalogue(
                         "Protocol",
                         "Denomination",
                         "Link",
+                        "_short_description",
                         "_synthetic_usd_denomination",
                         "_deposits_open",
                     )

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -57,9 +57,9 @@ def _format_gmx_product_name(web3: Web3, product: GMXVaultProduct, token_cache: 
     """Build the concise GMX trading-pair display name.
 
     The common vault database identifies a product by its chain ID and share
-    token address, not its display name. Keeping only the long-short token
-    pair makes the public catalogue scannable while the migration can safely
-    update existing rows without a name-derived key.
+    token address, not its display name. Keeping only the product type and
+    long-short pair makes the public catalogue scannable while the
+    migration can safely update existing rows without a name-derived key.
 
     :param web3:
         Product-chain Web3 connection used to resolve token symbols.
@@ -68,11 +68,13 @@ def _format_gmx_product_name(web3: Web3, product: GMXVaultProduct, token_cache: 
     :param token_cache:
         Shared ERC-20 metadata cache.
     :return:
-        Long-short token-pair label, for example ``"WBTC-USDC"``.
+        Product-type and long-short token-pair label, for example
+        ``"GM WBTC-USDC"`` or ``"GLV WBTC-USDC"``.
     """
 
     symbols = tuple(_fetch_token_symbol(web3, product.chain_id, address, token_cache) for address in product.accepted_deposit_tokens)
-    return "-".join(symbols)
+    product_label = "GM" if product.product_type == "gm" else "GLV"
+    return f"{product_label} {'-'.join(symbols)}"
 
 
 def _normalise_gmx_row(row: VaultRow, *, product: GMXVaultProduct, name: str) -> VaultRow:

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -202,9 +202,9 @@ SPIKO_EUTBL_NOTE = """Spiko EU T-Bills Money Market Fund (EUTBL).
 
 #: Public qualification for GMX's share-price-equivalent performance curve.
 #:
-#: Actual deposit tokens are product-specific, so the note distinguishes the
-#: USD comparison convention from a transaction path.
-GMX_SINGLE_SIDED_USDC_NOTE = "The vault performance is a GMX share curve displayed in USDC. GMX values the underlying share in USD; the USDC label is a comparison convention. It approximates a single-sided USDC deposit only where USDC is accepted and does not model the deposit transaction."
+#: GMX liquidity-provider shares retain exposure to every token in their
+#: underlying markets, despite the single-sided USDC performance convention.
+GMX_SINGLE_SIDED_USDC_NOTE = "The vault performance approximates the single-sided USDC deposit value. GMX vaults hold exposure to all underlying tokens they market make"
 
 #: Vault-specific notes and classifications that do not exclude a vault from
 #: research datasets.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -525,8 +525,8 @@ normal vault Parquet files.
 
 Use the manual scripts in this order. First idempotently migrate current
 products into the common metadata database. This refreshes existing GM and GLV
-rows by chain and share-token address, including their unique names and USDC
-display denomination:
+rows by chain and share-token address, including their trading-pair display
+names and USDC display denomination:
 
 ```shell
 source .local-test.env && \

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -525,8 +525,8 @@ normal vault Parquet files.
 
 Use the manual scripts in this order. First idempotently migrate current
 products into the common metadata database. This refreshes existing GM and GLV
-rows by chain and share-token address, including their trading-pair display
-names and USDC display denomination:
+rows by chain and share-token address, including their GM/GLV trading-pair
+display names and USDC display denomination:
 
 ```shell
 source .local-test.env && \

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -2,7 +2,7 @@
 
 Existing rows are identified by chain and share-token address, so each run also
 refreshes display metadata such as the concise GM/GLV trading-pair name and
-the direct GMX pool-details link.
+the direct GMX pool-details link. It also clears GMX short descriptions.
 
 Environment variables:
 

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -1,7 +1,8 @@
 """Migrate GMX V2 GM and GLV metadata into the common vault database.
 
 Existing rows are identified by chain and share-token address, so each run also
-refreshes display metadata such as the concise GM/GLV trading-pair name.
+refreshes display metadata such as the concise GM/GLV trading-pair name and
+the direct GMX pool-details link.
 
 Environment variables:
 

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -1,8 +1,10 @@
 """Migrate GMX V2 GM and GLV metadata into the common vault database.
 
-Existing rows are identified by chain and share-token address, so each run also
-refreshes display metadata such as the concise GM/GLV trading-pair name and
-the direct GMX pool-details link. It also clears GMX short descriptions.
+Existing rows are identified by chain and share-token address, so each run
+refreshes the GMX fields maintained by this migration: the concise GM/GLV
+trading-pair name, USDC display denomination, direct GMX pool-details link,
+performance note, deposit availability and short description. It does not
+overwrite manual enrichment fields belonging to other pipeline stages.
 
 Environment variables:
 

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -1,5 +1,8 @@
 """Migrate GMX V2 GM and GLV metadata into the common vault database.
 
+Existing rows are identified by chain and share-token address, so each run also
+refreshes display metadata such as the concise trading-pair name.
+
 Environment variables:
 
 - ``CHAINS``: Comma-separated ``arbitrum`` and/or ``avalanche``. Defaults to both.

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -1,7 +1,7 @@
 """Migrate GMX V2 GM and GLV metadata into the common vault database.
 
 Existing rows are identified by chain and share-token address, so each run also
-refreshes display metadata such as the concise trading-pair name.
+refreshes display metadata such as the concise GM/GLV trading-pair name.
 
 Environment variables:
 

--- a/tests/gmx/test_gmx_vault.py
+++ b/tests/gmx/test_gmx_vault.py
@@ -123,6 +123,7 @@ def test_gmx_vaults_explain_single_sided_usdc_performance_equivalence() -> None:
 
     for vault_class, token in ((GMXMarketVault, GM_TOKEN), (GMXLiquidityVault, GLV_TOKEN)):
         vault = vault_class(web3, VaultSpec(42161, token))
+        assert vault.short_description is None
         assert vault.get_notes() == expected
 
 

--- a/tests/gmx/test_gmx_vault.py
+++ b/tests/gmx/test_gmx_vault.py
@@ -119,7 +119,7 @@ def test_gmx_vaults_explain_single_sided_usdc_performance_equivalence() -> None:
     """GM and GLV expose the common performance-interpretation note."""
 
     web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=42161))
-    expected = "The vault performance is a GMX share curve displayed in USDC. GMX values the underlying share in USD; the USDC label is a comparison convention. It approximates a single-sided USDC deposit only where USDC is accepted and does not model the deposit transaction."
+    expected = "The vault performance approximates the single-sided USDC deposit value. GMX vaults hold exposure to all underlying tokens they market make"
 
     for vault_class, token in ((GMXMarketVault, GM_TOKEN), (GMXLiquidityVault, GLV_TOKEN)):
         vault = vault_class(web3, VaultSpec(42161, token))

--- a/tests/gmx/test_gmx_vault.py
+++ b/tests/gmx/test_gmx_vault.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from eth_typing import HexAddress
 from eth_utils import to_checksum_address
 
 from eth_defi.erc_4626.classification import create_vault_instance
@@ -68,6 +69,18 @@ def test_gmx_fee_interface_matches_protocol_liquidity_pools() -> None:
         assert fee_data.deposit == 0.0
         assert fee_data.withdraw == 0.0
         assert fee_data.can_calculate_investor_net_performance()
+
+
+@pytest.mark.parametrize(
+    ("vault_class", "token"),
+    ((GMXMarketVault, GM_TOKEN), (GMXLiquidityVault, GLV_TOKEN)),
+)
+def test_gmx_vault_link_opens_its_direct_gmx_pool_details_page(vault_class: type[GMXMarketVault] | type[GMXLiquidityVault], token: HexAddress) -> None:
+    """GM and GLV vaults use their product address and chain in GMX links."""
+
+    vault = vault_class(SimpleNamespace(eth=SimpleNamespace(chain_id=42161)), VaultSpec(42161, token))
+
+    assert vault.get_link() == f"https://app.gmx.io/#/pools/details?market={token.lower()}&operation=Deposit&chainId=42161"
 
 
 def test_gmx_withdrawals_have_an_asynchronous_settlement_estimate() -> None:

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -11,6 +11,7 @@ from eth_defi.gmx import vault_sync
 from eth_defi.gmx.vault_catalog import GMXVaultProduct
 from eth_defi.gmx.vault_sync import fetch_and_sync_gmx_vault_catalogue
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import GMX_SINGLE_SIDED_USDC_NOTE
 from eth_defi.vault.vaultdb import VaultDatabase
 
 GM_TOKEN = to_checksum_address("0x1000000000000000000000000000000000000001")
@@ -59,6 +60,8 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     first = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=FIRST_CATALOGUE_BLOCK)
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_manual_enrichment"] = "keep me"
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_short_description"] = "Remove me"
+    vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_notes"] = "Replace me"
+    vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_deposits_open"] = False
     monkeypatch.setattr(
         vault_sync,
         "create_vault_scan_record",
@@ -75,7 +78,9 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert row_after_failed_refresh["Protocol"] == "GMX"
     assert row_after_failed_refresh["Denomination"] == "USDC"
     assert row_after_failed_refresh["Link"] == f"https://app.gmx.io/#/pools/details?market={GM_TOKEN.lower()}&operation=Deposit&chainId=42161"
+    assert row_after_failed_refresh["_notes"] == GMX_SINGLE_SIDED_USDC_NOTE
     assert row_after_failed_refresh["_short_description"] is None
+    assert row_after_failed_refresh["_deposits_open"] is None
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
 
     monkeypatch.setattr(vault_sync, "fetch_gmx_v2_vault_products", lambda *_args, **_kwargs: iter((replace(product, is_enabled=False),)))

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -69,7 +69,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     )
     second = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=456)
     row_after_failed_refresh = vault_db.rows[VaultSpec(42161, GM_TOKEN)]
-    assert row_after_failed_refresh["Name"] == f"GMX Market [WBTC-USDC] (Arbitrum, {GM_TOKEN})"
+    assert row_after_failed_refresh["Name"] == "WBTC-USDC"
     assert row_after_failed_refresh["Protocol"] == "GMX"
     assert row_after_failed_refresh["Denomination"] == "USDC"
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
@@ -94,7 +94,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert second.updated == 1
     assert third.inserted == 0
     assert third.updated == 1
-    assert row["Name"] == f"GMX Market [WBTC-USDC] (Arbitrum, {GM_TOKEN})"
+    assert row["Name"] == "WBTC-USDC"
     assert row["_manual_enrichment"] == "keep me"
     assert detection.first_seen_at_block == FIRST_CATALOGUE_BLOCK
     assert detection.address == GM_TOKEN.lower()

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -58,6 +58,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
 
     first = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=FIRST_CATALOGUE_BLOCK)
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_manual_enrichment"] = "keep me"
+    vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_short_description"] = "Remove me"
     monkeypatch.setattr(
         vault_sync,
         "create_vault_scan_record",
@@ -74,6 +75,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert row_after_failed_refresh["Protocol"] == "GMX"
     assert row_after_failed_refresh["Denomination"] == "USDC"
     assert row_after_failed_refresh["Link"] == f"https://app.gmx.io/#/pools/details?market={GM_TOKEN.lower()}&operation=Deposit&chainId=42161"
+    assert row_after_failed_refresh["_short_description"] is None
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
 
     monkeypatch.setattr(vault_sync, "fetch_gmx_v2_vault_products", lambda *_args, **_kwargs: iter((replace(product, is_enabled=False),)))

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -73,6 +73,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert row_after_failed_refresh["Name"] == "GM WBTC-USDC"
     assert row_after_failed_refresh["Protocol"] == "GMX"
     assert row_after_failed_refresh["Denomination"] == "USDC"
+    assert row_after_failed_refresh["Link"] == f"https://app.gmx.io/#/pools/details?market={GM_TOKEN.lower()}&operation=Deposit&chainId=42161"
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
 
     monkeypatch.setattr(vault_sync, "fetch_gmx_v2_vault_products", lambda *_args, **_kwargs: iter((replace(product, is_enabled=False),)))
@@ -96,6 +97,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert third.inserted == 0
     assert third.updated == 1
     assert row["Name"] == "GM WBTC-USDC"
+    assert row["Link"] == f"https://app.gmx.io/#/pools/details?market={GM_TOKEN.lower()}&operation=Deposit&chainId=42161"
     assert row["_manual_enrichment"] == "keep me"
     assert detection.first_seen_at_block == FIRST_CATALOGUE_BLOCK
     assert detection.address == GM_TOKEN.lower()

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -53,6 +53,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
             "Denomination": "USD",
         },
     )
+    assert vault_sync._format_gmx_product_name(web3, replace(product, product_type="glv"), {}) == "GLV WBTC-USDC"
     vault_db = VaultDatabase()
 
     first = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=FIRST_CATALOGUE_BLOCK)
@@ -69,7 +70,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     )
     second = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=456)
     row_after_failed_refresh = vault_db.rows[VaultSpec(42161, GM_TOKEN)]
-    assert row_after_failed_refresh["Name"] == "WBTC-USDC"
+    assert row_after_failed_refresh["Name"] == "GM WBTC-USDC"
     assert row_after_failed_refresh["Protocol"] == "GMX"
     assert row_after_failed_refresh["Denomination"] == "USDC"
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
@@ -94,7 +95,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert second.updated == 1
     assert third.inserted == 0
     assert third.updated == 1
-    assert row["Name"] == "WBTC-USDC"
+    assert row["Name"] == "GM WBTC-USDC"
     assert row["_manual_enrichment"] == "keep me"
     assert detection.first_seen_at_block == FIRST_CATALOGUE_BLOCK
     assert detection.address == GM_TOKEN.lower()


### PR DESCRIPTION
## Why

GMX catalogue names currently expose implementation details, making the protocol page difficult to scan. The public label should identify the GMX product type and the long-short trading pair only. Vault links must also open the matching GMX product page instead of the generic pools list. The shared performance note should clearly describe the single-sided USDC value approximation and retained underlying-token exposure. GMX products do not need a generic short description. The migration must apply every GMX field changed by this PR even when a row-level scan is degraded.

## Lessons learnt

Vault rows use the chain ID and share-token address as their immutable identity. Display names can therefore remain concise and are safe to refresh through the idempotent metadata migration. GMX uses the same pool-details route for GM and GLV tokens, addressed through `market` plus `chainId`. A USDC-denominated performance convention does not remove underlying market-token exposure. Metadata migrations must explicitly refresh deterministic fields and clear stale values when a scan row is degraded.

## Summary

- Use names such as `GM WBTC-USDC` and `GLV WBTC-USDC`, without chain names or token addresses.
- Return direct GMX pool-detail links that select the correct token and deployment chain.
- Refresh the GMX fields maintained by the migration: name, USDC denomination, direct link, performance note, short-description removal and deposit availability.
- Preserve unrelated manual enrichment while applying those fields after a transient row-level scan failure.
- Describe GMX performance as a single-sided USDC deposit-value approximation with exposure to all market-made underlying tokens.
- Document and test the display-name, link, short-description, performance-note and migration behaviours.

## Related issues and PRs

Follow-up to #1517.

## Unrelated CI and test fixes

None.