### PR TITLE
fix: prevent Rysk discovery crash on unsupported chains

### DIFF
--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -575,6 +575,7 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
     from eth_defi.abi import get_topic_signature_from_event
 
     t3tris_configuration_events = get_t3tris_vault_configuration_discovery_events(web3)
+    rysk_configuration_events = get_rysk_premium_discovery_events(web3)
     event_groups = (
         (get_standard_erc_4626_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
         (get_brink_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
@@ -586,7 +587,7 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
         (get_t3tris_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
         (t3tris_configuration_events, (VaultEventKind.configuration,) * len(t3tris_configuration_events)),
         (get_securitize_dstoken_discovery_events(web3), (VaultEventKind.deposit,)),
-        (get_rysk_premium_discovery_events(web3), (VaultEventKind.configuration,)),
+        (rysk_configuration_events, (VaultEventKind.configuration,) * len(rysk_configuration_events)),
     )
     return {get_topic_signature_from_event(event): event_kind for events, event_kinds in event_groups for event, event_kind in zip(events, event_kinds, strict=True)}
 

--- a/tests/erc_4626/vault_protocol/test_rysk.py
+++ b/tests/erc_4626/vault_protocol/test_rysk.py
@@ -54,7 +54,10 @@ def test_rysk_uses_onchain_lead_and_feature_probes() -> None:
 
     unsupported_web3 = Mock()
     unsupported_web3.eth.chain_id = 42161
+    unsupported_web3.eth.contract = web3.eth.contract
     assert get_rysk_premium_discovery_events(unsupported_web3) == []
+    unsupported_topic_map = get_vault_event_topic_map(unsupported_web3)
+    assert RYSK_EPOCH_PRICE_SET_TOPIC not in unsupported_topic_map
 
     for chain_id in (1, 999):
         probe_names = {call.func_name for call in create_probe_calls([RYSK_KPK_WETH_PUT], chain_id=chain_id)}


### PR DESCRIPTION
## Why

Rysk lead discovery is enabled only on Ethereum and HyperEVM. Its empty event set on unsupported chains was paired with a fixed one-item classification tuple, aborting all Arbitrum discovery cycles.

## Lessons learnt

Whenever discovery events are chain-gated, their classifications must be derived from the returned event collection so strict cardinality checks remain valid.

## Summary

- Derive Rysk configuration classifications from the discovered event count.
- Cover building the complete topic map on an unsupported chain.

## Related issues and PRs

Fixes a production regression introduced by #1516 and follows the Rysk migration work in #1519.

## Unrelated CI and test fixes

None.