### PR TITLE
fix: resolve Axis USDx by token address

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -28,7 +28,7 @@ Apply these whenever this file is required before an agent CLI run:
 - For plan reviews with Claude CLI, default to the no-tools inline review pattern after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
 - For code and PR reviews with Claude CLI, scope the request to correctness bugs, behavioural regressions, missing tests, security or money-movement risks, and repository instruction compliance. Ask for findings first with file:line references and residual risks. These reviews need repository inspection: do not use `--tools ""` or tell Claude not to use tools.
 - For long Claude CLI reviews, use streaming output (`--output-format stream-json --verbose`) and a wall-clock timeout. If a grounded review produces no output after roughly one minute, stop it and repeat it for a smaller, tool-enabled file group. A no-tools review is only valid when the complete review material is embedded in the prompt, such as a plan or document.
-- Do not paste huge diffs into Claude, Codex, or Grok prompts. Make the agent inspect `git status --short`, `git diff --name-only`, and targeted hunks, or provide only the plan text for no-tools plan reviews.
+- Do not paste huge diffs into Claude, Codex, or Grok prompts. Make the agent inspect `git status --short`, `git diff --stat`, `git diff --name-only`, and targeted hunks. Never ask it to dump a whole PR diff or run `gh pr diff | head -N` for a large `N`.
 - For non-interactive Codex reviews, use `codex exec --json` in read-only mode. Plain text mode can buffer output and look hung.
 - Before trusting any external-agent "no findings" result, verify it reviewed the correct worktree and non-empty diff. For a streaming Claude review, require a successful `result` event with a final verdict; tool calls, thinking events, and a live process are not a completed review.
 
@@ -325,6 +325,31 @@ and web search/fetch. It deliberately also retains write permissions for normal
 implementation work. A review prompt must still explicitly say **do not edit
 files, change GitHub state, or run tests**.
 
+`--allowedTools` is additive: it does not reliably remove a broader project
+permission that is already present in `.claude/settings.json`. For a strictly
+read-only review of already identified files, use `--safe-mode` and explicitly
+deny mutation-capable tools. `--safe-mode` retains normal authentication; the
+explicit denial is what enforces the narrow tool set:
+
+```shell
+nohup timeout 120 claude -p "Inspect only eth_defi/example.py and report correctness findings with file:line references. Use Read only. Do not make changes." \
+  --model opus \
+  --effort low \
+  --safe-mode \
+  --permission-mode dontAsk \
+  --allowedTools "Read" \
+  --disallowedTools "Bash,Edit,Write,MultiEdit,Skill,Task" \
+  --output-format stream-json \
+  --verbose \
+  --no-session-persistence \
+  < /dev/null > /tmp/claude-read-review.jsonl 2>&1 &
+```
+
+Use this strict pattern only when the primary agent has already established the
+reviewed paths and diff. A grounded PR review that needs Git or GitHub commands
+must retain Bash, but its prompt must name the allowed read-only commands and
+the narrow file group.
+
 Run the smoke test below before a costly review. It proves the actual current
 worktree can use local disk, GitHub and web tools; do not claim a completed
 review unless it returns a final result.
@@ -353,11 +378,13 @@ as incomplete.
 
 ### Foreground command-window limits
 
-Some agent runners terminate a foreground command after roughly 30 seconds,
-even when Claude is actively reading files and emitting streaming JSON. This
-can leave a review with only tool calls and no final findings. Do not rely on a
-foreground `claude -p` invocation for a non-trivial worktree review in those
-environments.
+Some agent runners end foreground output capture after roughly 30 seconds,
+even when Claude is actively reading files and emitting streaming JSON. The
+Claude child may then continue after its output pipe has disappeared, causing
+the outer command to report an empty completion. This is neither a successful
+review nor evidence of an authentication failure: its final answer cannot be
+recovered from that foreground capture. Do not rely on a foreground `claude -p`
+invocation for a non-trivial worktree review in those environments.
 
 Start the review in the background and write the raw JSONL stream to a temporary
 file instead. Restrict tools to read-only operations and redirect stdin so the
@@ -369,12 +396,16 @@ the worktree; it does not override the separate one-minute no-output rule for a
 grounded Claude review.
 
 ```shell
-nohup timeout 900 claude -p "Review the current uncommitted worktree diff for correctness bugs only. Do not edit files or run tests. Return findings first with file:line references." \
+nohup timeout 900 claude -p "Review the current uncommitted worktree diff for correctness bugs only. Do not edit files, change GitHub state, or run tests. First inspect git status --short, git diff --stat, and git diff --name-only. Review only the resulting relevant file group with targeted diffs; do not dump the full diff. Return findings first with file:line references." \
+  --model opus \
+  --effort low \
   --permission-mode dontAsk \
   --allowedTools "Bash,Read,Grep,Glob,WebSearch,WebFetch" \
+  --disallowedTools "Edit,Write,MultiEdit,Skill,Task" \
   --output-format stream-json \
   --verbose \
   --no-session-persistence \
+  --debug-file /tmp/claude-review.debug.log \
   < /dev/null > /tmp/claude-review.jsonl 2>&1 &
 ```
 
@@ -393,6 +424,13 @@ event, narrow the file scope and repeat the background review rather than trying
 to resume a `--no-session-persistence` session. Do not describe a partial event
 stream as a review result, and do not fall back to a no-tools review unless the
 complete target content is supplied in its prompt.
+
+If the JSONL stream stops growing for one minute, terminate the process, keep
+the JSONL and debug log for diagnosis, and start a new smaller review. Inspect
+the debug log for the last dispatched tool and server errors; do not paste or
+commit it because it can include repository context. A clean `claude doctor`
+and `claude auth status`, together with a successful small detached Read-only
+review, means the broad prompt or tool scope is the likely problem.
 
 ### Reviewing a plan or document with Claude CLI
 

--- a/eth_defi/data/stablecoins/usdx-axis.yaml
+++ b/eth_defi/data/stablecoins/usdx-axis.yaml
@@ -2,16 +2,18 @@ symbol: USDx
 name: Axis USDx
 slug: usdx-axis
 category: stablecoin
-short_description: USDx is Axis's synthetic dollar, minted through a collateralised primary market against approved assets. Axis states that USDx targets a dollar value but does not guarantee a $1 market price, immediate redemption, or secondary-market liquidity.
+short_description: USDx is Axis's synthetic dollar. Axis says it is not a stablecoin and does not guarantee a $1 market price, immediate redemption, or secondary-market liquidity.
 long_description: |
   [USDx](https://axis.to/) is the synthetic dollar issued by [Axis](https://axis.to/).
-  Eligible participants mint it through Axis's primary market by providing approved
-  collateral, while authorised operators settle signed mint and redemption orders.
+  Axis distinguishes USDx from a stablecoin: authorised operators settle signed
+  mint and redemption orders, rather than providing a permissionless, immediate
+  one-to-one cash redemption facility.
 
-  Axis deploys the collateral into market-neutral trading strategies and directs any
+  Axis deploys backing into market-neutral trading strategies and directs any
   staking rewards to its separate sUSDx vault. USDx itself does not accrue staking
-  rewards, and Axis cautions that the token does not guarantee a fixed dollar market
-  price or immediate redemption.
+  rewards. Holders remain exposed to the strategy, operator, venue and liquidity
+  risks of the synthetic-dollar system; Axis does not guarantee a fixed dollar
+  market price or immediate redemption.
 links:
   homepage: https://axis.to/
   coingecko: ''
@@ -20,6 +22,9 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0xa1fA7777974312f7d801A8880714a218F76233f8'
+  - chain: plasma
+    address: '0xA1FA77779e6866fa3eF48FC0720657E042158387'
+ambiguous_symbol: true
 rate_fetch_failed_at: '2026-08-17T00:59:45'
 rate_fetch_failed_reason: missing_coingecko_id
 checks:

--- a/eth_defi/data/stablecoins/usdx.yaml
+++ b/eth_defi/data/stablecoins/usdx.yaml
@@ -50,13 +50,12 @@ entries:
     marked_dead_at: '2026-03-17'
     information_found_missing_at: ''
 - name: Kava USDX
-  short_description: USDX was the native stablecoin of the Kava blockchain. It was overcollateralised by multiple crypto assets deposited on the Kava platform. The Kava ecosystem has shifted focus away from USDX.
+  short_description: Kava USDX is a legacy Kava Mint CDP token that has traded materially below $1 since its 2022 depeg. It is not a cash-equivalent stablecoin.
   long_description: |
-    USDX is the native decentralised stablecoin of the [Kava](https://www.kava.io/) blockchain,
-    minted via Collateralised Debt Positions (CDPs) against a range of crypto assets including
-    KAVA, BTC, BNB, BUSD, and XRP. USDX maintains its USD peg through overcollateralisation:
-    borrowers must deposit collateral worth more than the USDX they mint, typically at a
-    minimum 150% collateralisation ratio.
+    USDX was the native decentralised dollar token of the [Kava](https://www.kava.io/)
+    blockchain, minted through Kava Mint collateralised debt positions (CDPs). The
+    token lost its dollar peg during the May 2022 market disruption and has not
+    subsequently returned to a reliable $1 market price.
 
     ## Mechanism
 
@@ -67,15 +66,13 @@ entries:
     a whole, new KAVA is minted and used to buy back USDX until the system is restored to
     health.
 
-    Minted USDX can be deposited into Kava's money market (HARD Protocol) to earn a variable
-    APY, providing an additional yield incentive for minters.
-
     ## Status
 
-    The Kava ecosystem has evolved significantly since USDX's launch in 2019. Kava merged its
-    Cosmos-based and EVM chains in 2022–2023, and the project has shifted its primary focus
-    towards its lending and EVM DeFi ecosystem. USDX remains technically functional but has
-    seen declining usage as Kava pivots toward broader DeFi infrastructure.
+    Kava has shifted its product focus away from USDX. Repaying USDX to close a
+    CDP may still release its collateral, but that is not a general one-to-one
+    cash redemption route. Secondary-market liquidity and the market price can
+    differ materially from $1, so USDX must not be treated as a dollar
+    denomination for an unrelated vault that merely shares its ticker.
 
     ## Sources
 

--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -154,6 +154,7 @@ _CHAIN_ALIASES_TO_ID: dict[str, int] = {
     "berachain": 80094,
     "hyperevm": 999,
     "hyperliquid": 999,
+    "plasma": 9745,
     "xlayer": 196,
     "x_layer": 196,
     "x-layer": 196,
@@ -379,6 +380,29 @@ class StablecoinRateFeeder:
     _depegged_symbols: set[str] | None = field(default=None, init=False, repr=False)
     _rate_contracts: dict[tuple[int, str], DenominationTokenRate] | None = field(default=None, init=False, repr=False)
     _rate_symbols: dict[str, DenominationTokenRate] | None = field(default=None, init=False, repr=False)
+    _address_slugs: dict[str, str] | None = field(default=None, init=False, repr=False)
+
+    def get_denomination_token_slug(self, address: HexAddress | str | None) -> str | None:
+        """Resolve a denomination token to its stablecoin metadata slug.
+
+        Token symbols are not unique: the legacy Kava USDX and Axis USDx are
+        unrelated assets. Contract addresses are globally unique, so this
+        lookup deliberately uses only the token address and never falls back to
+        the symbol.
+
+        :param address:
+            Denomination token contract address.
+
+        :return:
+            Stablecoin metadata slug for a known address, or ``None``.
+        """
+        if not address:
+            return None
+
+        if self._address_slugs is None:
+            self._address_slugs = build_stablecoin_address_slug_lookup(self.data_dir)
+
+        return self._address_slugs.get(str(address).lower())
 
     def get_denomination_token_rate_section(
         self,
@@ -917,6 +941,32 @@ def build_stablecoin_rate_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> tupl
 
     symbol_rates = {symbol: matches[0][1] for symbol, matches in symbol_candidates.items() if len(matches) == 1}
     return contract_rates, symbol_rates
+
+
+def build_stablecoin_address_slug_lookup(data_dir: Path = STABLECOINS_DATA_DIR) -> dict[str, str]:
+    """Build an address-to-stablecoin-slug lookup from package metadata.
+
+    This lookup identifies the stablecoin shown in vault metrics. It must not
+    use a token ticker because different issuers can reuse the same symbol.
+    Addresses are globally unique, so chain identifiers are intentionally not
+    part of the key.
+
+    :param data_dir:
+        Directory containing stablecoin metadata YAML files.
+
+    :return:
+        Lower-cased token addresses mapped to stablecoin metadata slugs.
+
+    """
+    address_slugs: dict[str, str] = {}
+    for target in iter_stablecoin_rate_targets(data_dir):
+        for _, address in target.contract_addresses:
+            # Preserve the original slug for a renamed token, such as
+            # agEUR/EURA. Both entries document the same contract, which is
+            # still a unique asset identity.
+            address_slugs.setdefault(address, target.slug)
+
+    return address_slugs
 
 
 def apply_coingecko_mapping_file(data_dir: Path, mapping_path: Path, progress_bar: bool = False) -> int:

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -32,7 +32,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
 from eth_defi.feed.stablecoin_rate import DenominationTokenRate, StablecoinRateFeeder
 from eth_defi.perp_dex.export import build_perp_dex_other_data
-from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid, format_series_as_multi_column_grid
+from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.token import is_stablecoin_like, normalise_token_symbol
 from eth_defi.vault.base import VaultSpec, WithdrawalPeriod
@@ -1837,7 +1837,6 @@ def calculate_vault_record(
     source_denomination = _unnullify(vault_metadata.get("_source_denomination"), denomination)
     share_token = _unnullify(vault_metadata.get("Share token"), "<broken>")
     normalised_denomination = normalise_token_symbol(denomination)
-    denomination_slug = normalised_denomination.lower()
 
     max_nav = prices_df["total_assets"].max()
     current_nav = prices_df["total_assets"].iloc[-1]
@@ -2213,6 +2212,10 @@ def calculate_vault_record(
 
     if stablecoin_rate_feeder is None:
         stablecoin_rate_feeder = StablecoinRateFeeder()
+
+    denomination_slug = stablecoin_rate_feeder.get_denomination_token_slug(denomination_token_address)
+    if denomination_slug is None:
+        denomination_slug = normalised_denomination.lower()
 
     denomination_token_rate = stablecoin_rate_feeder.get_denomination_token_rate_section(
         chain_id=chain_id,

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -23,6 +23,7 @@ AEGIS_YUSD_BINANCE_ADDRESS = "0xAB3dBcD9B096C3fF76275038bf58eAC10D22C61f"
 AEGIS_YUSD_AVALANCHE_ADDRESS = "0xca2671Dcd031a72359f456C212F62A9bDa737cD7"
 AEGIS_JUSD_ADDRESS = "0xc86168d2424d28942EE0866F043c1206bc9E4900"
 NOON_SUSN_ADDRESS = "0xE24a3DC889621612422A64E6388927901608B91D"
+AXIS_USDX_PLASMA_ADDRESS = "0xA1FA77779e6866fa3eF48FC0720657E042158387"
 
 
 @dataclass(slots=True)
@@ -138,6 +139,27 @@ slug: usdx
 """
     )
     return yaml_path
+
+
+def test_address_slug_lookup_keeps_axis_usdx_separate_from_kava_usdx(tmp_path: Path) -> None:
+    """Resolve Axis USDx by its contract address, never the shared ticker."""
+    _write_usdx_yaml(tmp_path)
+    (tmp_path / "usdx-axis.yaml").write_text(
+        f"""symbol: USDx
+name: Axis USDx
+slug: usdx-axis
+category: stablecoin
+ambiguous_symbol: true
+contract_addresses:
+  - chain: plasma
+    address: '{AXIS_USDX_PLASMA_ADDRESS}'
+"""
+    )
+
+    feeder = StablecoinRateFeeder(tmp_path)
+
+    assert feeder.get_denomination_token_slug(AXIS_USDX_PLASMA_ADDRESS) == "usdx-axis"
+    assert feeder.get_denomination_token_slug(USDX_ADDRESS) == "usdx"
 
 
 def _write_fiat_stablecoin_yaml(data_dir: Path, symbol: str, name: str, coingecko_id: str) -> Path:

--- a/tests/hyperliquid/test_trade_history_integration.py
+++ b/tests/hyperliquid/test_trade_history_integration.py
@@ -126,7 +126,11 @@ def test_reconstruct_vault_trade_history(session, tmp_path):
         db.close()
 
 
-@pytest.mark.timeout(120)
+# Flaky: CI timed out in DuckDB ``executemany`` at 120 seconds on PR #1529 on
+# 2026-08-27; the isolated live test passed locally in 117.22 seconds with a
+# 180-second timeout, so normal live API/data-volume variation can exceed 120.
+@flaky.flaky
+@pytest.mark.timeout(180)
 def test_reconstruct_normal_account_trade_history(session, tmp_path):
     """Reconstruct trade history for a normal (non-vault) Hyperliquid account.
 

--- a/tests/research/test_vault_metrics_stablecoin_rate.py
+++ b/tests/research/test_vault_metrics_stablecoin_rate.py
@@ -11,6 +11,7 @@ import pytest
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.feed.stablecoin_rate import StablecoinRateFeeder, iter_stablecoin_rate_targets, refresh_stablecoin_rates
 from eth_defi.research.vault_metrics import calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.flag import VaultFlag
@@ -20,6 +21,7 @@ VAULT_ADDRESS = "0x2222222222222222222222222222222222222222"
 USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
 EURE_ADDRESS = "0x3333333333333333333333333333333333333333"
+AXIS_USDX_PLASMA_ADDRESS = "0xA1FA77779e6866fa3eF48FC0720657E042158387"
 
 
 def _write_depegged_usdx_yaml(data_dir: Path) -> None:
@@ -175,9 +177,9 @@ def _calculate_bad_stablecoin_vault_metrics(
     token_symbol: str = "USDX",
     token_address: str | None = USDX_ADDRESS,
     token_decimals: int | None = 6,
+    chain_id: int = 1,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for a vault that uses a bad stablecoin denomination."""
-    chain_id = 1
     vault_id = f"{chain_id}-{VAULT_ADDRESS}"
     spec = VaultSpec(chain_id=chain_id, vault_address=VAULT_ADDRESS)
     detection = ERC4262VaultDetection(
@@ -302,6 +304,20 @@ def _assert_bad_stablecoin_vault_blacklisted(
     }
     assert exported["denomination_token_rate"] == expected_exported_rate
     assert "depegged_denomination_token" in exported["flags"]
+
+
+def test_calculate_lifetime_metrics_uses_axis_usdx_address_slug() -> None:
+    """Keep Axis USDx separate from the legacy Kava USDX ticker category."""
+    metrics = _calculate_bad_stablecoin_vault_metrics(
+        STABLECOINS_DATA_DIR,
+        token_symbol="USDx",
+        token_address=AXIS_USDX_PLASMA_ADDRESS,
+        chain_id=9745,
+    )
+
+    row = metrics.iloc[0]
+    assert row["denomination_slug"] == "usdx-axis"
+    assert row["risk"] != VaultTechnicalRisk.blacklisted
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Axis USDx (including the Plasma sUSDx vault denomination) shares its ticker with the unrelated legacy Kava USDX. Symbol-derived slugs labelled Axis vaults as Kava USDX and carried incorrect category-level context.

## Lessons learnt

Ticker symbols are not asset identities. Vault metadata must prefer the ERC-20 contract address; chain IDs are deliberately not part of this identity lookup.

## Summary

- Add the verified Axis USDx Plasma address and mark its ticker as ambiguous.
- Resolve denomination slugs by token address, while retaining symbol fallback for unknown assets.
- Correct the Axis and Kava USDX descriptions and add focused regression coverage.
- Remove an unused vault-metrics import.
- Document reliable detached Claude CLI review patterns.

## Related issues and PRs

None.

## Unrelated CI and test fixes

- Mark the unchanged live Hyperliquid normal-account reconstruction test flaky and increase its timeout from 120 to 180 seconds. PR #1529 CI timed out in DuckDB batch insertion; the same isolated test passed locally in 117.22 seconds on 2026-08-27.