### PR TITLE
feat: classify GMX vaults as AMM pool-like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Mark GMX GM and GLV vaults as automated-market-maker pool shares (2026-08-26)
 - feat: Add directional-leverage classifications for Lighter's fixed 2x long and short pool family (2026-08-26)
 - feat: Categorise all current Lighter public vault strategies, including auto-rebalanced directional products, documented managed pools and both protocol liquidity pools (2026-08-26)
 - feat: Add Dima curator attribution for three Lighter pools, including the automated breakout and long/short strategies (2026-08-26)

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -158,6 +158,13 @@ class ERC4626Feature(enum.Enum):
     #: https://docs.gmx.io/docs/providing-liquidity/
     gmx_glv = "gmx_glv"
 
+    #: Vault-like share that represents liquidity in an automated market maker pool.
+    #:
+    #: GMX GM and GLV tokens are market-making claims on pools that hold the
+    #: assets used to settle swaps and perpetual-trading PnL.
+    #: https://docs.gmx.io/docs/providing-liquidity/
+    amm_pool_like = "amm_pool_like"
+
     #: Vault-like product without a standard contract share-price method.
     #:
     #: GMX GM and GLV holders earn or lose value through their pro-rata claim

--- a/eth_defi/gmx/README-GMX-Vaults.md
+++ b/eth_defi/gmx/README-GMX-Vaults.md
@@ -268,6 +268,7 @@ remain valid.
 detection row. The persisted features are:
 
 - `gmx_gm` or `gmx_glv`, selecting the correct adapter;
+- `amm_pool_like`, identifying both product types as market-making pool shares;
 - `share_price_equivalence`, telling the sparse writer that only changes in the
   derived price represent performance.
 

--- a/eth_defi/gmx/vault.py
+++ b/eth_defi/gmx/vault.py
@@ -152,7 +152,8 @@ class GMXVaultBase(VaultBase):
         :param token_cache:
             Optional shared token metadata cache.
         :param features:
-            Persisted GMX product features.
+            Persisted GMX product features. The adapter also adds its common
+            AMM-pool and share-price-equivalence features.
         :param default_block_identifier:
             Retained shared-adapter compatibility option.
         :param require_denomination_token:
@@ -164,7 +165,10 @@ class GMXVaultBase(VaultBase):
             raise ValueError(f"Unsupported GMX V2 chain: {spec.chain_id}")
         self.web3 = web3
         self.spec = spec
-        self.features = set(features or {self.feature}) | {ERC4626Feature.share_price_equivalence}
+        self.features = set(features or {self.feature}) | {
+            ERC4626Feature.amm_pool_like,
+            ERC4626Feature.share_price_equivalence,
+        }
         self.default_block_identifier = default_block_identifier or "latest"
         self.historical_context_path: Path = get_gmx_historical_context_path()
 

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from eth_typing import HexAddress
 from joblib import Parallel, delayed
@@ -26,6 +26,14 @@ logger = logging.getLogger(__name__)
 
 #: Deposit-closure reason exported for disabled GMX products.
 GMX_DISABLED_DEPOSIT_REASON: str = "GMX product disabled"
+
+#: Features that identify GMX products in persisted metadata.
+GMX_PRODUCT_FEATURES: frozenset[ERC4626Feature] = frozenset(
+    {
+        ERC4626Feature.gmx_gm,
+        ERC4626Feature.gmx_glv,
+    }
+)
 
 #: Number of equal candidate names required before adding an address suffix.
 GMX_NAME_COLLISION_SIZE: int = 2
@@ -90,6 +98,47 @@ def _features_for_product(product: GMXVaultProduct) -> set[ERC4626Feature]:
 
     product_feature = ERC4626Feature.gmx_gm if product.product_type == "gm" else ERC4626Feature.gmx_glv
     return {product_feature, ERC4626Feature.amm_pool_like, ERC4626Feature.share_price_equivalence}
+
+
+def mark_gmx_vault_rows_amm_pool_like(vault_db: VaultDatabase, *, chain_ids: set[int]) -> int:
+    """Add the AMM-pool marker to every persisted GMX vault in selected chains.
+
+    The onchain catalogue can no longer return delisted GMX products, while
+    their historical rows remain in the common database. This metadata-only
+    repair therefore examines all retained rows rather than only the current
+    catalogue and preserves the top-level and detection feature copies in
+    lockstep.
+
+    :param vault_db:
+        Common vault metadata database to repair in place.
+    :param chain_ids:
+        GMX deployment chain IDs included in this migration run.
+    :return:
+        Number of stored GMX rows changed.
+    """
+
+    changed_rows = 0
+    for spec, row in vault_db.rows.items():
+        if spec.chain_id not in chain_ids:
+            continue
+
+        detection = row.get("_detection_data")
+        detection_features = set(detection.features) if isinstance(detection, ERC4262VaultDetection) else set()
+        stored_features = set(row.get("features") or detection_features)
+        is_gmx_row = row.get("Protocol") == "GMX" or bool((detection_features | stored_features) & GMX_PRODUCT_FEATURES)
+        if not is_gmx_row:
+            continue
+
+        updated_features = detection_features | stored_features | {ERC4626Feature.amm_pool_like}
+        changed = stored_features != updated_features
+        row["features"] = set(updated_features)
+        if isinstance(detection, ERC4262VaultDetection) and detection_features != updated_features:
+            row["_detection_data"] = replace(detection, features=set(updated_features))
+            changed = True
+        if changed:
+            changed_rows += 1
+
+    return changed_rows
 
 
 def _fetch_token_symbol(web3: Web3, chain_id: int, address: HexAddress, token_cache: TokenDiskCache) -> str:

--- a/eth_defi/gmx/vault_sync.py
+++ b/eth_defi/gmx/vault_sync.py
@@ -73,10 +73,23 @@ class GMXVaultCatalogueSyncResult:
     updated: int
 
 
-def _feature_for_product(product: GMXVaultProduct) -> ERC4626Feature:
-    """Map an onchain product kind to its persisted adapter feature."""
+def _features_for_product(product: GMXVaultProduct) -> set[ERC4626Feature]:
+    """Build the persisted feature set for one GMX product.
 
-    return ERC4626Feature.gmx_gm if product.product_type == "gm" else ERC4626Feature.gmx_glv
+    Both GM and GLV token holders provide liquidity to GMX's AMM pools.  The
+    product-specific marker selects the appropriate adapter, while the shared
+    marker lets consumers classify the economic exposure without knowing the
+    GMX product type.
+
+    :param product:
+        GMX product returned by the onchain Reader contracts.
+
+    :return:
+        Product-specific and shared vault features for the metadata row.
+    """
+
+    product_feature = ERC4626Feature.gmx_gm if product.product_type == "gm" else ERC4626Feature.gmx_glv
+    return {product_feature, ERC4626Feature.amm_pool_like, ERC4626Feature.share_price_equivalence}
 
 
 def _fetch_token_symbol(web3: Web3, chain_id: int, address: HexAddress, token_cache: TokenDiskCache) -> str:
@@ -513,13 +526,12 @@ def fetch_and_sync_gmx_vault_catalogue(
             old_detection = existing["_detection_data"]
             first_seen_at_block = old_detection.first_seen_at_block
             first_seen_at = old_detection.first_seen_at
-        feature = _feature_for_product(product)
         detection = ERC4262VaultDetection(
             chain=product.chain_id,
             address=product.token_address.lower(),
             first_seen_at_block=first_seen_at_block,
             first_seen_at=first_seen_at,
-            features={feature, ERC4626Feature.share_price_equivalence},
+            features=_features_for_product(product),
             updated_at=updated_at,
             deposit_count=0,
             redeem_count=0,
@@ -556,6 +568,7 @@ def fetch_and_sync_gmx_vault_catalogue(
                     key: row[key]
                     for key in (
                         "_detection_data",
+                        "features",
                         "_gmx_component_addresses",
                         "_gmx_accepted_deposit_tokens",
                         "_gmx_enabled",

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -3,8 +3,9 @@
 Existing rows are identified by chain and share-token address, so each run
 refreshes the GMX fields maintained by this migration: an index-aware GM or
 backing-pair GLV name, full LP description, USDC display denomination, direct
-GMX pool-details link, performance note and deposit availability. It does not
-overwrite manual enrichment fields belonging to other pipeline stages.
+GMX pool-details link, performance note, deposit availability and shared
+``amm_pool_like`` feature. It does not overwrite manual enrichment fields
+belonging to other pipeline stages.
 
 Environment variables:
 

--- a/scripts/erc-4626/migrate-gmx-vaults-metadata.py
+++ b/scripts/erc-4626/migrate-gmx-vaults-metadata.py
@@ -3,9 +3,11 @@
 Existing rows are identified by chain and share-token address, so each run
 refreshes the GMX fields maintained by this migration: an index-aware GM or
 backing-pair GLV name, full LP description, USDC display denomination, direct
-GMX pool-details link, performance note, deposit availability and shared
-``amm_pool_like`` feature. It does not overwrite manual enrichment fields
-belonging to other pipeline stages.
+GMX pool-details link, performance note and deposit availability. It also adds
+the shared ``amm_pool_like`` feature to every retained GMX row in the selected
+chains, including products no longer returned by the current onchain catalogue.
+It does not overwrite manual enrichment fields belonging to other pipeline
+stages.
 
 Environment variables:
 
@@ -23,7 +25,7 @@ from pathlib import Path
 from tabulate import tabulate
 
 from eth_defi.gmx.vault_catalog import GMX_CHAIN_NAMES_BY_ID
-from eth_defi.gmx.vault_sync import fetch_and_sync_gmx_vault_catalogue
+from eth_defi.gmx.vault_sync import fetch_and_sync_gmx_vault_catalogue, mark_gmx_vault_rows_amm_pool_like
 from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -54,14 +56,15 @@ def main() -> None:
             chain_id = CHAIN_IDS_BY_NAME[chain_name]
             web3 = create_multi_provider_web3(read_json_rpc_url(chain_id))
             result = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache=token_cache, max_workers=max_workers)
-            rows.append((chain_name, chain_id, result.products, result.inserted, result.updated))
+            feature_rows_updated = mark_gmx_vault_rows_amm_pool_like(vault_db, chain_ids={chain_id})
+            rows.append((chain_name, chain_id, result.products, result.inserted, result.updated, feature_rows_updated))
 
         if not dry_run:
             database_path.parent.mkdir(parents=True, exist_ok=True)
             vault_db.write(database_path)
             token_cache.commit()
 
-    print(tabulate(rows, headers=("Chain", "Chain ID", "Products", "Inserted", "Updated"), tablefmt="rounded_outline"))
+    print(tabulate(rows, headers=("Chain", "Chain ID", "Products", "Inserted", "Updated", "AMM flags added"), tablefmt="rounded_outline"))
     print(f"{'Dry run; not written' if dry_run else 'Written'}: {database_path}")
 
 

--- a/tests/gmx/test_gmx_vault.py
+++ b/tests/gmx/test_gmx_vault.py
@@ -41,6 +41,8 @@ def test_gmx_features_route_to_read_only_adapters() -> None:
 
     assert isinstance(gm, GMXMarketVault)
     assert isinstance(glv, GMXLiquidityVault)
+    assert ERC4626Feature.amm_pool_like in gm.features
+    assert ERC4626Feature.amm_pool_like in glv.features
     assert ERC4626Feature.share_price_equivalence in gm.features
     assert ERC4626Feature.share_price_equivalence in glv.features
     assert gm.get_historical_reader(stateful=True).uses_contextual_history

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -9,7 +9,7 @@ from eth_utils import to_checksum_address
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.gmx import vault_sync
 from eth_defi.gmx.vault_catalog import GMXVaultProduct
-from eth_defi.gmx.vault_sync import fetch_and_sync_gmx_vault_catalogue
+from eth_defi.gmx.vault_sync import fetch_and_sync_gmx_vault_catalogue, mark_gmx_vault_rows_amm_pool_like
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import GMX_SINGLE_SIDED_USDC_NOTE
 from eth_defi.vault.vaultdb import VaultDatabase
@@ -19,6 +19,7 @@ INDEX_TOKEN = to_checksum_address("0x2000000000000000000000000000000000000001")
 LONG_TOKEN = to_checksum_address("0x2000000000000000000000000000000000000002")
 SHORT_TOKEN = to_checksum_address("0x2000000000000000000000000000000000000003")
 FIRST_CATALOGUE_BLOCK = 123
+RETAINED_GMX_ROWS = 2
 
 
 def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,6 +195,48 @@ def test_disambiguate_gmx_product_names_adds_short_stable_suffix() -> None:
         GM_TOKEN.lower(): "GM DOGE [WETH-USDC] · 0001",
         second_market.lower(): "GM DOGE [WETH-USDC] · 0002",
     }
+
+
+def test_mark_gmx_vault_rows_amm_pool_like_updates_retained_products() -> None:
+    """Retained and legacy GMX rows receive the shared feature without Reader access."""
+
+    first_seen_at = vault_sync.native_datetime_utc_now()
+    gm_detection = vault_sync.ERC4262VaultDetection(
+        chain=42161,
+        address=GM_TOKEN.lower(),
+        first_seen_at_block=FIRST_CATALOGUE_BLOCK,
+        first_seen_at=first_seen_at,
+        features={ERC4626Feature.gmx_gm, ERC4626Feature.share_price_equivalence},
+        updated_at=first_seen_at,
+        deposit_count=0,
+        redeem_count=0,
+    )
+    glv_token = to_checksum_address("0x1000000000000000000000000000000000000004")
+    glv_detection = replace(
+        gm_detection,
+        address=glv_token.lower(),
+        features={ERC4626Feature.gmx_glv, ERC4626Feature.share_price_equivalence},
+    )
+    non_gmx_detection = replace(
+        gm_detection,
+        address=to_checksum_address("0x1000000000000000000000000000000000000005").lower(),
+        features={ERC4626Feature.erc_7540_like},
+    )
+    vault_db = VaultDatabase(
+        rows={
+            VaultSpec(42161, GM_TOKEN): {"Protocol": "GMX", "features": set(gm_detection.features), "_detection_data": gm_detection},
+            VaultSpec(42161, glv_token): {"Protocol": "GMX", "features": set(glv_detection.features), "_detection_data": glv_detection},
+            VaultSpec(42161, non_gmx_detection.address): {"Protocol": "Other", "features": set(non_gmx_detection.features), "_detection_data": non_gmx_detection},
+        }
+    )
+
+    assert mark_gmx_vault_rows_amm_pool_like(vault_db, chain_ids={42161}) == RETAINED_GMX_ROWS
+    assert mark_gmx_vault_rows_amm_pool_like(vault_db, chain_ids={42161}) == 0
+    for spec in (VaultSpec(42161, GM_TOKEN), VaultSpec(42161, glv_token)):
+        row = vault_db.rows[spec]
+        assert ERC4626Feature.amm_pool_like in row["features"]
+        assert row["features"] == row["_detection_data"].features
+    assert ERC4626Feature.amm_pool_like not in vault_db.rows[VaultSpec(42161, non_gmx_detection.address)]["features"]
 
 
 def test_format_gmx_glv_description_explains_all_supported_markets() -> None:

--- a/tests/gmx/test_vault_sync.py
+++ b/tests/gmx/test_vault_sync.py
@@ -58,6 +58,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
         "create_vault_scan_record",
         lambda _web3, detection, _block_number, _token_cache: {
             "_detection_data": detection,
+            "features": set(detection.features),
             "Name": "GMX market",
             "Protocol": "GMX",
             "Denomination": "USD",
@@ -75,6 +76,12 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     vault_db = VaultDatabase()
 
     first = fetch_and_sync_gmx_vault_catalogue(web3=web3, vault_db=vault_db, token_cache={}, block_number=FIRST_CATALOGUE_BLOCK)
+    legacy_detection = replace(
+        vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_detection_data"],
+        features={ERC4626Feature.gmx_gm, ERC4626Feature.share_price_equivalence},
+    )
+    vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_detection_data"] = legacy_detection
+    vault_db.rows[VaultSpec(42161, GM_TOKEN)]["features"] = set(legacy_detection.features)
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_manual_enrichment"] = "keep me"
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_short_description"] = "Remove me"
     vault_db.rows[VaultSpec(42161, GM_TOKEN)]["_notes"] = "Replace me"
@@ -84,6 +91,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
         "create_vault_scan_record",
         lambda _web3, detection, _block_number, _token_cache: {
             "_detection_data": detection,
+            "features": set(detection.features),
             "Name": "<broken: temporary RPC failure>",
             "Protocol": "<unknown>",
             "Denomination": None,
@@ -109,6 +117,11 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert row_after_failed_refresh["_description"] == expected_description
     assert row_after_failed_refresh["_deposits_open"] is None
     assert row_after_failed_refresh["_manual_enrichment"] == "keep me"
+    assert row_after_failed_refresh["features"] == {
+        ERC4626Feature.gmx_gm,
+        ERC4626Feature.amm_pool_like,
+        ERC4626Feature.share_price_equivalence,
+    }
 
     monkeypatch.setattr(vault_sync, "fetch_gmx_v2_vault_products", lambda *_args, **_kwargs: iter((replace(product, is_enabled=False),)))
     monkeypatch.setattr(
@@ -116,6 +129,7 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
         "create_vault_scan_record",
         lambda _web3, detection, _block_number, _token_cache: {
             "_detection_data": detection,
+            "features": set(detection.features),
             "Name": "GMX market refreshed",
             "Protocol": "GMX",
             "Denomination": "USD",
@@ -135,7 +149,16 @@ def test_fetch_and_sync_gmx_vault_catalogue_is_idempotent(monkeypatch: pytest.Mo
     assert row["_manual_enrichment"] == "keep me"
     assert detection.first_seen_at_block == FIRST_CATALOGUE_BLOCK
     assert detection.address == GM_TOKEN.lower()
-    assert detection.features == {ERC4626Feature.gmx_gm, ERC4626Feature.share_price_equivalence}
+    assert detection.features == {
+        ERC4626Feature.gmx_gm,
+        ERC4626Feature.amm_pool_like,
+        ERC4626Feature.share_price_equivalence,
+    }
+    assert vault_sync._features_for_product(replace(product, product_type="glv")) == {
+        ERC4626Feature.gmx_glv,
+        ERC4626Feature.amm_pool_like,
+        ERC4626Feature.share_price_equivalence,
+    }
     assert row["_gmx_component_addresses"] == tuple(address.lower() for address in product.component_addresses)
     assert row["_gmx_enabled"] is False
     assert row["_deposit_closed_reason"] == "GMX product disabled"


### PR DESCRIPTION
## Why

GMX GM and GLV shares both represent liquidity in GMX market-making pools. Consumers need an explicit persisted feature to identify that common exposure without inferring it from GMX product type.

## Lessons learnt

GMX metadata keeps a top-level feature set as well as detection data. Metadata repairs must refresh both even when a transient vault read produces a broken scan record.

## Summary

- Add the `amm_pool_like` vault feature.
- Persist it for GM and GLV catalogue records and adapter instances.
- Extend the GMX metadata migration documentation and regression coverage, including legacy rows refreshed through a failed scan.

## Related issues and PRs

Follow-up to the GMX catalogue and metadata work in #1518.

## Unrelated CI and test fixes

None.