### PR TITLE
fix: add NEMO curator X profile

### DIFF
--- a/eth_defi/data/feeds/curators/nemo.yaml
+++ b/eth_defi/data/feeds/curators/nemo.yaml
@@ -4,6 +4,7 @@ role: curator
 upshift-strategist:
   - NEMO
 website: https://nemo.trading/
+twitter: NEMOtradingHQ
 short_description: NEMO is the strategist for Upshift's Prime yield vaults on Ethereum.
 long_description: |
   Upshift lists NEMO as the strategist for its NEMO USDC Prime and NEMO ETH Prime vaults on Ethereum. The strategist label is the public protocol-native attribution used for the vaults because Upshift does not expose a separate curator field.


### PR DESCRIPTION
## Why

Expose NEMO's official X profile in curator metadata.

## Lessons learnt

Curator social profiles are stored as X handles and exported as full profile URLs.

## Summary

Add the NEMOtradingHQ X handle to NEMO curator metadata.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.