### PR TITLE
fix: make unspecified Spiko fees zero

### DIFF
--- a/eth_defi/tokenised_fund/spiko/vault.py
+++ b/eth_defi/tokenised_fund/spiko/vault.py
@@ -525,25 +525,25 @@ class SpikoVault(TokenisedFundVault):
         return self.product.management_fee
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
-        """Return no separately published performance fee.
+        """Return Spiko's zero performance fee.
 
         :param block_identifier:
             Accepted for shared fee API compatibility.
         :return:
-            ``None``.
+            Zero, as Spiko states only a management fee for reviewed products.
         """
 
         _ = block_identifier
-        return None
+        return 0.0
 
     def get_fee_data(self) -> FeeData:
         """Return published Spiko fee metadata.
 
         :return:
-            Management fee with no inferred dealing fees.
+            Stated management fee and zeroes for the other standard fee types.
         """
 
-        return FeeData(fee_mode=VaultFeeMode.internalised_skimming, management=self.product.management_fee, performance=None, deposit=None, withdraw=None)
+        return FeeData(fee_mode=VaultFeeMode.internalised_skimming, management=self.product.management_fee, performance=0.0, deposit=0.0, withdraw=0.0)
 
     def get_link(self, referral: str | None = None) -> str:
         """Return the official Spiko product page.

--- a/tests/spiko/test_eutbl_vault.py
+++ b/tests/spiko/test_eutbl_vault.py
@@ -78,6 +78,9 @@ def test_eutbl_adapter_and_historical_reader(web3: Web3) -> None:
     assert vault.fetch_redemption_closed_reason() == SPIKO_PERMISSIONED_FLOW_REASON
     assert vault.get_fee_data().fee_mode is VaultFeeMode.internalised_skimming
     assert vault.get_fee_data().management == EUTBL_MANAGEMENT_FEE
+    assert vault.get_fee_data().performance == 0.0
+    assert vault.get_fee_data().deposit == 0.0
+    assert vault.get_fee_data().withdraw == 0.0
     assert vault.fetch_info()["source_denomination"] == "EUR"
     assert vault.fetch_info()["synthetic_usd_denomination"] is True
 

--- a/tests/spiko/test_spiko_vault.py
+++ b/tests/spiko/test_spiko_vault.py
@@ -61,6 +61,9 @@ def test_spiko_adapter_and_historical_reader(web3: Web3) -> None:
     assert vault.fetch_redemption_closed_reason() == SPIKO_PERMISSIONED_FLOW_REASON
     assert vault.get_fee_data().fee_mode is VaultFeeMode.internalised_skimming
     assert vault.get_fee_data().management == USTBL_MANAGEMENT_FEE
+    assert vault.get_fee_data().performance == 0.0
+    assert vault.get_fee_data().deposit == 0.0
+    assert vault.get_fee_data().withdraw == 0.0
     assert isinstance(vault.get_deposit_manager(), TokenisedFundDepositManager)
 
     reader = vault.get_historical_reader(stateful=True)


### PR DESCRIPTION
## Why

Spiko publishes a 0.25% annual management fee for its reviewed money-market funds. The standard fee fields must treat all other fees as zero so investor net performance remains calculable.

## Lessons learnt

Spiko fee metadata should retain only the published management fee and explicitly zero the standard performance, deposit and withdrawal fee fields.

## Summary

- Keep the 0.25% management fee for USTBL and EUTBL.
- Export 0% performance, deposit and withdrawal fees.
- Cover the fee data for both Spiko funds.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.