### PR TITLE
feat: add USD metrics for crypto vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Export cleaned exchange-rate Parquet and USD-denominated period metrics for private ETH/BTC vault records (2026-08-28)
 - feat: Add a private crypto-vaults Parquet bundle for stablecoin, ETH and BTC-denominated vaults (2026-08-27)
 - feat: Mark GMX GM and GLV vaults as automated-market-maker pool shares (2026-08-26)
 - feat: Add directional-leverage classifications for Lighter's fixed 2x long and short pool family (2026-08-26)

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -30,6 +30,7 @@ incremental scanning model, see
    eth_defi.currency_api.client
    eth_defi.currency_api.database
    eth_defi.currency_api.cleaning
+   eth_defi.currency_api.parquet
    eth_defi.currency_api.session
    eth_defi.currency_api.constants
    eth_defi.currency_api.cli

--- a/docs/superpowers/plans/2026-08-28-crypto-vault-usd-period-metrics.md
+++ b/docs/superpowers/plans/2026-08-28-crypto-vault-usd-period-metrics.md
@@ -1,0 +1,566 @@
+# Crypto vault USD period metrics and exchange-rate Parquet plan
+
+## Goal
+
+Extend the private crypto-vault export so ETH- and BTC-denominated vault JSON
+records contain `periodic_metrics_usd`: the same `PeriodMetrics` structure as
+the existing native-denomination `period_results`, calculated after converting
+the daily share-price and TVL bars to USD with the historical currency API
+series.
+
+Also publish a cleaned `exchange-rates.parquet` companion to the existing
+`exchange-rates.duckdb` R2 data-file export, and show both base-denomination and
+USD lifetime CAGR in the crypto performance examiner.
+
+This is additive. Do not change the public stablecoin export, the crypto price
+Parquet schema, native `period_results`, qualification thresholds or sticky
+selection behaviour.
+
+## References reviewed
+
+- `docs/superpowers/plans/2026-08-27-crypto-vaults-export.md`: existing private
+  bundle contract, native-unit semantics and failure isolation.
+- `eth_defi/currency_api/README-currency-api.md`: rate direction, data floor,
+  known-bad-rate cleaning and current DuckDB R2 export.
+- `eth_defi/currency_api/database.py` and `cleaning.py`: stored schema and the
+  sanitised read path.
+- `eth_defi/research/vault_metrics.py`: `PeriodMetrics`, daily forward filling,
+  `calculate_period_metrics()`, `calculate_vault_record()` and
+  `calculate_lifetime_metrics()`.
+- `eth_defi/vault/crypto_vaults.py` and `crypto_vault_export.py`: crypto JSON,
+  local paths, manifest and private R2 publication.
+- `eth_defi/vault/data_file_export.py`: flat public/alternative data-file keys
+  and alternative-bucket daily backups.
+- `scripts/erc-4626/export-crypto-vaults.py` and
+  `examine-crypto-vault-performance.py`: standalone build and operator report.
+- `scripts/erc-4626/README-vault-scripts.md`: current production and operator
+  documentation.
+
+## Current findings and coverage
+
+There is no current `calculate_lifetime_rows()` function on `master`. The
+corresponding implementation path is `calculate_lifetime_metrics()`, which
+groups vaults and calls `calculate_vault_record()` for each vault. Add the
+opt-in USD calculation there rather than creating a second ambiguously named
+lifetime pipeline.
+
+The local production-shaped data checked on 2026-08-28 has:
+
+- BTC rates: 2024-03-02 through 2026-08-25, 906 daily rows;
+- ETH rates: 2024-03-02 through 2026-08-25, 906 daily rows;
+- one raw missing day for both currencies, 2025-12-10;
+- one additional known-bad day removed by `filter_known_bad_rates()`,
+  2025-12-06;
+- crypto prices through 2026-08-26; and
+- 399 selected BTC vaults and 1,183 selected ETH vaults. Of these, 36 BTC and
+  239 ETH vaults start before exchange-rate history begins.
+
+The provider builds the file labelled date D from rates fetched just after
+00:00 UTC on D. Treat it as a start-of-day D snapshot, equivalent to the prior
+UTC end-of-day vault bar: shift its effective vault date to D-1. The raw
+2024-03-02 through 2026-08-25 rows therefore cover effective vault dates
+2024-03-01 through 2026-08-24. This convention follows the provider's
+midnight-scheduled publication workflow and the generated response date; link
+and document both in the implementation.
+
+The available effective rates cover all recent one-week through one-year
+lookbacks, apart from small fillable gaps, but cannot provide a true USD view
+of native history before 2024-03-01. For older vaults, USD `lifetime` means the
+maximum common vault/rate window beginning no earlier than 2024-03-01. Preserve
+the effective range in the existing `PeriodMetrics.period_start_at`,
+`samples_start_at`, `samples_end_at` and sample-count fields. Do not backfill or
+fabricate pre-2024 rates.
+
+## 1. Start from a new branch and worktree
+
+1. Fetch `origin/master` and verify merge commit `ecc96c8f4` is its ancestor.
+   Also verify by content that `crypto_vaults.py`, `crypto_vault_export.py` and
+   `tests/vault/test_crypto_vaults.py` contain the merged PR #1530 hardening,
+   including optional Brotli import handling and the isolated flat-key
+   publication test. Squash history will not contain the feature branch's
+   individual fix commits, so do not mistake their absence for missing code.
+2. Create a new worktree and feature branch from current `origin/master`, for
+   example branch `add-crypto-vault-usd-metrics` in a sibling worktree named
+   `crypto-vault-usd-metrics`.
+3. Follow the repository worktree setup: ensure `.venv` and `.claude` resolve
+   to the parent checkout and copy the gitignored `.local-test.env` from the
+   main checkout when it is absent. Never edit `.local-test.env`.
+4. Confirm a clean worktree and run all Python/test commands through Poetry.
+
+## 2. Materialise and export `exchange-rates.parquet`
+
+Add a focused currency API Parquet helper, preferably
+`eth_defi/currency_api/parquet.py`, with typed functions to load one cleaned
+read-only DuckDB snapshot and atomically materialise it as a sanitised Parquet
+file. Accept separate explicit `source_path` and `destination_path` arguments:
+an overridden DuckDB may live outside the pipeline directory, but the Parquet
+destination remains `$PIPELINE_DATA_DIR/exchange-rates.parquet`.
+
+The output contract is:
+
+```text
+$PIPELINE_DATA_DIR/exchange-rates.parquet
+R2 flat key: exchange-rates.parquet
+UPLOAD_PREFIX=test- -> test-exchange-rates.parquet
+```
+
+The Parquet contains all stored currencies, not only BTC and ETH, with stable
+columns in this order:
+
+```text
+date, base_currency, quote_currency, rate, source, written_at
+```
+
+Pin the physical schema as `date32`, UTF-8 strings for the three
+currency/source columns, `float64` for `rate`, and `timestamp[us]` without a
+timezone for the naive-UTC `written_at` value. Do not let Pandas inference
+change this contract.
+
+Materialisation rules:
+
+1. Open the configured `exchange-rates.duckdb` with a focused
+   `duckdb.connect(..., read_only=True)` reader and select the `exchange_rates`
+   table. Do not instantiate `CurrencyRateDatabase`: its constructor opens
+   read-write, creates directories and initialises/migrates schema. Always close
+   the read-only connection.
+2. Apply `filter_known_bad_rates()`; the DuckDB remains the auditable raw
+   source and the Parquet is the cleaned consumer view.
+3. Preserve the stored direction: `rate` is quote units per one base unit. Do
+   not invert values in the exported Parquet.
+4. Validate finite positive rates, required columns, sorted
+   `(date, base_currency, quote_currency, source)` order and uniqueness of that
+   logical key.
+5. Write Zstandard-compressed Parquet to a temporary file, verify it can be
+   read with the expected row count/schema, then atomically replace the prior
+   file. Preserve each source row's `written_at`; do not stamp the
+   materialisation time into row data. A conversion failure must never replace
+   the last good file.
+
+Materialise the cleaned snapshot once in post-processing after the currency
+scan and before crypto metadata calculation. Pass that exact cleaned snapshot
+or its verified Parquet to the USD conversion context; do not reread and clean
+the mutable DuckDB independently for metadata. Update
+`eth_defi/vault/data_file_export.py` so `export-data-files.py` uploads the
+already materialised Parquet next to the existing DuckDB rather than creating a
+second snapshot later. Source resolution must use the same
+`CURRENCY_API_DB_PATH`/`CURRENCY_API_DATABASE_PATH` contract, while destination
+resolution always uses the active pipeline data directory.
+
+Upload the new flat key to the same primary and alternative data buckets as
+the DuckDB and include it in the existing alternative-bucket
+`daily/YYYY-MM-DD/...` backup loop. Do not add a duplicate
+`crypto-exchange-rates.parquet` key or place the general rate file inside the
+crypto manifest. If the source DuckDB is absent, log and omit both the newly
+generated Parquet and any stale Parquet left from an earlier run. If the source
+exists but fresh materialisation fails, omit the stale Parquet, log an error
+with its traceback, and continue uploading unrelated data files. After those
+uploads/backups complete, propagate the accumulated materialisation failure so
+the guarded `export-data-files` step reports failure without suppressing the
+other artefacts. Retain the last good local Parquet for diagnosis and recovery,
+but exclude its path explicitly from that run's upload and backup lists; do not
+delete or silently republish it. Carry the materialisation success flag into
+the data-file path builder so this exclusion does not depend on deleting or
+renaming the old file.
+
+In the scheduled all-chain flow, publish a newly built crypto bundle only after
+that run's `export-data-files` step succeeds. If data export is skipped or
+fails, retain the local crypto artefacts but do not advance the private R2
+bundle, because its `usd_metrics` digest would not have a confirmed matching
+rate Parquet in the data export. The existing step-level boolean is sufficient:
+gate conservatively on the whole data-file export instead of adding a new
+generation manifest.
+
+For `export-crypto-vaults.py` standalone publication, reuse a focused shared
+uploader to place the exact local `exchange-rates.parquet` in the alternative
+bucket and its normal daily backup before publishing the crypto bundle. Abort
+only the standalone crypto publication if this companion upload fails. Local
+build mode (`CRYPTO_VAULTS_PUBLISH=false`) does not require R2.
+
+If a new public `eth_defi.currency_api.parquet` module is added, include it in
+the currency API Sphinx index as required for API modules.
+
+## 3. Build a reusable USD conversion context
+
+Add a small `@dataclass(frozen=True, slots=True)` in the vault layer to carry
+cleaned USD-per-underlying daily series for `ETH` and `BTC`, plus an immutable
+vault-ID-to-family mapping. Keep generic DuckDB reading and Parquet
+materialisation in `currency_api`; the vault-ID classification is crypto-bundle
+policy and does not belong there. Build the mapping from the same
+`VaultDatabase` denomination-symbol classifier used by the crypto bundle before
+calling `calculate_lifetime_metrics()`. This avoids depending on
+`canonical_underlying`, which is added only later by
+`build_crypto_vault_record()`. Load the rates and construct the mapping once per
+crypto metadata build, not once per vault.
+
+Construction rules:
+
+1. Select only `base_currency='usd'`, `source=SOURCE_NAME` and
+   `quote_currency IN ('eth', 'btc')` from the already cleaned immutable
+   snapshot used to create `exchange-rates.parquet`.
+2. Assert the snapshot has already passed `filter_known_bad_rates()`; cleaning
+   occurs exactly once before either metrics or Parquet materialisation.
+3. Invert the stored quote-per-USD rate to USD per ETH/BTC and reject zero,
+   negative, duplicate or non-finite values. Add deliberately broad,
+   family-specific USD-per-unit sanity bounds that accept plausible long-term
+   ETH/BTC prices but reject an accidentally uninverted sub-one rate. Keep the
+   bounds as documented constants and test their boundaries. Treat a bound
+   violation as a validation failure for that currency family: emit the
+   family-specific invalid-rate error periods described below while the other
+   family and all native metrics continue.
+4. Normalise DuckDB `DATE` values explicitly to midnight on a naive UTC daily
+   `DatetimeIndex`, then subtract one calendar day to form the effective vault
+   date. Never join a Python `date`, timezone-aware timestamp and naive vault
+   timestamp implicitly.
+5. Reindex each currency to calendar days from its first valid rate through the
+   last UTC date present in the crypto price DataFrame. Forward fill at most
+   three consecutive missing days, including at the trailing edge. Thus the
+   observed one-day publication lag keeps the vault's last date, while a tail
+   longer than three days is usable only through the third filled day. This
+   also covers isolated missing/known-bad dates without permitting indefinitely
+   stale valuation.
+6. Never backward fill before effective date 2024-03-01. A vault that predates
+   rate history is truncated to the overlapping window for its USD metrics.
+7. Reserve a build-level error for an absent or unreadable exchange-rate
+   database. If only one required currency series is entirely absent, retain
+   native metrics and emit a full `periodic_metrics_usd` list with an explicit
+   missing-rate `error_reason` for vaults in that family; the other family
+   continues normally. A trailing gap within three days uses the bounded
+   forward-filled rate; beyond that, truncate the USD metric window to the
+   third filled day. An internal gap longer than the three-day allowance splits
+   the usable data: calculate a period only from the latest contiguous covered
+   segment that satisfies the established period rules, otherwise return a
+   `PeriodMetrics.error_reason` for that period. One bad currency or period
+   must not remove native metrics or unrelated vaults.
+
+Use stable error-reason constants/messages that distinguish at least missing
+currency series, invalid currency series, insufficient contiguous rate
+coverage and the existing insufficient-vault-samples cases. The examiner may
+display all errored periods as `N/A`, but tests and operators must be able to
+tell why the USD calculation degraded.
+
+Use the context's precomputed family mapping for conversion and write the same
+mapping later as each JSON record's existing `canonical_underlying`: all
+reviewed ETH-like wrappers use ETH/USD and all reviewed BTC-like wrappers use
+BTC/USD. This is a canonical-underlying benchmark, not a wrapper
+redemption-price oracle; it intentionally does not model stETH/ETH,
+restaking-token/ETH or protocol receipt-token exchange-rate drift.
+
+The existing crypto price validation rejects unsupported denominations before
+common metric calculation. Keep that invariant and log per-currency input
+coverage plus final successful and degraded vault counts; do not add a second
+unreachable unsupported-family branch to the USD context.
+
+## 4. Calculate `periodic_metrics_usd`
+
+Thread an optional exchange-rate context through
+`calculate_lifetime_metrics()` to `calculate_vault_record()`. The default is
+`None`, so every existing caller and the public stablecoin pipeline retain
+their current behaviour and output columns.
+
+Refactor the small repeated portion of `calculate_vault_record()` into a
+helper that calculates the complete list of `PeriodMetrics` for supplied
+inputs. Preserve the current distinction between sparse real observations and
+the regular daily curve: `calculate_period_metrics()` derives `raw_samples`,
+sample endpoints, gross return, fee duration and eligibility from sparse
+observations, while `daily_samples`, volatility, Sharpe and drawdown use the
+regular daily curve. Reuse the helper for both native and USD views without
+collapsing these two inputs, so sample semantics cannot drift.
+
+For an ETH/BTC vault:
+
+1. Preserve the original sparse real share-price observations. Join each
+   observation's UTC date to the bounded effective-date rate series and produce
+   a sparse USD-valued observation series for raw counts, endpoints and returns.
+2. Separately prepare the existing forward-filled native daily share-price bars
+   for the covered segment and multiply them by the regular effective-date rate
+   series to produce the daily USD curve used by risk metrics.
+3. A provider row labelled D is a start-of-day D snapshot and applies to the
+   vault's end-of-day calendar bar D-1. Shift the rate's effective date back one
+   day exactly once; do not also shift vault timestamps. Add a stepped-rate
+   fixture plus first/last coverage assertions so the convention cannot regress.
+   Document that using a midnight snapshot for the preceding end-of-day bar is
+   still an approximation because the external source does not publish an exact
+   fixing timestamp.
+4. Calculate `share_price_usd = share_price_native * underlying_usd_rate` for
+   both the sparse endpoint series and regular daily curve.
+5. Forward-fill the vault's daily native TVL consistently and calculate
+   `tvl_usd = total_assets_native * underlying_usd_rate`.
+6. Recalculate daily returns from the regular `share_price_usd`; never multiply
+   the native return column by an exchange rate.
+7. Call the shared period helper for every established lookback, including
+   `lifetime`, and store the result as `periodic_metrics_usd`.
+
+Apply the bounded-rate coverage before calling
+`prepare_daily_share_price_series()` or any extracted helper that regularises
+prices. Split on every rate gap longer than three days and pass only the latest
+contiguous covered segment eligible for that requested period. Filter the
+sparse real-observation series to the same segment, but never count a synthetic
+daily bar as a raw observation. Never pass NaN rate gaps to the native
+forward-fill helper: it would turn a deliberately uncovered USD interval into
+a stale flat price and defeat the three-day bound. If the selected segment
+cannot satisfy the established period rules, return the explicit
+insufficient-rate-coverage error instead of bridging the gap.
+
+`periodic_metrics_usd` must serialise as the same list-of-dictionaries shape as
+`PeriodMetrics`. Its share-price and TVL fields are USD; its returns and risk
+statistics describe a USD investor's combined vault performance and ETH/BTC
+market movement. Keep ranking fields `null` in this change rather than copying
+native-unit rankings or introducing a new ranking population.
+
+Do not apply an externalised performance fee to ETH/BTC market appreciation.
+For each USD period, calculate the investor's native-denomination net return
+over the exact USD sample endpoints with the existing fee-mode-adjusted native
+fee logic, then compose it with the underlying FX factor:
+
+```text
+usd_net_factor = native_net_factor * (rate_end / rate_start)
+usd_net_return = usd_net_factor - 1
+```
+
+Gross return, volatility, Sharpe and drawdown still come from the converted USD
+price series. This composition applies management/performance fees to vault
+performance in its denomination token while entry/exit fees still scale the
+investor's final holding; it does not charge a vault performance fee on an
+unrelated ETH/BTC/USD move. Extend the common period calculation with an
+explicit optional native fee-basis/FX-return path (or an equivalently small
+typed strategy), rather than silently feeding USD prices to
+`calculate_net_profit()`. Internalised fees remain already reflected in the
+native share price through `get_net_fees()`. State these invariants in the
+helper docstring and cover both internalised and externalised fee modes in
+tests.
+
+Document that permitted one-to-three-day forward-filled rate gaps create
+flat-then-jump USD returns, so short-window volatility, Sharpe and drawdown
+retain the same cadence-sensitive approximation caveat as native sparse bars.
+Reuse the existing zero annual risk-free-rate convention for both native and
+USD Sharpe calculations.
+
+Keep the existing native `period_results`, top-level `cagr`/`cagr_net`,
+`current_total_assets` and `peak_total_assets` unchanged. Do not add
+`cagr_usd`, USD columns to `CleanedVaultPriceRow`, or other duplicate top-level
+fields. `export_lifetime_row()` already recursively serialises dataclasses, so
+the new list should use that path rather than a second JSON encoder.
+
+Only ETH- and BTC-family records receive `periodic_metrics_usd`; omit it from
+stablecoin records to avoid duplicating their existing USD-like native metrics.
+Treat this as an additive JSON field within the current compatible crypto
+schema version. Do not bump the shared sticky-state schema or require a
+migration script; the next successful crypto metadata cycle generates the new
+field while preserving sticky qualification state.
+
+Pass the verified cleaned snapshot/Parquet path explicitly into
+`build_crypto_vault_metadata()` and through the guarded post-processing
+wrapper. Resolve the DuckDB source and pipeline-directory Parquet destination
+separately in `export-crypto-vaults.py` so scheduled and standalone builds use
+the same snapshot contract.
+
+Add one bundle-level `usd_metrics` provenance section to
+`crypto-vault-metadata.json` containing the source, base currency, stored and
+applied rate directions, per-currency input min/max dates and row counts,
+three-day fill allowance, cleaning-policy digest and a deterministic digest of
+the cleaned, pre-fill ETH/BTC rows materialised in `exchange-rates.parquet`.
+Coverage fields may describe the bounded reindexed series, but the digest must
+remain reproducible from the published cleaned Parquet. The existing per-record
+`canonical_underlying` already states the rate basis, so do not add a duplicate
+`usd_rate_basis` field. Confirm no fixed-schema Parquet writer consumes the
+opt-in lifetime DataFrame column; the new nested data must remain JSON-only.
+
+## 5. Update the performance examiner
+
+The table is produced by
+`scripts/erc-4626/examine-crypto-vault-performance.py`, not by the export
+script. Update the examiner while leaving
+`scripts/erc-4626/export-crypto-vaults.py` responsible only for building and
+publishing artefacts.
+
+Rename the current displayed CAGR column to `Lifetime CAGR (base)` and add
+`Lifetime CAGR (USD)`. The base compatibility fields are top-level `cagr_net`
+with fallback to top-level `cagr`. The nested `PeriodMetrics` fields are
+`cagr_net` with fallback to `cagr_gross`. Read the latter from the
+`period='lifetime'` entry in `periodic_metrics_usd` and show `N/A` only when the
+USD period has an `error_reason` or insufficient samples. Treat a supposedly
+successful USD period missing both documented CAGR keys as an invalid export,
+not as an ordinary `N/A` result.
+
+Add a `USD from` date column sourced from the USD lifetime
+`samples_start_at`. This prevents the two CAGR columns being mistaken for the
+same window when native history predates effective date 2024-03-01. Keep it
+visible for all rows, using `N/A` when no USD lifetime window exists.
+
+Keep the existing stablecoin/blacklist exclusions, approximate latest USD TVL,
+sorting, `LIMIT` behaviour and tabulated output. Update the module description
+to distinguish:
+
+- base CAGR: vault share performance in the denomination family; and
+- USD CAGR: base performance plus the canonical ETH/BTC USD move over the
+  available exchange-rate window.
+
+## Tests
+
+Add focused coverage without running the full suite.
+
+### Currency Parquet and R2
+
+- Materialise a small DuckDB fixture and assert column order, logical-key
+  uniqueness, sorting, exact Parquet logical/physical types, Zstandard
+  readability and atomic replacement. Assert `written_at` remains source
+  provenance rather than materialisation time.
+- Set `CURRENCY_API_DB_PATH` to a source outside the pipeline directory and
+  assert the read-only source is neither created nor mutated while the Parquet
+  is written to the explicit pipeline-directory destination.
+- Prove the known-bad BTC/ETH cells are absent while ordinary currencies and
+  the raw quote-per-base direction remain unchanged.
+- Assert `exchange-rates.parquet` joins the existing data-file path list,
+  honours `UPLOAD_PREFIX`, uploads to both configured data buckets and receives
+  only the established alternative-bucket daily backup.
+- Assert an absent DuckDB cannot cause an old Parquet to be uploaded and a
+  failed fresh conversion does not upload stale output while unrelated files
+  still upload and the guarded step ultimately reports failure.
+- Assert scheduled crypto publication is skipped when that run's data-file
+  export is skipped or fails, while public processing and local crypto artefacts
+  remain intact. Assert standalone publication uploads and backs up the matching
+  alternative-bucket rate Parquet before the crypto manifest.
+- Materialise unchanged input twice and assert identical bytes/digest with no
+  temporary files left behind. Verify prefix/key consistency across primary,
+  alternative and alternative daily-backup calls.
+- Reject zero, negative, non-finite and duplicate logical-key fixture rows while
+  preserving the prior good Parquet.
+
+### USD conversion and metrics
+
+- Verify inversion, ETH/BTC canonical mapping, finite-value validation and
+  three-day bounded forward fill, including the broad direction sanity bounds.
+- Verify there is no backward fill before the first rate, a long trailing gap
+  truncates the window, and a longer internal gap degrades only affected
+  periods/vaults with an explicit error reason. Specifically prove the shared
+  daily preparation cannot refill a greater-than-three-day rate gap and that a
+  successful post-gap period shifts `samples_start_at` to the covered segment.
+- Assert provider date D becomes effective vault date D-1, including the first
+  and last available rows and a stepped rate. For every lookback after a long
+  gap, assert `raw_samples` counts only real vault observations,
+  `daily_samples` counts the regular covered curve, and sample/period endpoints
+  retain their established meanings.
+- Use a flat one-ETH vault with a rising ETH/USD series to prove native CAGR is
+  zero while USD CAGR is positive, with USD TVL fields converted correctly.
+- Verify BTC uses BTC rates, wrapper symbols use their canonical family, and
+  stablecoin records do not gain `periodic_metrics_usd`.
+- Verify the USD lifetime sample start is clamped to rate coverage for a vault
+  beginning before effective date 2024-03-01.
+- Assert native `period_results`, compatibility CAGR fields, qualification and
+  the cleaned crypto Parquet schema are unchanged.
+- Assert USD rankings remain null and JSON serialisation contains the complete
+  `PeriodMetrics` key set without non-finite values.
+- With an externalised non-zero performance fee, use a flat native price and a
+  rising ETH/USD rate to prove the FX gain is not performance-fee charged. Also
+  cover a positive native gain, management/deposit/withdrawal fees and an
+  internalised fee mode so USD net CAGR composes the native investor factor and
+  FX factor exactly.
+- Assert an absent/unreadable database fails only the guarded crypto metadata
+  phase and does not prevent established public post-processing steps. Assert
+  an absent individual ETH or BTC series instead produces errored USD periods
+  for only that family while preserving all native and other-family metrics.
+- Assert bundle-level USD provenance digests and coverage match the exact
+  cleaned pre-fill rows published in the Parquet, and the opt-in nested column
+  is never written into the crypto price Parquet.
+- Run the existing cross-vault ranking pass and assert it reads and mutates only
+  `period_results`; every `periodic_metrics_usd` ranking field remains null.
+
+### Examiner
+
+- Assert the report contains `Lifetime CAGR (base)` and
+  `Lifetime CAGR (USD)` with correct net/gross fallback and formatting, plus
+  the effective `USD from` date.
+- Assert a missing or errored USD lifetime period displays `N/A` and does not
+  change TVL sorting or stablecoin exclusion.
+
+Suggested focused commands:
+
+```shell
+poetry run ruff format
+poetry run ruff check \
+  eth_defi/currency_api \
+  eth_defi/research/vault_metrics.py \
+  eth_defi/vault \
+  scripts/erc-4626/export-crypto-vaults.py \
+  scripts/erc-4626/examine-crypto-vault-performance.py \
+  tests/currency_api \
+  tests/vault/test_crypto_vaults.py \
+  tests/erc_4626/test_export_data_files.py \
+  tests/erc_4626/test_post_processing.py
+
+source .local-test.env && poetry run pytest \
+  tests/currency_api/test_currency_api.py \
+  tests/research/test_vault_metrics.py \
+  tests/vault/test_crypto_vaults.py \
+  tests/erc_4626/test_export_data_files.py \
+  tests/erc_4626/test_post_processing.py \
+  --timeout=180
+```
+
+Do not build Sphinx locally.
+
+## Production-data acceptance
+
+1. Run `export-crypto-vaults.py` with `CRYPTO_VAULTS_PUBLISH=false` against a
+   copy or the established local production state.
+2. Confirm both raw ETH and BTC rate series still cover source labels from
+   2024-03-02 through the current publication tail, and that their effective
+   vault dates are exactly one day earlier. Record all raw and cleaned gaps,
+   and verify gaps within the allowance are filled while longer gaps produce
+   the documented per-period degradation rather than aborting the bundle.
+3. Confirm every selected ETH/BTC vault receives either a successful USD
+   lifetime period or the established insufficient-samples/coverage error;
+   never weaken the shared minimum-duration rules. Separately count vaults
+   whose native history starts before the rate floor and verify their USD
+   sample start is not earlier than effective date 2024-03-01.
+4. Compare representative WETH/stETH/restaking and WBTC/BTC-wrapper records:
+   native metrics stay unchanged, USD price/TVL arithmetic follows the
+   canonical underlying, and no wrapper-specific valuation is claimed.
+5. Run the examiner and manually inspect the top TVL rows with both CAGR
+   columns for plausible direction and magnitude.
+6. Run `export-data-files.py` with `UPLOAD_PREFIX=test-`, confirm
+   `test-exchange-rates.parquet` is readable from R2, matches the local digest
+   and has an alternative daily backup. Do not require a new R2 integration
+   mechanism; this uses the existing tested uploader and bucket configuration.
+
+## Documentation and release notes
+
+Update:
+
+- `eth_defi/currency_api/README-currency-api.md` with the cleaned Parquet
+  contract, rate direction, filename, R2 key and backup behaviour;
+- `scripts/erc-4626/README-vault-scripts.md` with USD period semantics, the
+  raw 2024-03-02/effective 2024-03-01 floor, bounded rate filling and both
+  examiner CAGR columns;
+- `docs/source/api/currency_api/index.rst` if a new public module is added;
+- relevant script/module docstrings and environment-variable lists; and
+- `CHANGELOG.md` with a dated feature entry when the implementation PR is
+  opened.
+
+Use British English, sentence-case headings and `onchain` spelling. Do not edit
+generated Sphinx files.
+
+## Rollout, rollback and completion
+
+No migration script is required. The next successful all-chain cycle scans
+rates first, materialises one cleaned exchange-rate snapshot, regenerates crypto
+metadata with the additive USD field from that snapshot, uploads the same
+Parquet during data export and publishes the crypto bundle only after the data
+export succeeds.
+
+Daily rollback is sufficient: restore the prior crypto JSON/manifest objects
+and the matching `exchange-rates.parquet` from the alternative daily backup.
+The raw DuckDB, vault price Parquets, reader state and sticky state do not need
+to change.
+
+The work is complete when:
+
+- the clean exchange-rate Parquet is present in both data-file R2 exports and
+  the alternative daily backup;
+- ETH/BTC JSON records contain valid, coverage-bounded
+  `periodic_metrics_usd` without changing native metrics or Parquet schemas;
+- the examiner displays both base and USD lifetime CAGR;
+- focused tests, Ruff and production-shaped acceptance checks pass; and
+- documentation states the USD-rate direction, canonical-wrapper
+  approximation and raw 2024-03-02/effective 2024-03-01 lifetime boundary
+  accurately.

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -205,21 +205,34 @@ poetry run python -m eth_defi.currency_api.cli
 | `MAX_TRANSIENT_ATTEMPTS` | `5` | Consecutive transient failures per date before giving up |
 | `SOURCE` | `fawazahmed0` | Value written to the `source` column |
 
-## Uploading the DuckDB bundle
+## Uploading exchange-rate bundles
 
 The all-chain vault scanner writes the currency API database to
 `$PIPELINE_DATA_DIR/exchange-rates.duckdb` by default, using
 `CURRENCY_API_DB_PATH` or `CURRENCY_API_DATABASE_PATH` when either override is
 set. `scripts/erc-4626/export-data-files.py` follows the same path resolution
-and uploads the resulting DuckDB file with the other vault data artefacts.
+and uploads the resulting DuckDB file with the other vault data artefacts. It
+also materialises a read-only, cleaned ``exchange-rates.parquet`` companion
+from the same database. The Parquet retains the source direction (quote units
+per USD), removes only documented known-bad rows, and has stable columns
+``date``, ``base_currency``, ``quote_currency``, ``rate``, ``source`` and
+``written_at``.
 
 The upload creates a flat R2 object key from the local file name. The default
-object is therefore `exchange-rates.duckdb`, next to `vault-prices-1h.parquet`,
+objects are therefore `exchange-rates.duckdb` and `exchange-rates.parquet`, next to `vault-prices-1h.parquet`,
 `cleaned-vault-prices-1h.parquet`, the vault metadata pickle, reader state,
 sticky export state, and Core3 DuckDB. When
-`R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` is configured, the same file is
+`R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` is configured, both files are
 uploaded to the alternative bucket and included in its daily
 `daily/YYYY-MM-DD/...` backup copy.
+
+Crypto-vault USD metrics consume the same cleaned Parquet snapshot that the
+data export later publishes. Provider observations labelled date ``D`` are
+treated as effective for the preceding UTC vault day ``D - 1`` and can be
+forward filled for at most three days. A longer gap starts a new USD-metric
+segment, so the USD lifetime view begins at that newest contiguous segment
+rather than combining unrelated rate windows. This is a valuation convention
+for the provider's midnight snapshot, not an intraday price fixing.
 
 ```shell
 source .local-test.env && poetry run python scripts/erc-4626/export-data-files.py

--- a/eth_defi/currency_api/parquet.py
+++ b/eth_defi/currency_api/parquet.py
@@ -1,0 +1,188 @@
+"""Cleaned Parquet materialisation for currency API exchange rates.
+
+The raw DuckDB database remains the auditable source of currency API records.
+This module creates a deterministic, sanitised Parquet snapshot for consumers
+that must not apply rate-cleaning policy themselves.
+"""
+
+import datetime
+import hashlib
+import math
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from eth_defi.currency_api.cleaning import filter_known_bad_rates
+
+#: Stable schema for the cleaned exchange-rate consumer export.
+EXCHANGE_RATE_PARQUET_SCHEMA = pa.schema(
+    [
+        pa.field("date", pa.date32(), nullable=False),
+        pa.field("base_currency", pa.string(), nullable=False),
+        pa.field("quote_currency", pa.string(), nullable=False),
+        pa.field("rate", pa.float64(), nullable=False),
+        pa.field("source", pa.string(), nullable=False),
+        pa.field("written_at", pa.timestamp("us"), nullable=True),
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExchangeRateParquetSnapshot:
+    """Verified cleaned exchange-rate Parquet snapshot."""
+
+    #: Local destination path of the materialised Parquet file.
+    path: Path
+
+    #: Number of cleaned exchange-rate rows in the snapshot.
+    row_count: int
+
+    #: SHA-256 digest of the byte-identical local Parquet file.
+    sha256: str
+
+
+def load_cleaned_exchange_rates(source_path: Path) -> pd.DataFrame:
+    """Read and clean all exchange-rate rows from an existing DuckDB database.
+
+    Uses DuckDB read-only mode and intentionally bypasses
+    :class:`~eth_defi.currency_api.database.CurrencyRateDatabase`: that mutable
+    storage class creates directories and may initialise schema. The returned
+    frame is sorted by its logical key and has stable column order.
+
+    :param source_path:
+        Existing raw currency API DuckDB database.
+    :return:
+        Sanitised DataFrame with ``date``, currency, ``rate``, ``source`` and
+        naive-UTC ``written_at`` columns.
+    :raises FileNotFoundError:
+        If the source database does not exist.
+    :raises ValueError:
+        If source rows do not meet the consumer export contract.
+    """
+    if not source_path.is_file():
+        raise FileNotFoundError(source_path)
+
+    connection = duckdb.connect(str(source_path), read_only=True)
+    try:
+        rates = connection.execute(
+            """
+            SELECT date, base_currency, quote_currency, rate, source, written_at
+            FROM exchange_rates
+            """
+        ).fetchdf()
+    finally:
+        connection.close()
+
+    cleaned = filter_known_bad_rates(rates)
+    return _validate_and_normalise_rates(cleaned)
+
+
+def materialise_exchange_rate_parquet(
+    source_path: Path,
+    destination_path: Path,
+) -> ExchangeRateParquetSnapshot:
+    """Atomically materialise one cleaned Parquet snapshot from DuckDB.
+
+    The write is deterministic for unchanged source rows: row order, column
+    order and row values are all fixed, and no materialisation timestamp is
+    inserted. A failed conversion leaves the prior destination untouched.
+
+    :param source_path:
+        Existing raw currency API DuckDB database opened read-only.
+    :param destination_path:
+        Cleaned Parquet destination, normally below the pipeline data directory.
+    :return:
+        Verified Parquet snapshot metadata.
+    """
+    rates = load_cleaned_exchange_rates(source_path)
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    table = _rates_to_arrow_table(rates)
+
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        suffix=".parquet",
+        dir=destination_path.parent,
+        prefix=f".{destination_path.stem}-",
+    )
+    os.close(file_descriptor)
+    temporary_path = Path(temporary_name)
+    try:
+        pq.write_table(table, temporary_path, compression="zstd")
+        verified = pq.read_table(temporary_path)
+        if verified.schema != EXCHANGE_RATE_PARQUET_SCHEMA:
+            raise ValueError(f"Unexpected exchange-rate Parquet schema: {verified.schema}")
+        if verified.num_rows != len(rates):
+            raise ValueError(f"Exchange-rate Parquet row count mismatch: {verified.num_rows} != {len(rates)}")
+        payload = temporary_path.read_bytes()
+        digest = hashlib.sha256(payload).hexdigest()
+        os.replace(temporary_path, destination_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+    return ExchangeRateParquetSnapshot(
+        path=destination_path,
+        row_count=len(rates),
+        sha256=digest,
+    )
+
+
+def _validate_and_normalise_rates(rates: pd.DataFrame) -> pd.DataFrame:
+    """Validate source rows and normalise them for deterministic Parquet output.
+
+    :param rates:
+        Cleaned currency API rows in storage schema.
+    :return:
+        Sorted and type-normalised DataFrame suitable for Arrow conversion.
+    :raises ValueError:
+        If required columns, finite positive rates or logical-key uniqueness are
+        violated.
+    """
+    expected_columns = list(EXCHANGE_RATE_PARQUET_SCHEMA.names)
+    missing_columns = set(expected_columns) - set(rates.columns)
+    if missing_columns:
+        raise ValueError(f"Exchange-rate source is missing columns: {sorted(missing_columns)!r}")
+
+    normalised = rates.loc[:, expected_columns].copy()
+    normalised["date"] = pd.to_datetime(normalised["date"], errors="raise").dt.date
+    for column in ("base_currency", "quote_currency", "source"):
+        normalised[column] = normalised[column].astype("string")
+    normalised["rate"] = pd.to_numeric(normalised["rate"], errors="raise")
+    normalised["written_at"] = pd.to_datetime(normalised["written_at"], errors="coerce").dt.tz_localize(None)
+
+    if normalised[["date", "base_currency", "quote_currency", "source"]].isna().any().any():
+        message = "Exchange-rate source contains null logical-key values"
+        raise ValueError(message)
+    if normalised["rate"].isna().any() or not normalised["rate"].map(math.isfinite).all() or (normalised["rate"] <= 0).any():
+        message = "Exchange-rate source contains non-finite or non-positive rates"
+        raise ValueError(message)
+    logical_key = ["date", "base_currency", "quote_currency", "source"]
+    if normalised.duplicated(logical_key).any():
+        message = "Exchange-rate source contains duplicate logical keys"
+        raise ValueError(message)
+
+    return normalised.sort_values(logical_key, kind="stable").reset_index(drop=True)
+
+
+def _rates_to_arrow_table(rates: pd.DataFrame) -> pa.Table:
+    """Convert validated rates to the exact stable Arrow schema.
+
+    :param rates:
+        Validated and sorted cleaned rates.
+    :return:
+        Arrow table using :data:`EXCHANGE_RATE_PARQUET_SCHEMA`.
+    """
+    dates = [value if isinstance(value, datetime.date) else value.date() for value in rates["date"]]
+    arrays = [
+        pa.array(dates, type=pa.date32()),
+        pa.array(rates["base_currency"].tolist(), type=pa.string()),
+        pa.array(rates["quote_currency"].tolist(), type=pa.string()),
+        pa.array(rates["rate"].tolist(), type=pa.float64()),
+        pa.array(rates["source"].tolist(), type=pa.string()),
+        pa.array(rates["written_at"].tolist(), type=pa.timestamp("us")),
+    ]
+    return pa.Table.from_arrays(arrays, schema=EXCHANGE_RATE_PARQUET_SCHEMA)

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 import math
 import warnings
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, is_dataclass
 from decimal import Decimal
 from enum import Enum
@@ -179,6 +180,54 @@ class PeriodMetrics:
 
     #: Average utilisation over the period (lending vaults only, 0.0–1.0)
     avg_utilisation: Percent | None = None
+
+
+@dataclass(slots=True)
+class USDPeriodMetrics(PeriodMetrics):
+    """USD-converted period metrics for one ETH/BTC vault period.
+
+    This JSON-only subtype leaves the public/native :class:`PeriodMetrics`
+    schema untouched. The exchange-rate fields are USD per canonical
+    underlying unit, e.g. Bitcoin price in US dollars for a BTC vault.
+    """
+
+    #: USD per canonical underlying unit at ``samples_start_at``.
+    exchange_rate_start: float | None = None
+
+    #: USD per canonical underlying unit at ``samples_end_at``.
+    exchange_rate_end: float | None = None
+
+
+#: USD metrics cannot be calculated because an ETH/BTC rate series is absent.
+USD_RATE_ERROR_MISSING_SERIES = "USD exchange-rate series is unavailable"
+
+#: USD metrics cannot be calculated because an ETH/BTC rate series failed validation.
+USD_RATE_ERROR_INVALID_SERIES = "USD exchange-rate series failed validation"
+
+#: USD metrics cannot be calculated without a contiguous bounded rate window.
+USD_RATE_ERROR_INSUFFICIENT_COVERAGE = "USD exchange-rate coverage is insufficient"
+
+
+@dataclass(frozen=True, slots=True)
+class CryptoUSDConversionContext:
+    """Cleaned ETH/BTC USD-rate inputs for one crypto metadata build.
+
+    The context is optional in the common metrics pipeline. Public stablecoin
+    callers keep their existing behaviour by passing ``None``. Values are keyed
+    by denomination family strings (``"eth"`` and ``"btc"``), while the vault
+    mapping is built by the crypto bundle before JSON-only canonical-underlying
+    fields exist.
+
+    """
+
+    #: Bounded effective-date USD-per-underlying daily rates by family.
+    rates_by_family: Mapping[str, pd.Series]
+
+    #: Family-specific validation or absence errors by family.
+    errors_by_family: Mapping[str, str]
+
+    #: Vault ID to denomination family mapping from crypto metadata policy.
+    vault_families: Mapping[str, str]
 
 
 @dataclass(slots=True)
@@ -1207,7 +1256,7 @@ def _calculate_netflow_metrics(
     if exclude_current_utc_day and now_.date() == native_datetime_utc_now().date():
         now_ -= pd.Timedelta(days=1)
 
-    results = []
+    results: list[NetflowMetrics] = []
     for period_label, days in [("1d", 1), ("7d", 7), ("30d", 30)]:
         cutoff = now_ - pd.Timedelta(days=days)
         mask = (prices_df.index > cutoff) & (prices_df.index <= now_)
@@ -1255,6 +1304,8 @@ def calculate_period_metrics(
     tvl: pd.Series,
     now_: pd.Timestamp,
     utilisation: pd.Series | None = None,
+    native_fee_share_price: pd.Series | None = None,
+    exchange_rate: pd.Series | None = None,
 ) -> PeriodMetrics:
     """Calculate metrics for one period.
 
@@ -1294,9 +1345,27 @@ def calculate_period_metrics(
         values 0.0–1.0). When provided, ``avg_utilisation`` is a calendar-day
         average for the period rather than an observation-frequency average.
 
+    :param native_fee_share_price:
+        Optional sparse native-denomination prices aligned to
+        ``share_price_hourly``. USD metrics use these values when calculating
+        externalised investor fees, so a vault performance fee is never charged
+        on ETH/BTC/USD market appreciation.
+
+    :param exchange_rate:
+        Optional USD-per-underlying sparse rate series aligned to
+        ``share_price_hourly``. Must be supplied together with
+        ``native_fee_share_price``.
+
     :return:
         PeriodMetrics dataclass with calculated metrics
     """
+    if (native_fee_share_price is None) != (exchange_rate is None):
+        raise ValueError("native_fee_share_price and exchange_rate must be supplied together")
+    if native_fee_share_price is not None and not native_fee_share_price.index.equals(share_price_hourly.index):
+        raise ValueError("native_fee_share_price must align with share_price_hourly")
+    if exchange_rate is not None and not exchange_rate.index.equals(share_price_hourly.index):
+        raise ValueError("exchange_rate must align with share_price_hourly")
+
     if share_price_hourly.empty:
         return PeriodMetrics(period=period, period_end_at=now_, error_reason="Vault has no usable share-price observations")
 
@@ -1386,17 +1455,23 @@ def calculate_period_metrics(
     net_performance_known = gross_fee_data.fee_mode is not None and net_fee_data.can_calculate_investor_net_performance()
     returns_net = None
     if net_performance_known:
-        returns_net = calculate_net_profit(
+        net_return_native = calculate_net_profit(
             start=samples_start_at,
             end=samples_end_at,
-            share_price_start=share_price_start,
-            share_price_end=share_price_end,
+            share_price_start=float(native_fee_share_price.loc[samples_start_at]) if native_fee_share_price is not None else share_price_start,
+            share_price_end=float(native_fee_share_price.loc[samples_end_at]) if native_fee_share_price is not None else share_price_end,
             management_fee_annual=net_fee_data.management,
             performance_fee=net_fee_data.performance,
             deposit_fee=net_fee_data.deposit,
             withdrawal_fee=net_fee_data.withdraw,
             sample_count=raw_samples,
         )
+        if exchange_rate is None:
+            returns_net = net_return_native
+        else:
+            rate_start = float(exchange_rate.loc[samples_start_at])
+            rate_end = float(exchange_rate.loc[samples_end_at])
+            returns_net = (1.0 + net_return_native) * (rate_end / rate_start) - 1.0
 
     # Calculate CAGR (gross and net)
     # CAGR formula: (1 + return) ^ (1/years) - 1
@@ -1526,6 +1601,225 @@ def calculate_period_metrics(
         tvl_high=tvl_high,
         avg_utilisation=avg_utilisation,
     )
+
+
+def calculate_period_results(
+    *,
+    gross_fee_data: FeeData,
+    net_fee_data: FeeData,
+    share_price_observations: pd.Series,
+    share_price_daily: pd.Series,
+    daily_returns: pd.Series,
+    tvl: pd.Series,
+    now_: pd.Timestamp,
+    utilisation: pd.Series | None = None,
+    native_fee_share_price: pd.Series | None = None,
+    exchange_rate: pd.Series | None = None,
+) -> list[PeriodMetrics]:
+    """Calculate every established period from paired sparse and daily inputs.
+
+    The sparse observations preserve the established endpoint, raw-sample and
+    fee semantics. The daily curve is independently supplied for volatility,
+    Sharpe and drawdown. USD metrics reuse this helper with native fee-basis
+    prices and matching USD-per-underlying rates.
+
+    :param gross_fee_data:
+        Vault fee schedule before fee-mode adjustments.
+    :param net_fee_data:
+        Investor-facing fee schedule after fee-mode adjustments.
+    :param share_price_observations:
+        Sparse real price observations used for period endpoints.
+    :param share_price_daily:
+        Regular covered daily price curve used for risk metrics.
+    :param daily_returns:
+        Daily returns derived from ``share_price_daily``.
+    :param tvl:
+        TVL curve aligned to the selected metric view.
+    :param now_:
+        Last timestamp of the selected contiguous metric segment.
+    :param utilisation:
+        Optional regular daily utilisation curve.
+    :param native_fee_share_price:
+        Optional native sparse fee-basis prices for a converted USD view.
+    :param exchange_rate:
+        Optional sparse USD-per-underlying rates for a converted USD view.
+    :return:
+        One :class:`PeriodMetrics` instance for each established lookback.
+    """
+    return [
+        calculate_period_metrics(
+            period=period,
+            gross_fee_data=gross_fee_data,
+            net_fee_data=net_fee_data,
+            share_price_hourly=share_price_observations,
+            share_price_daily=share_price_daily,
+            daily_returns=daily_returns,
+            tvl=tvl,
+            now_=now_,
+            utilisation=utilisation,
+            native_fee_share_price=native_fee_share_price,
+            exchange_rate=exchange_rate,
+        )
+        for period in LOOKBACK_AND_TOLERANCES
+    ]
+
+
+def calculate_crypto_usd_period_results(
+    *,
+    context: CryptoUSDConversionContext,
+    vault_id: str,
+    native_share_price_observations: pd.Series,
+    native_daily_share_prices: pd.Series,
+    native_total_assets: pd.Series,
+    gross_fee_data: FeeData,
+    net_fee_data: FeeData,
+) -> list[USDPeriodMetrics] | None:
+    """Calculate JSON-only USD period metrics for an ETH/BTC crypto vault.
+
+    A provider-rate gap longer than the configured bounded fill creates a new
+    segment. This function uses only the latest contiguous covered segment and
+    filters sparse real vault observations to it before calculating endpoints
+    or fees. Stablecoin vaults return ``None`` and retain their native metrics.
+
+    :param context:
+        Prepared crypto conversion rates and vault denomination mapping.
+    :param vault_id:
+        Common ``chain-address`` vault identifier.
+    :param native_share_price_observations:
+        Sparse real native share-price observations.
+    :param native_daily_share_prices:
+        Existing forward-filled native daily share-price curve.
+    :param native_total_assets:
+        Sparse native total-assets observations.
+    :param gross_fee_data:
+        Vault fee schedule before fee-mode adjustments.
+    :param net_fee_data:
+        Investor-facing fee schedule after fee-mode adjustments.
+    :return:
+        USD period metrics for ETH/BTC with USD-per-underlying endpoint rates,
+        an errored list when rate input is unavailable, or ``None`` for
+        non-crypto-denominated records.
+    """
+    family = context.vault_families.get(vault_id)
+    if family not in {"eth", "btc"}:
+        return None
+
+    error_reason = context.errors_by_family.get(family)
+    rates = context.rates_by_family.get(family)
+    if error_reason is not None or rates is None or rates.empty:
+        return _build_usd_rate_error_results(error_reason or USD_RATE_ERROR_MISSING_SERIES)
+
+    segment = _get_latest_contiguous_rate_segment(rates)
+    if segment is None:
+        return _build_usd_rate_error_results(USD_RATE_ERROR_INSUFFICIENT_COVERAGE)
+    segment_start, segment_end = segment
+
+    sparse_dates = native_share_price_observations.index.normalize()
+    sparse_rates = rates.reindex(sparse_dates)
+    sparse_mask = (sparse_dates >= segment_start) & (sparse_dates <= segment_end) & sparse_rates.notna().to_numpy()
+    native_sparse = native_share_price_observations.loc[sparse_mask]
+    # Price rows occasionally have several observations with the same block
+    # timestamp. Preserve the last value, matching daily resampling semantics,
+    # before endpoint lookups use timestamp labels.
+    native_sparse = native_sparse.loc[~native_sparse.index.duplicated(keep="last")]
+    rate_sparse = pd.Series(
+        rates.reindex(native_sparse.index.normalize()).to_numpy(),
+        index=native_sparse.index,
+        dtype="float64",
+    )
+    if native_sparse.empty:
+        return _build_usd_rate_error_results(USD_RATE_ERROR_INSUFFICIENT_COVERAGE)
+
+    daily_native = native_daily_share_prices.loc[segment_start:segment_end]
+    daily_rates = rates.loc[segment_start:segment_end]
+    daily_rates = daily_rates.reindex(daily_native.index)
+    if daily_native.empty or daily_rates.isna().any():
+        return _build_usd_rate_error_results(USD_RATE_ERROR_INSUFFICIENT_COVERAGE)
+    daily_usd = daily_native * daily_rates
+    daily_returns = daily_usd.pct_change(fill_method=None)
+
+    native_tvl = pd.to_numeric(native_total_assets, errors="coerce")
+    tvl_dates = native_tvl.index.normalize()
+    tvl_rates = rates.reindex(tvl_dates)
+    tvl_mask = (tvl_dates >= segment_start) & (tvl_dates <= segment_end) & tvl_rates.notna().to_numpy()
+    usd_tvl = pd.Series(
+        native_tvl.loc[tvl_mask].to_numpy() * tvl_rates.loc[tvl_mask].to_numpy(),
+        index=native_tvl.index[tvl_mask],
+        dtype="float64",
+    )
+    usd_sparse = native_sparse * rate_sparse
+    metrics = calculate_period_results(
+        gross_fee_data=gross_fee_data,
+        net_fee_data=net_fee_data,
+        share_price_observations=usd_sparse,
+        share_price_daily=daily_usd,
+        daily_returns=daily_returns,
+        tvl=usd_tvl,
+        now_=segment_end,
+        native_fee_share_price=native_sparse,
+        exchange_rate=rate_sparse,
+    )
+    return _attach_usd_exchange_rates(metrics, rate_sparse)
+
+
+def _get_latest_contiguous_rate_segment(rates: pd.Series) -> tuple[pd.Timestamp, pd.Timestamp] | None:
+    """Find the latest contiguous non-null effective-rate segment.
+
+    :param rates:
+        Daily bounded USD-per-underlying rate series.
+    :return:
+        Inclusive start and end timestamps of the latest contiguous coverage,
+        or ``None`` when no valid rate exists.
+    """
+    valid = rates.dropna()
+    if valid.empty:
+        return None
+    discontinuities = valid.index.to_series().diff().gt(pd.Timedelta(days=1))
+    segment_id = discontinuities.cumsum()
+    latest_segment = valid.loc[segment_id == segment_id.iloc[-1]]
+    return latest_segment.index[0], latest_segment.index[-1]
+
+
+def _attach_usd_exchange_rates(
+    metrics: list[PeriodMetrics],
+    exchange_rates: pd.Series,
+) -> list[USDPeriodMetrics]:
+    """Attach endpoint USD-underlying prices to converted metric records.
+
+    :param metrics:
+        Converted period metrics before endpoint-rate metadata is attached.
+    :param exchange_rates:
+        Sparse USD-per-underlying rates aligned to metric samples.
+    :return:
+        JSON-only USD period metrics with endpoint conversion prices.
+    """
+    results: list[USDPeriodMetrics] = []
+    for metric in metrics:
+        if metric.samples_start_at is None or metric.samples_end_at is None:
+            exchange_rate_start = None
+            exchange_rate_end = None
+        else:
+            exchange_rate_start = float(exchange_rates.loc[metric.samples_start_at])
+            exchange_rate_end = float(exchange_rates.loc[metric.samples_end_at])
+        results.append(
+            USDPeriodMetrics(
+                **asdict(metric),
+                exchange_rate_start=exchange_rate_start,
+                exchange_rate_end=exchange_rate_end,
+            )
+        )
+    return results
+
+
+def _build_usd_rate_error_results(error_reason: str) -> list[USDPeriodMetrics]:
+    """Create the full expected USD period list for unavailable rate input.
+
+    :param error_reason:
+        Stable operator-facing exchange-rate error message.
+    :return:
+        Errored metrics for every established period.
+    """
+    return [USDPeriodMetrics(period=period, error_reason=error_reason) for period in LOOKBACK_AND_TOLERANCES]
 
 
 def apply_abnormal_value_checks(
@@ -1772,6 +2066,7 @@ def calculate_vault_record(
     xerberus_pools: dict[tuple[int, str], XerberusPoolLookupRow] | None = None,
     xerberus_protocols: dict[str, XerberusProtocolExportRecord] | None = None,
     stablecoin_rate_feeder: StablecoinRateFeeder | None = None,
+    crypto_usd_conversion_context: CryptoUSDConversionContext | None = None,
 ) -> pd.Series:
     """Process a single vault metadata + prices to calculate its full data.
 
@@ -1819,6 +2114,12 @@ def calculate_vault_record(
         should pass one shared
         :py:class:`~eth_defi.feed.stablecoin_rate.StablecoinRateFeeder` so the
         stablecoin YAML lookups are cached consistently across the batch.
+
+    :param crypto_usd_conversion_context:
+        Optional effective USD-per-underlying exchange-rate context for the
+        private crypto bundle. When supplied, ETH/BTC records gain
+        ``periodic_metrics_usd`` while their established native
+        ``period_results`` remain unchanged.
 
     :return:
         Series with calculated metrics
@@ -2245,20 +2546,27 @@ def calculate_vault_record(
         if not utilisation_observations.empty:
             utilisation_series = utilisation_observations.resample("D").last().ffill()
 
-    period_results = []
-    for period in LOOKBACK_AND_TOLERANCES.keys():
-        period_metric = calculate_period_metrics(
-            period=period,
+    period_results = calculate_period_results(
+        gross_fee_data=gross_fee_data,
+        net_fee_data=net_fee_data,
+        share_price_observations=share_price_hourly,
+        share_price_daily=share_price_daily,
+        daily_returns=daily_returns,
+        tvl=tvl_series,
+        now_=now_,
+        utilisation=utilisation_series,
+    )
+    periodic_metrics_usd = None
+    if crypto_usd_conversion_context is not None:
+        periodic_metrics_usd = calculate_crypto_usd_period_results(
+            context=crypto_usd_conversion_context,
+            vault_id=id_val,
+            native_share_price_observations=share_price_hourly,
+            native_daily_share_prices=share_price_daily,
+            native_total_assets=tvl_series,
             gross_fee_data=gross_fee_data,
             net_fee_data=net_fee_data,
-            share_price_hourly=share_price_hourly,
-            share_price_daily=share_price_daily,
-            daily_returns=daily_returns,
-            tvl=tvl_series,
-            now_=now_,
-            utilisation=utilisation_series,
         )
-        period_results.append(period_metric)
 
     # Extract period metrics for backward compatibility
     lifetime_pm = get_period_metrics(period_results, "lifetime")
@@ -2496,6 +2804,7 @@ def calculate_vault_record(
             "denomination_token_rate": denomination_token_rate,
             # Protocol-specific extension data; see other_data definition above for structure
             "other_data": other_data,
+            **({"periodic_metrics_usd": periodic_metrics_usd} if periodic_metrics_usd is not None else {}),
         }
     )
 
@@ -2508,6 +2817,7 @@ def calculate_lifetime_metrics(
     xerberus_pools: dict[tuple[int, str], XerberusPoolLookupRow] | None = None,
     xerberus_protocols: dict[str, XerberusProtocolExportRecord] | None = None,
     stablecoin_rate_feeder: StablecoinRateFeeder | None = None,
+    crypto_usd_conversion_context: CryptoUSDConversionContext | None = None,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for each vault in the provided DataFrame.
 
@@ -2560,6 +2870,11 @@ def calculate_lifetime_metrics(
         Stablecoin rate/depeg lookup helper shared across all vault rows in
         this calculation. If omitted, one default feeder is constructed.
 
+    :param crypto_usd_conversion_context:
+        Optional USD conversion context for the crypto bundle. ETH/BTC output
+        records contain an additional ``periodic_metrics_usd`` field when it
+        is supplied; all existing native metrics preserve their semantics.
+
     :return:
         DataFrame, one row per vault.
     """
@@ -2597,6 +2912,7 @@ def calculate_lifetime_metrics(
                 xerberus_pools=xerberus_pools,
                 xerberus_protocols=xerberus_protocols,
                 stablecoin_rate_feeder=stablecoin_rate_feeder,
+                crypto_usd_conversion_context=crypto_usd_conversion_context,
             )
         except (ArithmeticError, AssertionError, KeyError, TypeError, ValueError):
             logger.exception("Skipping invalid vault metrics record for %s", vault_id)

--- a/eth_defi/vault/crypto_vaults.py
+++ b/eth_defi/vault/crypto_vaults.py
@@ -5,6 +5,7 @@ state path.  It shares only the established metric calculations and JSON
 serialisation helpers so that public stablecoin exports remain unchanged.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -12,6 +13,7 @@ import tempfile
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 import pandas as pd
@@ -20,8 +22,21 @@ import pyarrow.parquet as pq
 from atomicwrites import atomic_write
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.research.vault_metrics import calculate_lifetime_metrics, export_lifetime_row
-from eth_defi.research.wrangle_vault_prices import filter_vaults_by_denomination_families, generate_cleaned_vault_datasets, materialise_daily_crypto_prices
+from eth_defi.currency_api.cleaning import KNOWN_BAD_RATES
+from eth_defi.currency_api.constants import SOURCE_NAME
+from eth_defi.research.vault_metrics import (
+    USD_RATE_ERROR_INSUFFICIENT_COVERAGE,
+    USD_RATE_ERROR_INVALID_SERIES,
+    USD_RATE_ERROR_MISSING_SERIES,
+    CryptoUSDConversionContext,
+    calculate_lifetime_metrics,
+    export_lifetime_row,
+)
+from eth_defi.research.wrangle_vault_prices import (
+    filter_vaults_by_denomination_families,
+    generate_cleaned_vault_datasets,
+    materialise_daily_crypto_prices,
+)
 from eth_defi.vault.base import VaultSpec, verify_parquet_file
 from eth_defi.vault.denomination import (
     BTC_USD_GUIDELINE_RATE,
@@ -46,6 +61,36 @@ CRYPTO_VAULTS_SCHEMA_VERSION = 1
 CRYPTO_CLEANED_PRICE_FILENAME = "crypto-cleaned-vault-prices-1d.parquet"
 
 logger = logging.getLogger(__name__)
+
+#: Maximum provider-day gap filled when building the effective USD rate curve.
+#: A longer gap starts a new metric segment rather than inventing a price.
+USD_RATE_FORWARD_FILL_DAYS = 3
+
+#: Broad plausibility ranges for inverted USD-per-native exchange rates.
+#: They reject malformed provider values without turning a normal market move
+#: into an unsupported denomination failure.
+USD_RATE_BOUNDS = {
+    DenominationFamily.eth.value: (10.0, 100_000.0),
+    DenominationFamily.btc.value: (100.0, 1_000_000.0),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class USDExchangeRateSeriesBuild:
+    """Validated effective USD-rate series for one denomination family.
+
+    The result keeps the optional rate curve, its export provenance and a
+    stable error together, avoiding positional tuple handling at the caller.
+    """
+
+    #: Effective USD-per-underlying daily rate curve when validation succeeds.
+    rates: pd.Series | None
+
+    #: JSON-serialisable source coverage information when source rows exist.
+    coverage: dict[str, Any] | None
+
+    #: Stable reason USD metrics cannot be calculated for this family.
+    error_reason: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -240,6 +285,10 @@ def build_crypto_vault_record(record: dict[str, Any], vault_row: VaultRow, thres
     # standard stablecoin history, while false ETH/BTC records use crypto history.
     result["stablecoinish"] = family is DenominationFamily.stablecoin
     result["wrapper_kind"] = "stablecoin" if family is DenominationFamily.stablecoin else wrapper_kind
+    if family is DenominationFamily.stablecoin:
+        # A mixed metrics DataFrame represents absent ETH/BTC values as NaN.
+        # Do not expose that implementation detail as a nullable USD metric.
+        result.pop("periodic_metrics_usd", None)
     result["current_total_assets"] = result.pop("current_nav", None)
     result["peak_total_assets"] = result.pop("peak_nav", None)
     result["qualification_threshold"] = float(threshold)
@@ -285,12 +334,146 @@ def _validate_crypto_price_rows(vault_db: VaultDatabase, prices_df: pd.DataFrame
         raise ValueError(f"Crypto cleaned prices contain unsupported denominations: {sorted(unsupported_vault_ids)!r}")
 
 
+def build_crypto_usd_conversion_context(
+    vault_db: VaultDatabase,
+    prices_df: pd.DataFrame,
+    exchange_rate_parquet_path: Path,
+) -> tuple[CryptoUSDConversionContext, dict[str, Any]]:
+    """Build effective USD rate curves and provenance for crypto metrics.
+
+    Currency API values are stored as quote units per USD. The provider label
+    for day ``D`` represents the value fetched around 00:00 UTC, so each raw
+    USD→ETH/BTC value becomes an effective USD price for ``D - 1``. Bounded
+    forward fill only bridges short provider gaps; metric calculation later
+    isolates the newest remaining contiguous segment.
+
+    :param vault_db:
+        Common vault metadata used to map vault IDs to denomination families.
+    :param prices_df:
+        Crypto cleaned prices with a naive UTC DatetimeIndex.
+    :param exchange_rate_parquet_path:
+        The verified cleaned exchange-rate snapshot used by this export.
+    :return:
+        Shared calculation context and JSON-serialisable provenance.
+    :raises FileNotFoundError:
+        If the shared exchange-rate snapshot is absent.
+    :raises ValueError:
+        If its schema does not support a reliable USD conversion.
+    """
+    if not exchange_rate_parquet_path.is_file():
+        raise FileNotFoundError(exchange_rate_parquet_path)
+    expected_columns = {"date", "base_currency", "quote_currency", "rate", "source"}
+    exchange_rates = pd.read_parquet(exchange_rate_parquet_path)
+    missing_columns = expected_columns - set(exchange_rates.columns)
+    if missing_columns:
+        raise ValueError(f"Exchange-rate Parquet is missing columns: {sorted(missing_columns)!r}")
+
+    vault_families = {spec.as_string_id(): family.value for spec, row in vault_db.rows.items() if (family := classify_denomination(row.get("Denomination"))) in {DenominationFamily.eth, DenominationFamily.btc}}
+    rate_rows = exchange_rates.loc[(exchange_rates["base_currency"] == "usd") & (exchange_rates["source"] == SOURCE_NAME) & exchange_rates["quote_currency"].isin(("eth", "btc"))].copy()
+    if rate_rows.empty:
+        raise ValueError("Exchange-rate Parquet has no fawazahmed0 USD→ETH/BTC rates")
+    rate_rows["date"] = pd.to_datetime(rate_rows["date"], errors="raise").dt.normalize()
+    rate_rows["rate"] = pd.to_numeric(rate_rows["rate"], errors="coerce")
+
+    price_end = prices_df.index.max().normalize()
+    family_builds = {family: _build_effective_usd_rate_series(family, rate_rows, price_end) for family in (DenominationFamily.eth.value, DenominationFamily.btc.value)}
+    rates_by_family = {family: build.rates for family, build in family_builds.items() if build.rates is not None}
+    errors_by_family = {family: build.error_reason for family, build in family_builds.items() if build.error_reason is not None}
+    coverage = {family: build.coverage for family, build in family_builds.items() if build.coverage is not None}
+
+    selected_rates = rate_rows.sort_values(["quote_currency", "date"], kind="stable").to_csv(index=False).encode("utf-8")
+    cleaning_policy = repr(KNOWN_BAD_RATES).encode("utf-8")
+    provenance = {
+        "provider": SOURCE_NAME,
+        "rate_parquet_filename": exchange_rate_parquet_path.name,
+        "rate_parquet_sha256": hashlib.sha256(exchange_rate_parquet_path.read_bytes()).hexdigest(),
+        "selected_rate_rows_sha256": hashlib.sha256(selected_rates).hexdigest(),
+        "cleaning_policy_sha256": hashlib.sha256(cleaning_policy).hexdigest(),
+        "stored_rate_direction": "quote units per USD",
+        "applied_rate_direction": "USD per ETH/BTC",
+        "effective_date_policy": "provider date minus one UTC day",
+        "forward_fill_limit_days": USD_RATE_FORWARD_FILL_DAYS,
+        "coverage": coverage,
+        "errors": errors_by_family,
+    }
+    context = CryptoUSDConversionContext(
+        rates_by_family=MappingProxyType(rates_by_family),
+        errors_by_family=MappingProxyType(errors_by_family),
+        vault_families=MappingProxyType(vault_families),
+    )
+    return context, provenance
+
+
+def _build_effective_usd_rate_series(
+    family: str,
+    rate_rows: pd.DataFrame,
+    price_end: pd.Timestamp,
+) -> USDExchangeRateSeriesBuild:
+    """Validate and regularise one ETH/BTC provider series.
+
+    :param family:
+        Canonical ``eth`` or ``btc`` denomination family.
+    :param rate_rows:
+        Cleaned USD-base provider rows for both supported families.
+    :param price_end:
+        Latest UTC date in the crypto price Parquet.
+    :return:
+        Validated rate-series build result.
+    """
+    family_rows = rate_rows.loc[rate_rows["quote_currency"] == family].sort_values("date", kind="stable")
+    if family_rows.empty:
+        return USDExchangeRateSeriesBuild(None, None, USD_RATE_ERROR_MISSING_SERIES)
+    raw_rates = family_rows["rate"]
+    minimum, maximum = USD_RATE_BOUNDS[family]
+    valid_rates = raw_rates.notna() & (raw_rates > 0)
+    usd_per_native = 1.0 / raw_rates.loc[valid_rates]
+    valid_rates.loc[valid_rates] &= usd_per_native.between(minimum, maximum)
+    rejected_rows = int((~valid_rates).sum())
+    family_rows = family_rows.loc[valid_rates].copy()
+    usd_per_native = usd_per_native.loc[usd_per_native.between(minimum, maximum)]
+    if family_rows.empty:
+        return USDExchangeRateSeriesBuild(None, None, USD_RATE_ERROR_INVALID_SERIES)
+
+    effective_dates = family_rows["date"] - pd.Timedelta(days=1)
+    if effective_dates.duplicated().any():
+        return USDExchangeRateSeriesBuild(None, None, USD_RATE_ERROR_INVALID_SERIES)
+    raw_effective_rates = pd.Series(usd_per_native.to_numpy(), index=effective_dates, dtype="float64").sort_index()
+    if price_end < raw_effective_rates.index.min():
+        coverage = {
+            "provider_observation_start": family_rows["date"].min().date().isoformat(),
+            "provider_observation_end": family_rows["date"].max().date().isoformat(),
+            "effective_observation_start": None,
+            "effective_observation_end": None,
+            "provider_rows": len(family_rows),
+            "rejected_provider_rows": rejected_rows,
+            "covered_effective_days": 0,
+            "usd_per_underlying_min": float(usd_per_native.min()),
+            "usd_per_underlying_max": float(usd_per_native.max()),
+        }
+        return USDExchangeRateSeriesBuild(None, coverage, USD_RATE_ERROR_INSUFFICIENT_COVERAGE)
+    effective_index = pd.date_range(raw_effective_rates.index.min(), price_end, freq="D")
+    effective_rates = raw_effective_rates.reindex(effective_index).ffill(limit=USD_RATE_FORWARD_FILL_DAYS)
+    coverage = {
+        "provider_observation_start": family_rows["date"].min().date().isoformat(),
+        "provider_observation_end": family_rows["date"].max().date().isoformat(),
+        "effective_observation_start": effective_rates.index.min().date().isoformat(),
+        "effective_observation_end": effective_rates.index.max().date().isoformat(),
+        "provider_rows": len(family_rows),
+        "rejected_provider_rows": rejected_rows,
+        "covered_effective_days": int(effective_rates.notna().sum()),
+        "usd_per_underlying_min": float(usd_per_native.min()),
+        "usd_per_underlying_max": float(usd_per_native.max()),
+    }
+    return USDExchangeRateSeriesBuild(effective_rates, coverage, None)
+
+
 def build_crypto_vault_metadata(
     *,
     vault_db_path: Path,
     cleaned_price_path: Path,
     metadata_path: Path,
     sticky_state_path: Path,
+    exchange_rate_parquet_path: Path | None = None,
     threshold_usd: Decimal | None = None,
 ) -> dict[str, Any]:
     """Calculate and atomically persist private crypto-vault metadata.
@@ -307,6 +490,10 @@ def build_crypto_vault_metadata(
         Crypto metadata JSON destination.
     :param sticky_state_path:
         Crypto sticky-state JSON destination.
+    :param exchange_rate_parquet_path:
+        Optional verified snapshot used to add USD period metrics to ETH/BTC
+        vaults. Stablecoin records deliberately do not get a duplicate USD
+        metric view.
     :param threshold_usd:
         Optional fixed USD guideline; defaults to environment/config value.
     :return:
@@ -320,7 +507,19 @@ def build_crypto_vault_metadata(
         prices_df["timestamp"] = pd.to_datetime(prices_df["timestamp"])
         prices_df.set_index("timestamp", inplace=True)
     _validate_crypto_price_rows(vault_db, prices_df)
-    metrics_df = calculate_lifetime_metrics(prices_df, vault_db)
+    crypto_usd_conversion_context = None
+    usd_metrics_provenance = None
+    if exchange_rate_parquet_path is not None:
+        crypto_usd_conversion_context, usd_metrics_provenance = build_crypto_usd_conversion_context(
+            vault_db,
+            prices_df,
+            exchange_rate_parquet_path,
+        )
+    metrics_df = calculate_lifetime_metrics(
+        prices_df,
+        vault_db,
+        crypto_usd_conversion_context=crypto_usd_conversion_context,
+    )
     state = _load_sticky_state(sticky_state_path)
     selected_records: list[dict[str, Any]] = []
     current_ids: set[str] = set()
@@ -355,6 +554,8 @@ def build_crypto_vault_metadata(
         "fixed_usd_rates": {"ETH": float(ETH_USD_GUIDELINE_RATE), "BTC": float(BTC_USD_GUIDELINE_RATE)},
         "vaults": selected_records,
     }
+    if usd_metrics_provenance is not None:
+        metadata["usd_metrics"] = usd_metrics_provenance
     _save_json_atomic(metadata, metadata_path)
     _save_json_atomic(state, sticky_state_path)
     return metadata

--- a/eth_defi/vault/data_file_export.py
+++ b/eth_defi/vault/data_file_export.py
@@ -9,22 +9,26 @@ import logging
 import os
 from pathlib import Path
 
+import duckdb
+import pyarrow as pa
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.cloudflare_r2 import copy_r2_object_daily_backup, create_r2_client, upload_file_to_r2
 from eth_defi.core3.constants import resolve_core3_database_path
 from eth_defi.currency_api.constants import CURRENCY_API_DATABASE
-from eth_defi.xerberus.constants import resolve_xerberus_database_path
+from eth_defi.currency_api.parquet import materialise_exchange_rate_parquet
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.settlement_data import (
     VAULT_SETTLEMENT_DATABASE_FILENAME,
     checkpoint_vault_settlement_database_if_exists,
 )
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
+from eth_defi.xerberus.constants import resolve_xerberus_database_path
 
 logger = logging.getLogger(__name__)
 
 EXCHANGE_RATE_DATABASE_FILENAME = "exchange-rates.duckdb"
+EXCHANGE_RATE_PARQUET_FILENAME = "exchange-rates.parquet"
 
 
 def resolve_exchange_rate_database_path(base_path: Path | None = None) -> Path:
@@ -50,11 +54,29 @@ def resolve_exchange_rate_database_path(base_path: Path | None = None) -> Path:
     return CURRENCY_API_DATABASE
 
 
+def resolve_exchange_rate_parquet_path(base_path: Path) -> Path:
+    """Resolve the cleaned exchange-rate Parquet destination.
+
+    The currency API DuckDB database may be kept outside pipeline state through
+    ``CURRENCY_API_DB_PATH``. The flat exported Parquet always belongs below the
+    selected pipeline data directory so its R2 key stays stable.
+
+    :param base_path:
+        Active pipeline data directory.
+    :return:
+        Destination path for ``exchange-rates.parquet``.
+    """
+    return base_path / EXCHANGE_RATE_PARQUET_FILENAME
+
+
 def get_data_file_paths(
     base_path: Path,
     core3_db_path: Path | None = None,
     exchange_rate_db_path: Path | None = None,
     xerberus_db_path: Path | None = None,
+    *,
+    exchange_rate_parquet_path: Path | None = None,
+    include_exchange_rate_parquet: bool = True,
 ) -> list[Path]:
     """Build the data file list uploaded to R2.
 
@@ -66,13 +88,18 @@ def get_data_file_paths(
         Optional exchange-rate DuckDB path override.
     :param xerberus_db_path:
         Optional Xerberus DuckDB path override.
+    :param exchange_rate_parquet_path:
+        Optional already materialised cleaned exchange-rate Parquet path.
+    :param include_exchange_rate_parquet:
+        Include the cleaned Parquet when its materialisation succeeded for this
+        run. Set false to avoid re-uploading a stale prior file after a failure.
     :return:
         Files to upload, including optional files that may be skipped later
         if they do not exist.
     """
     sticky_export_state_paths = [base_path / "vault-export-state.json"]
     exchange_rate_path = exchange_rate_db_path or resolve_exchange_rate_database_path(base_path)
-    return [
+    paths = [
         base_path / "vault-prices-1h.parquet",
         base_path / "cleaned-vault-prices-1h.parquet",
         base_path / "vault-metadata-db.pickle",
@@ -83,6 +110,9 @@ def get_data_file_paths(
         exchange_rate_path,
         *sticky_export_state_paths,
     ]
+    if include_exchange_rate_parquet:
+        paths.append(exchange_rate_parquet_path or resolve_exchange_rate_parquet_path(base_path))
+    return paths
 
 
 def upload_files_to_r2(  # noqa: PLR0917
@@ -183,12 +213,68 @@ def upload_files_to_r2(  # noqa: PLR0917
     return uploaded_count
 
 
-def main() -> None:
+def publish_exchange_rate_parquet_to_alternative_bucket(parquet_path: Path) -> None:
+    """Publish one verified exchange-rate Parquet to the private data bucket.
+
+    The focused crypto exporter uses this before its metadata bundle is made
+    current. It shares the flat key, upload prefix and daily-backup convention
+    with the complete data-file export without uploading unrelated vault files.
+
+    :param parquet_path:
+        Existing verified ``exchange-rates.parquet`` snapshot.
+    :return:
+        ``None`` after upload and optional daily backup.
+    :raises FileNotFoundError:
+        If the supplied local snapshot does not exist.
+    :raises AssertionError:
+        If private R2 configuration is incomplete.
+    """
+    if not parquet_path.is_file():
+        raise FileNotFoundError(parquet_path)
+
+    bucket_name = os.environ.get("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME")
+    access_key_id = os.environ.get("R2_DATA_ACCESS_KEY_ID") or os.environ.get("R2_VAULT_METADATA_ACCESS_KEY_ID")
+    secret_access_key = os.environ.get("R2_DATA_SECRET_ACCESS_KEY") or os.environ.get("R2_VAULT_METADATA_SECRET_ACCESS_KEY")
+    endpoint_url = os.environ.get("R2_DATA_ENDPOINT_URL") or os.environ.get("R2_VAULT_METADATA_ENDPOINT_URL")
+    assert bucket_name, "R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME is required"
+    assert access_key_id, "R2 data access key is required"
+    assert secret_access_key, "R2 data secret key is required"
+    assert endpoint_url, "R2 data endpoint URL is required"
+
+    client = create_r2_client(
+        endpoint_url=endpoint_url,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+    object_key = f"{os.environ.get('UPLOAD_PREFIX', '')}{parquet_path.name}"
+    upload_file_to_r2(
+        s3_client=client,
+        file_path=parquet_path,
+        bucket_name=bucket_name,
+        object_name=object_key,
+        skip_if_current=True,
+    )
+    if os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false":
+        copy_r2_object_daily_backup(client, bucket_name, object_key)
+
+
+def main(
+    exchange_rate_parquet_path: Path | None = None,
+    exchange_rate_parquet_error: Exception | None = None,
+) -> None:
     """Run the data file export script.
 
     Reads R2 configuration from environment variables, uploads vault data
-    files to configured buckets, and creates daily backups in the
-    alternative bucket when enabled.
+    files to configured buckets, and creates daily backups in the alternative
+    bucket when enabled. A scheduled caller can supply the exact Parquet
+    snapshot already used for crypto USD metrics. Standalone use materialises a
+    fresh snapshot before upload.
+
+    :param exchange_rate_parquet_path:
+        Optional verified Parquet snapshot created earlier in this scan cycle.
+    :param exchange_rate_parquet_error:
+        Earlier materialisation failure. Unrelated files still upload, after
+        which this error is propagated and stale Parquet is omitted.
     """
     setup_console_logging(
         log_file=Path("logs/export-data-files.log"),
@@ -216,7 +302,21 @@ def main() -> None:
         logger.info("Alternative bucket configured: %s", alt_bucket_name)
 
     base_path = get_pipeline_data_dir()
-    paths = get_data_file_paths(base_path)
+    if exchange_rate_parquet_path is None and exchange_rate_parquet_error is None:
+        try:
+            exchange_rate_parquet_path = materialise_exchange_rate_parquet(
+                source_path=resolve_exchange_rate_database_path(base_path),
+                destination_path=resolve_exchange_rate_parquet_path(base_path),
+            ).path
+        except (duckdb.Error, FileNotFoundError, KeyError, OSError, TypeError, ValueError, pa.ArrowException) as exc:
+            logger.exception("Exchange-rate Parquet materialisation failed")
+            exchange_rate_parquet_error = exc
+
+    paths = get_data_file_paths(
+        base_path,
+        exchange_rate_parquet_path=exchange_rate_parquet_path,
+        include_exchange_rate_parquet=exchange_rate_parquet_error is None,
+    )
     checkpoint_vault_settlement_database_if_exists(base_path / VAULT_SETTLEMENT_DATABASE_FILENAME)
 
     print("\nExporting data files to R2")
@@ -271,3 +371,6 @@ def main() -> None:
                 backup_created,
                 backup_skipped,
             )
+
+    if exchange_rate_parquet_error is not None:
+        raise exchange_rate_parquet_error

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     brotli = None
 
+import duckdb
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -27,7 +28,8 @@ import pyarrow.parquet as pq
 from eth_defi.apex.constants import APEX_CHAIN_ID, APEX_METRICS_DATABASE
 from eth_defi.apex.metrics import ApexMetricsDatabase
 from eth_defi.apex.vault_data_export import build_raw_prices_dataframe as build_apex_prices_dataframe
-from eth_defi.cloudflare_r2 import R2RetryableOperationError, calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
+from eth_defi.cloudflare_r2 import R2OperationError, R2RetryableOperationError, calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
+from eth_defi.currency_api.parquet import materialise_exchange_rate_parquet
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
 from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.grvt.vault_data_export import build_raw_prices_dataframe as build_grvt_prices_dataframe
@@ -50,6 +52,11 @@ from eth_defi.vault import top_vaults_json
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.crypto_vault_export import publish_crypto_vault_bundle
 from eth_defi.vault.crypto_vaults import CryptoVaultPaths, build_crypto_vault_metadata, build_crypto_vault_prices, resolve_crypto_vault_paths
+from eth_defi.vault.data_file_export import (
+    publish_exchange_rate_parquet_to_alternative_bucket,
+    resolve_exchange_rate_database_path,
+    resolve_exchange_rate_parquet_path,
+)
 from eth_defi.vault.sample_export import export_sample_files_to_r2
 from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, get_pipeline_data_dir
 
@@ -806,6 +813,7 @@ def calculate_crypto_vault_metadata(
     *,
     vault_db_path: Path,
     paths: CryptoVaultPaths,
+    exchange_rate_parquet_path: Path,
 ) -> dict[str, Any] | None:
     """Calculate isolated crypto metadata while containing phase failures.
 
@@ -813,6 +821,8 @@ def calculate_crypto_vault_metadata(
         Common vault metadata pickle.
     :param paths:
         Explicit crypto bundle paths.
+    :param exchange_rate_parquet_path:
+        Verified exchange-rate snapshot shared with the R2 data export.
     :return:
         Metadata document, or ``None`` after a contained failure.
     """
@@ -822,6 +832,7 @@ def calculate_crypto_vault_metadata(
             cleaned_price_path=paths.cleaned_price_path,
             metadata_path=paths.metadata_path,
             sticky_state_path=paths.sticky_state_path,
+            exchange_rate_parquet_path=exchange_rate_parquet_path,
         )
     except Exception:
         logger.exception("Crypto vault metadata calculation failed")
@@ -842,6 +853,22 @@ def export_crypto_vault_bundle(paths: CryptoVaultPaths, metadata: dict[str, Any]
         return publish_crypto_vault_bundle(paths, metadata)
     except Exception:
         logger.exception("Crypto vault bundle export failed")
+        return False
+
+
+def export_crypto_exchange_rate_parquet(parquet_path: Path) -> bool:
+    """Publish the crypto bundle's rate snapshot without stopping public work.
+
+    :param parquet_path:
+        Verified local exchange-rate Parquet used for USD metric calculation.
+    :return:
+        ``True`` when the private rate snapshot and its backup were published.
+    """
+    try:
+        publish_exchange_rate_parquet_to_alternative_bucket(parquet_path)
+        return True
+    except (AssertionError, FileNotFoundError, OSError, R2OperationError):
+        logger.exception("Crypto exchange-rate Parquet export failed")
         return False
 
 
@@ -881,9 +908,18 @@ def export_protocol_metadata() -> bool:
         return False
 
 
-def export_data_files() -> bool:
+def export_data_files(
+    exchange_rate_parquet_path: Path | None = None,
+    exchange_rate_parquet_error: Exception | None = None,
+) -> bool:
     """Export database files (parquet, pickle, DuckDB) to R2.
 
+    :param exchange_rate_parquet_path:
+        Optional exact snapshot used by the crypto USD metrics phase.
+    :param exchange_rate_parquet_error:
+        Earlier snapshot materialisation error. The export uploads unrelated
+        data and then reports this phase as failed without publishing stale
+        exchange-rate Parquet.
     :return: True if export succeeded
     """
     try:
@@ -891,7 +927,10 @@ def export_data_files() -> bool:
         spec = importlib.util.spec_from_file_location("export_data_files", "scripts/erc-4626/export-data-files.py")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        module.main()
+        module.main(
+            exchange_rate_parquet_path=exchange_rate_parquet_path,
+            exchange_rate_parquet_error=exchange_rate_parquet_error,
+        )
         logger.info("Data file export complete")
         return True
     except R2RetryableOperationError as exc:
@@ -1216,6 +1255,22 @@ def run_post_processing(
     )
     steps["clean-crypto-vault-prices"] = crypto_clean_ok
 
+    # The crypto USD metrics and R2 data-file export must share one immutable
+    # local snapshot. A currency failure is isolated like crypto cleaning: it
+    # cannot prevent public exports, but it blocks crypto metadata publication.
+    exchange_rate_parquet_path = None
+    exchange_rate_parquet_error = None
+    try:
+        exchange_rate_parquet_path = materialise_exchange_rate_parquet(
+            source_path=resolve_exchange_rate_database_path(data_dir),
+            destination_path=resolve_exchange_rate_parquet_path(data_dir),
+        ).path
+        steps["materialise-exchange-rate-parquet"] = True
+    except (duckdb.Error, FileNotFoundError, KeyError, OSError, TypeError, ValueError, pa.ArrowException) as exc:
+        logger.exception("Exchange-rate Parquet materialisation failed")
+        exchange_rate_parquet_error = exc
+        steps["materialise-exchange-rate-parquet"] = False
+
     # Export top vaults JSON. This depends on cleaned Parquet and must run before
     # the public data-file upload.
     if skip_top_vaults:
@@ -1232,17 +1287,18 @@ def run_post_processing(
         )
 
     crypto_metadata = None
-    if crypto_clean_ok and cleaning_ok:
+    if crypto_clean_ok and cleaning_ok and exchange_rate_parquet_path is not None:
         crypto_metadata = calculate_crypto_vault_metadata(
             vault_db_path=resolved_vault_db_path,
             paths=crypto_paths,
+            exchange_rate_parquet_path=exchange_rate_parquet_path,
         )
         steps["calculate-crypto-vault-metadata"] = crypto_metadata is not None
     elif not crypto_clean_ok:
         logger.warning("Skipping crypto metadata — crypto cleaning failed")
         steps["calculate-crypto-vault-metadata"] = False
     else:
-        logger.warning("Skipping crypto metadata and publication — clean-prices failed, refusing to publish stale stablecoin data")
+        logger.warning("Skipping crypto metadata — no current exchange-rate snapshot or clean price input")
         steps["calculate-crypto-vault-metadata"] = False
 
     # Export sparklines.
@@ -1268,7 +1324,10 @@ def run_post_processing(
         logger.warning("Skipping data file export — clean_prices failed, refusing to export stale data")
         steps["export-data-files"] = False
     else:
-        steps["export-data-files"] = export_data_files()
+        steps["export-data-files"] = export_data_files(
+            exchange_rate_parquet_path=exchange_rate_parquet_path,
+            exchange_rate_parquet_error=exchange_rate_parquet_error,
+        )
 
     # Export Ethereum-only sample files to the public bucket.
     if skip_samples:
@@ -1295,8 +1354,18 @@ def run_post_processing(
                 skip_json_sample=not json_ok,
             )
 
+    crypto_rate_published = bool(steps.get("export-data-files"))
+    if not crypto_rate_published and exchange_rate_parquet_path is not None:
+        # ``SKIP_DATA=true`` and public-data export failures must not prevent
+        # the independent private bundle. Publish the exact local snapshot
+        # before making crypto metadata current.
+        crypto_rate_published = export_crypto_exchange_rate_parquet(exchange_rate_parquet_path)
+
     if crypto_metadata is None:
         logger.warning("Skipping crypto bundle publication — crypto metadata was not generated")
+        steps["export-crypto-vault-bundle"] = False
+    elif not crypto_rate_published:
+        logger.warning("Skipping crypto bundle publication — exchange-rate snapshot was not published to the private bucket")
         steps["export-crypto-vault-bundle"] = False
     else:
         steps["export-crypto-vault-bundle"] = export_crypto_vault_bundle(crypto_paths, crypto_metadata)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -203,6 +203,21 @@ unit aliases are added: ``denomination`` is also the unit for
 Shared period ranking fields are left unset because USD-gated rankings across
 stablecoin, ETH and BTC native units would not be comparable.
 
+ETH/BTC records additionally contain ``periodic_metrics_usd``. It has the same
+per-period shape as ``period_results`` but converts native share-price and TVL
+bars using the canonical ETH/BTC USD rate; it is JSON-only and does not change
+the crypto Parquet schema or the established native CAGR fields. The metadata
+``usd_metrics`` section records the exact cleaned ``exchange-rates.parquet``
+snapshot, rate direction, effective-date convention and bounded-fill coverage.
+Each USD period also includes ``exchange_rate_start`` and
+``exchange_rate_end`` in USD per canonical underlying unit (for example, the
+Bitcoin prices used for a BTC vault's period endpoints).
+The provider date ``D`` is applied to the preceding UTC vault day ``D - 1``;
+gaps are forward filled for at most three days, after which USD calculations
+use only the latest contiguous covered window. Consequently, a later long
+provider gap restarts the USD lifetime view and excludes earlier rate history.
+This is a provider-snapshot guideline, not a wrapper redemption oracle.
+
 Only the configured alternative R2 bucket receives this bundle. Its objects use
 flat root keys with the ``crypto-`` prefix, such as
 ``crypto-cleaned-vault-prices-1d.parquet``, ``crypto-vault-metadata.json`` and
@@ -244,7 +259,8 @@ when the private R2 bucket is intentionally unavailable.
 
 Afterwards, inspect the local artefacts without network access. The report
 lists ETH- and BTC-denominated vault name, protocol, denomination token,
-lifetime CAGR, native-unit TVL and approximate USD-equivalent TVL. It reads the
+base and USD lifetime CAGR, the USD metric start date, native-unit TVL and
+approximate USD-equivalent TVL. It reads the
 latest ETH and BTC rates from the local currency API DuckDB database and treats
 each wrapper as its canonical underlying; this is a comparison estimate, not a
 wrapper redemption valuation. Stablecoin and blacklisted vaults, plus values

--- a/scripts/erc-4626/examine-crypto-vault-performance.py
+++ b/scripts/erc-4626/examine-crypto-vault-performance.py
@@ -2,9 +2,10 @@
 
 The report reads the exported metadata and daily price Parquet, checks their
 basic identities and prints ETH- and BTC-denominated vault name, protocol,
-denomination token, lifetime CAGR and current TVL. The USD figure uses the
-latest local currency API ETH/BTC rate and treats each wrapper as its canonical
-underlying. It is a comparison estimate, not a wrapper redemption valuation.
+denomination token, native and USD lifetime CAGR, and current TVL. The USD TVL
+figure uses the latest local currency API ETH/BTC rate and treats each wrapper
+as its canonical underlying. It is a comparison estimate, not a wrapper
+redemption valuation.
 
 Environment variables:
 
@@ -42,6 +43,49 @@ def _get_lifetime_cagr(vault: dict[str, Any]) -> float | None:
         Net lifetime CAGR, gross lifetime CAGR or ``None``.
     """
     return vault.get("cagr_net") if vault.get("cagr_net") is not None else vault.get("cagr")
+
+
+def _get_lifetime_usd_cagr(vault: dict[str, Any]) -> float | None:
+    """Choose the net USD lifetime CAGR from converted period metrics.
+
+    The crypto export keeps its established native CAGR fields untouched. This
+    value comes from the optional USD period view, which applies the rate
+    snapshot pinned in the metadata document.
+
+    :param vault:
+        One JSON ETH/BTC vault-metadata record.
+    :return:
+        Net USD lifetime CAGR, gross USD CAGR or ``None`` when unavailable.
+    """
+    usd_metrics = vault.get("periodic_metrics_usd")
+    if usd_metrics is None:
+        return None
+    lifetime = next((metric for metric in usd_metrics if metric.get("period") == "lifetime"), None)
+    if lifetime is None or lifetime.get("error_reason") is not None:
+        return None
+    cagr = lifetime.get("cagr_net") if lifetime.get("cagr_net") is not None else lifetime.get("cagr_gross")
+    if cagr is None:
+        message = f"USD lifetime metric is missing CAGR fields for {vault['id']}"
+        raise ValueError(message)
+    return cagr
+
+
+def _get_lifetime_usd_start(vault: dict[str, Any]) -> str | None:
+    """Return the effective USD lifetime sample start for comparison.
+
+    :param vault:
+        One JSON ETH/BTC vault-metadata record.
+    :return:
+        ISO timestamp for the USD lifetime sample start, or ``None``.
+    """
+    usd_metrics = vault.get("periodic_metrics_usd")
+    if usd_metrics is None:
+        return None
+    lifetime = next((metric for metric in usd_metrics if metric.get("period") == "lifetime"), None)
+    if lifetime is None or lifetime.get("error_reason") is not None:
+        return None
+    value = lifetime.get("samples_start_at")
+    return str(value) if value is not None else None
 
 
 def _format_tvl(vault: dict[str, Any]) -> str:
@@ -115,7 +159,9 @@ def build_performance_table(metadata: dict[str, Any], usd_rates: dict[str, tuple
                 "Vault name": vault.get("name") or vault.get("symbol") or vault["id"],
                 "Protocol": vault.get("protocol") or "Unknown",
                 "Denomination token": vault.get("denomination") or "Unknown",
-                "Lifetime CAGR": _get_lifetime_cagr(vault),
+                "Lifetime CAGR (base)": _get_lifetime_cagr(vault),
+                "Lifetime CAGR (USD)": _get_lifetime_usd_cagr(vault),
+                "USD from": _get_lifetime_usd_start(vault),
                 "TVL": _format_tvl(vault),
                 "Approx. TVL (USD)": float(vault.get("current_total_assets") or 0) * usd_rate,
                 "USD rate as of": rate_date,
@@ -123,7 +169,7 @@ def build_performance_table(metadata: dict[str, Any], usd_rates: dict[str, tuple
         )
     table = pd.DataFrame(rows)
     if table.empty:
-        return table.reindex(columns=["Vault name", "Protocol", "Denomination token", "Lifetime CAGR", "TVL", "Approx. TVL (USD)", "USD rate as of"])
+        return table.reindex(columns=["Vault name", "Protocol", "Denomination token", "Lifetime CAGR (base)", "Lifetime CAGR (USD)", "USD from", "TVL", "Approx. TVL (USD)", "USD rate as of"])
     return table.sort_values(["Approx. TVL (USD)", "Vault name"], ascending=[False, True], kind="stable")
 
 
@@ -190,7 +236,9 @@ def main() -> None:
     if limit:
         table = table.head(limit)
     display_table = table.copy()
-    display_table["Lifetime CAGR"] = display_table["Lifetime CAGR"].map(lambda value: "N/A" if pd.isna(value) else f"{value:.2%}")
+    for column in ("Lifetime CAGR (base)", "Lifetime CAGR (USD)"):
+        display_table[column] = display_table[column].map(lambda value: "N/A" if pd.isna(value) else f"{value:.2%}")
+    display_table["USD from"] = display_table["USD from"].fillna("N/A")
     display_table["Approx. TVL (USD)"] = display_table["Approx. TVL (USD)"].map(lambda value: f"${value:,.0f}")
     print(tabulate(display_table, headers="keys", tablefmt="rounded_outline", showindex=False))
 

--- a/scripts/erc-4626/export-crypto-vaults.py
+++ b/scripts/erc-4626/export-crypto-vaults.py
@@ -16,6 +16,9 @@ Environment variables:
 - ``CRYPTO_VAULTS_DIRECTORY``: Local private bundle directory. Defaults to
   ``crypto-vaults`` below the pipeline data directory.
 - ``SETTLEMENT_DATABASE``: Optional vault settlement DuckDB database.
+- ``CURRENCY_API_DB_PATH`` / ``CURRENCY_API_DATABASE_PATH``: Source
+  exchange-rate DuckDB database. Defaults to ``exchange-rates.duckdb`` below
+  the pipeline data directory.
 - ``CRYPTO_VAULTS_MIN_TVL_USD``: Fixed USD low-TVL guideline.
 - ``CRYPTO_VAULTS_PUBLISH``: Set to ``false`` to build local artefacts without
   uploading them to R2. Defaults to ``true``.
@@ -31,12 +34,18 @@ from pathlib import Path
 
 from tabulate import tabulate
 
+from eth_defi.currency_api.parquet import materialise_exchange_rate_parquet
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.crypto_vault_export import publish_crypto_vault_bundle
 from eth_defi.vault.crypto_vaults import (
     build_crypto_vault_metadata,
     build_crypto_vault_prices,
     resolve_crypto_vault_paths,
+)
+from eth_defi.vault.data_file_export import (
+    publish_exchange_rate_parquet_to_alternative_bucket,
+    resolve_exchange_rate_database_path,
+    resolve_exchange_rate_parquet_path,
 )
 from eth_defi.vault.settlement_data import get_default_vault_settlement_database_path
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
@@ -91,14 +100,22 @@ def main() -> None:
         cleaned_stablecoin_path=cleaned_stablecoin_path,
         settlement_db_path=settlement_db_path,
     )
+    exchange_rate_parquet_path = materialise_exchange_rate_parquet(
+        source_path=resolve_exchange_rate_database_path(data_dir),
+        destination_path=resolve_exchange_rate_parquet_path(data_dir),
+    ).path
     metadata = build_crypto_vault_metadata(
         vault_db_path=vault_db_path,
         cleaned_price_path=crypto_paths.cleaned_price_path,
         metadata_path=crypto_paths.metadata_path,
         sticky_state_path=crypto_paths.sticky_state_path,
+        exchange_rate_parquet_path=exchange_rate_parquet_path,
     )
     publish = os.environ.get("CRYPTO_VAULTS_PUBLISH", "true").lower() != "false"
     if publish:
+        # Publish and back up the exact rate snapshot first. Consumers never
+        # observe a metadata generation whose USD metrics lack rate artefacts.
+        publish_exchange_rate_parquet_to_alternative_bucket(exchange_rate_parquet_path)
         publish_crypto_vault_bundle(crypto_paths, metadata)
         logger.info("Published private crypto-vaults bundle with %d vaults", len(metadata["vaults"]))
     else:

--- a/tests/currency_api/test_parquet.py
+++ b/tests/currency_api/test_parquet.py
@@ -1,0 +1,77 @@
+"""Focused tests for cleaned currency API Parquet materialisation."""
+
+import datetime
+from pathlib import Path
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from eth_defi.currency_api.constants import SOURCE_NAME
+from eth_defi.currency_api.parquet import EXCHANGE_RATE_PARQUET_SCHEMA, materialise_exchange_rate_parquet
+
+EXPECTED_CLEANED_ROW_COUNT = 2
+
+
+def _create_exchange_rate_database(path: Path) -> None:
+    """Create a small raw exchange-rate database for Parquet tests.
+
+    :param path:
+        DuckDB destination.
+    :return:
+        ``None`` after writing raw provider rows.
+    """
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE exchange_rates (
+                date DATE NOT NULL,
+                base_currency VARCHAR NOT NULL,
+                quote_currency VARCHAR NOT NULL,
+                rate DOUBLE NOT NULL,
+                source VARCHAR NOT NULL,
+                written_at TIMESTAMP
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO exchange_rates VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (datetime.date(2025, 12, 5), "usd", "eth", 0.0005, SOURCE_NAME, datetime.datetime.fromisoformat("2025-12-05T00:01:00")),
+                (datetime.date(2025, 12, 6), "usd", "eth", 49_644.07797781, SOURCE_NAME, datetime.datetime.fromisoformat("2025-12-06T00:01:00")),
+                (datetime.date(2025, 12, 6), "usd", "btc", 38.87461377, SOURCE_NAME, datetime.datetime.fromisoformat("2025-12-06T00:01:00")),
+                (datetime.date(2025, 12, 5), "usd", "eur", 0.91, SOURCE_NAME, datetime.datetime.fromisoformat("2025-12-05T00:01:00")),
+            ],
+        )
+    finally:
+        connection.close()
+
+
+def test_materialise_exchange_rate_parquet_is_cleaned_deterministic_and_read_only(tmp_path: Path) -> None:
+    """Export exactly typed source-rate rows without mutating the DuckDB input.
+
+    :param tmp_path:
+        Isolated temporary directory supplied by pytest.
+    """
+    source_path = tmp_path / "source" / "exchange-rates.duckdb"
+    source_path.parent.mkdir()
+    _create_exchange_rate_database(source_path)
+    source_bytes = source_path.read_bytes()
+    destination_path = tmp_path / "pipeline" / "exchange-rates.parquet"
+
+    first = materialise_exchange_rate_parquet(source_path, destination_path)
+    first_bytes = destination_path.read_bytes()
+    second = materialise_exchange_rate_parquet(source_path, destination_path)
+
+    table = pq.read_table(destination_path)
+    assert table.schema == EXCHANGE_RATE_PARQUET_SCHEMA
+    assert table.column("date").type == pa.date32()
+    assert table.column("written_at").type == pa.timestamp("us")
+    assert first.row_count == EXPECTED_CLEANED_ROW_COUNT
+    assert first.sha256 == second.sha256
+    assert first_bytes == destination_path.read_bytes()
+    assert source_path.read_bytes() == source_bytes
+    assert table.to_pydict()["quote_currency"] == ["eth", "eur"]
+    assert table.to_pydict()["rate"] == [0.0005, 0.91]
+    assert not list(destination_path.parent.glob(".exchange-rates-*.parquet"))

--- a/tests/erc_4626/test_export_data_files.py
+++ b/tests/erc_4626/test_export_data_files.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.vault import data_file_export
 from eth_defi.vault.settlement_data import VAULT_SETTLEMENT_DATABASE_FILENAME, VaultSettlementDatabase
 
@@ -12,8 +13,8 @@ def write_export_test_file(path: Path) -> None:
     """Create a valid export fixture file.
 
     Most export files can be byte placeholders because upload tests mock the
-    R2 calls. The settlement database is checkpointed before export, so it must
-    be a valid DuckDB file instead of arbitrary bytes.
+    R2 calls. Settlement data is checkpointed and exchange rates are converted
+    to Parquet before export, so both need valid DuckDB files.
 
     :param path:
         File path to create.
@@ -25,6 +26,9 @@ def write_export_test_file(path: Path) -> None:
             db.save()
         finally:
             db.close()
+    elif path.name == data_file_export.EXCHANGE_RATE_DATABASE_FILENAME:
+        db = CurrencyRateDatabase(path)
+        db.close()
     else:
         path.write_bytes(b"data")
 

--- a/tests/erc_4626/test_export_data_files.py
+++ b/tests/erc_4626/test_export_data_files.py
@@ -59,6 +59,13 @@ def test_exchange_rate_duckdb_defaults_to_pipeline_data_dir(tmp_path: Path, monk
     assert tmp_path / "exchange-rates.duckdb" in paths
 
 
+def test_exchange_rate_parquet_defaults_to_pipeline_data_dir(tmp_path: Path) -> None:
+    """Cleaned exchange-rate Parquet uses the stable flat data-export name."""
+    paths = data_file_export.get_data_file_paths(tmp_path)
+
+    assert tmp_path / "exchange-rates.parquet" in paths
+
+
 def test_exchange_rate_duckdb_path_accepts_currency_api_database_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Exchange-rate DuckDB upload follows the currency API scanner path contract."""
     exchange_rate_path = tmp_path / "rates.duckdb"
@@ -219,3 +226,51 @@ def test_exchange_rate_duckdb_upload_gets_alternative_daily_backup(
     assert ("private-bucket", "exchange-rates.duckdb") in uploaded
     assert ("private-bucket", "exchange-rates.duckdb") in backups
     assert all(bucket == "private-bucket" for bucket, _ in backups)
+
+
+def test_exchange_rate_parquet_upload_gets_alternative_daily_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The verified Parquet snapshot follows the existing private backup path."""
+    exchange_rate_parquet_path = tmp_path / "exchange-rates.parquet"
+    exchange_rate_parquet_path.write_bytes(b"verified rate snapshot")
+    core3_path = tmp_path / "core3" / "core3.duckdb"
+    for path in data_file_export.get_data_file_paths(
+        tmp_path,
+        core3_db_path=core3_path,
+        exchange_rate_parquet_path=exchange_rate_parquet_path,
+    ):
+        if path != exchange_rate_parquet_path:
+            write_export_test_file(path)
+
+    monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("R2_DATA_BUCKET_NAME", "public-bucket")
+    monkeypatch.setenv("R2_DATA_ACCESS_KEY_ID", "access")
+    monkeypatch.setenv("R2_DATA_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("R2_DATA_ENDPOINT_URL", "https://example.invalid")
+    monkeypatch.setenv("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME", "private-bucket")
+    monkeypatch.setenv("R2_DAILY_BACKUP", "true")
+
+    uploaded: list[tuple[str, str]] = []
+    backups: list[tuple[str, str]] = []
+
+    def fake_upload_file_to_r2(*, bucket_name: str, object_name: str, **_: object) -> bool:
+        uploaded.append((bucket_name, object_name))
+        return True
+
+    def fake_copy_r2_object_daily_backup(_s3_client: object, bucket_name: str, source_key: str) -> bool:
+        backups.append((bucket_name, source_key))
+        return True
+
+    monkeypatch.setattr(data_file_export, "create_r2_client", lambda **_: object())
+    monkeypatch.setattr(data_file_export, "upload_file_to_r2", fake_upload_file_to_r2)
+    monkeypatch.setattr(data_file_export, "copy_r2_object_daily_backup", fake_copy_r2_object_daily_backup)
+
+    data_file_export.main(exchange_rate_parquet_path=exchange_rate_parquet_path)
+    capsys.readouterr()
+
+    assert ("public-bucket", "exchange-rates.parquet") in uploaded
+    assert ("private-bucket", "exchange-rates.parquet") in uploaded
+    assert ("private-bucket", "exchange-rates.parquet") in backups

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -1,7 +1,5 @@
 """Tests for vault post-processing error handling."""
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -40,8 +38,12 @@ def test_run_post_processing_contains_crypto_failures_and_keeps_public_skips(
     crypto_calls: list[tuple[str, object]] = []
 
     monkeypatch.setattr(post_processing, "merge_native_protocols", lambda **_: {})
+    exchange_rate_path = tmp_path / "exchange-rates.parquet"
+    exchange_rate_path.write_bytes(b"rate snapshot")
     monkeypatch.setattr(post_processing, "clean_crypto_vault_prices", lambda **kwargs: crypto_calls.append(("clean", kwargs)) or True)
+    monkeypatch.setattr(post_processing, "materialise_exchange_rate_parquet", lambda **_: SimpleNamespace(path=exchange_rate_path))
     monkeypatch.setattr(post_processing, "calculate_crypto_vault_metadata", lambda **kwargs: crypto_calls.append(("metadata", kwargs)) or {"vaults": []})
+    monkeypatch.setattr(post_processing, "export_crypto_exchange_rate_parquet", lambda path: crypto_calls.append(("rate", path)) or True)
     monkeypatch.setattr(post_processing, "export_crypto_vault_bundle", lambda paths, metadata: crypto_calls.append(("export", (paths, metadata))) or False)
 
     steps = post_processing.run_post_processing(
@@ -56,11 +58,12 @@ def test_run_post_processing_contains_crypto_failures_and_keeps_public_skips(
         crypto_vaults_dir=tmp_path / "crypto-vaults",
     )
 
-    assert [name for name, _ in crypto_calls] == ["clean", "metadata", "export"]
+    assert [name for name, _ in crypto_calls] == ["clean", "metadata", "rate", "export"]
     clean_kwargs = crypto_calls[0][1]
     assert isinstance(clean_kwargs, dict)
     assert clean_kwargs["cleaned_path"] == tmp_path / "crypto-vaults" / "crypto-cleaned-vault-prices-1d.parquet"
     assert steps["clean-crypto-vault-prices"] is True
+    assert steps["materialise-exchange-rate-parquet"] is True
     assert steps["calculate-crypto-vault-metadata"] is True
     assert steps["export-crypto-vault-bundle"] is False
 
@@ -102,7 +105,7 @@ def test_export_data_files_logs_retryable_r2_failure_as_warning_without_tracebac
     """Transient R2 failures should await the scanner's next export attempt quietly."""
     retryable_error = R2RetryableOperationError("R2 CompleteMultipartUpload failed with http_status=500")
 
-    def fake_main() -> None:
+    def fake_main(**_: object) -> None:
         raise retryable_error
 
     module = SimpleNamespace(main=fake_main)

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -23,10 +23,12 @@ from eth_defi.research import vault_metrics
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
 from eth_defi.research.vault_metrics import (
+    CryptoUSDConversionContext,
     PeriodMetrics,
     apply_abnormal_value_checks,
     apply_morpho_not_in_api_check,
     calculate_annualised_volatility_from_daily_returns,
+    calculate_crypto_usd_period_results,
     calculate_hourly_returns_for_all_vaults,
     calculate_lifetime_metrics,
     calculate_period_metrics,
@@ -86,6 +88,92 @@ def test_period_metrics_rejects_empty_share_price_series_cleanly() -> None:
 
     assert result.error_reason == "Vault has no usable share-price observations"
     assert result.raw_samples == 0
+
+
+def test_usd_period_fee_path_does_not_charge_performance_fee_on_eth_appreciation() -> None:
+    """USD fee composition applies externalised fees to native vault returns only."""
+    index = pd.to_datetime(["2026-01-01", "2026-01-05"])
+    native_prices = pd.Series([1.0, 1.0], index=index)
+    usd_prices = pd.Series([1_000.0, 2_000.0], index=index)
+    daily_usd_prices, daily_usd_returns = prepare_daily_share_price_series(usd_prices)
+    native_fees = FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=0.0,
+        performance=0.2,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+    usd_metrics = calculate_period_metrics(
+        period="lifetime",
+        gross_fee_data=native_fees,
+        net_fee_data=native_fees,
+        share_price_hourly=usd_prices,
+        share_price_daily=daily_usd_prices,
+        daily_returns=daily_usd_returns,
+        tvl=pd.Series([1_000.0, 2_000.0], index=index),
+        now_=index[-1],
+        native_fee_share_price=native_prices,
+        exchange_rate=pd.Series([1_000.0, 2_000.0], index=index),
+    )
+
+    assert usd_metrics.returns_gross == pytest.approx(1.0)
+    assert usd_metrics.returns_net == pytest.approx(1.0)
+    assert usd_metrics.tvl_end == pytest.approx(2_000.0)
+
+
+def test_usd_period_metrics_include_underlying_exchange_rate_endpoints() -> None:
+    """BTC/ETH USD metrics expose the precise underlying prices they used."""
+    index = pd.to_datetime(["2026-01-01", "2026-01-05"])
+    native_prices = pd.Series([1.0, 1.0], index=index)
+    daily_native_prices, _ = prepare_daily_share_price_series(native_prices)
+    rates = pd.Series([1_000.0, 1_250.0, 1_500.0, 1_750.0, 2_000.0], index=pd.date_range("2026-01-01", "2026-01-05", freq="D"))
+    fees = FeeData(fee_mode=VaultFeeMode.feeless, management=0.0, performance=0.0, deposit=0.0, withdraw=0.0)
+    metrics = calculate_crypto_usd_period_results(
+        context=CryptoUSDConversionContext(
+            rates_by_family={"eth": rates},
+            errors_by_family={},
+            vault_families={"1-0xeth": "eth"},
+        ),
+        vault_id="1-0xeth",
+        native_share_price_observations=native_prices,
+        native_daily_share_prices=daily_native_prices,
+        native_total_assets=pd.Series([2.0, 2.0], index=index),
+        gross_fee_data=fees,
+        net_fee_data=fees,
+    )
+
+    assert metrics is not None
+    lifetime = next(metric for metric in metrics if metric.period == "lifetime")
+    assert lifetime.exchange_rate_start == pytest.approx(1_000.0)
+    assert lifetime.exchange_rate_end == pytest.approx(2_000.0)
+
+
+def test_usd_period_metrics_restart_lifetime_after_long_rate_gap() -> None:
+    """A rate gap longer than the bounded fill excludes older USD history."""
+    index = pd.date_range("2026-01-01", "2026-01-12", freq="D")
+    rates = pd.Series([1_000.0] * 3 + [float("nan")] * 4 + [2_000.0] * 5, index=index)
+    observations = pd.Series([1.0, 1.0, 1.0], index=pd.to_datetime(["2026-01-01", "2026-01-08", "2026-01-12"]))
+    daily_native_prices, _ = prepare_daily_share_price_series(observations)
+    fees = FeeData(fee_mode=VaultFeeMode.feeless, management=0.0, performance=0.0, deposit=0.0, withdraw=0.0)
+
+    metrics = calculate_crypto_usd_period_results(
+        context=CryptoUSDConversionContext(
+            rates_by_family={"eth": rates},
+            errors_by_family={},
+            vault_families={"1-0xeth": "eth"},
+        ),
+        vault_id="1-0xeth",
+        native_share_price_observations=observations,
+        native_daily_share_prices=daily_native_prices,
+        native_total_assets=pd.Series([1.0, 1.0, 1.0], index=observations.index),
+        gross_fee_data=fees,
+        net_fee_data=fees,
+    )
+
+    assert metrics is not None
+    lifetime = next(metric for metric in metrics if metric.period == "lifetime")
+    assert lifetime.samples_start_at == pd.Timestamp("2026-01-08")
+    assert lifetime.exchange_rate_start == pytest.approx(2_000.0)
 
 
 def test_return_resampling_preserves_missing_calendar_days() -> None:

--- a/tests/vault/test_crypto_vaults.py
+++ b/tests/vault/test_crypto_vaults.py
@@ -18,6 +18,7 @@ from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.crypto_vault_export import build_crypto_vault_manifest, publish_crypto_vault_bundle
 from eth_defi.vault.crypto_vaults import (
     CryptoVaultPaths,
+    build_crypto_usd_conversion_context,
     build_crypto_vault_record,
     resolve_crypto_vault_paths,
 )
@@ -28,6 +29,7 @@ from eth_defi.vault.denomination import (
     convert_usd_threshold_to_denomination,
     normalise_denomination_symbol,
 )
+from eth_defi.vault.vaultdb import VaultDatabase
 
 DENOMINATION_DECIMALS = 18
 
@@ -206,8 +208,42 @@ def test_crypto_metadata_identifies_underlying_and_stablecoinish_history() -> No
     assert "total_assets_unit" not in wbtc_record
     assert stablecoin_record["canonical_underlying"] == "USD"
     assert stablecoin_record["stablecoinish"] is True
+    assert "periodic_metrics_usd" not in stablecoin_record
     assert mixed_case_stablecoin_record["denomination"] == "sUSDe"
     assert mixed_case_stablecoin_record["stablecoinish"] is True
+
+
+def test_crypto_usd_context_shifts_provider_date_and_bounds_gap_fill(tmp_path: Path) -> None:
+    """USD conversion uses the prior vault day and never fills a long gap.
+
+    :param tmp_path:
+        Isolated local export directory supplied by pytest.
+    """
+    eth_spec = VaultSpec(1, "0x0000000000000000000000000000000000000002")
+    vault_db = VaultDatabase(rows={eth_spec: _vault_row(1, eth_spec.vault_address, "wstETH")})
+    exchange_rate_path = tmp_path / "exchange-rates.parquet"
+    pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2026-01-02", "2026-01-03", "2026-01-08"]),
+            "base_currency": ["usd"] * 3,
+            "quote_currency": ["eth"] * 3,
+            "rate": [0.001, 0.0005, 0.00025],
+            "source": ["fawazahmed0"] * 3,
+            "written_at": pd.to_datetime(["2026-01-02", "2026-01-03", "2026-01-08"]),
+        }
+    ).to_parquet(exchange_rate_path)
+    prices = pd.DataFrame(index=pd.date_range("2026-01-01", "2026-01-08", freq="D"))
+
+    context, provenance = build_crypto_usd_conversion_context(vault_db, prices, exchange_rate_path)
+
+    eth_rates = context.rates_by_family["eth"]
+    assert eth_rates.loc[pd.Timestamp("2026-01-01")] == pytest.approx(1_000)
+    assert eth_rates.loc[pd.Timestamp("2026-01-02")] == pytest.approx(2_000)
+    assert eth_rates.loc[pd.Timestamp("2026-01-05")] == pytest.approx(2_000)
+    assert pd.isna(eth_rates.loc[pd.Timestamp("2026-01-06")])
+    assert eth_rates.loc[pd.Timestamp("2026-01-07")] == pytest.approx(4_000)
+    assert context.vault_families[eth_spec.as_string_id()] == "eth"
+    assert provenance["effective_date_policy"] == "provider date minus one UTC day"
 
 
 def test_manifest_describes_flat_crypto_payloads(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

ETH- and BTC-denominated vault performance needs a USD comparison view without changing the established native metrics or public stablecoin export.

## Lessons learnt

Native vault yield and underlying ETH/BTC market movement must be composed separately when investor fees are applied. Currency-provider dates require an explicit effective-date convention and bounded gap handling.

## Summary

- Export a cleaned exchange-rates.parquet snapshot to R2 and private backups.
- Add JSON-only periodic_metrics_usd with exchange-rate endpoints for ETH/BTC crypto vaults.
- Keep stablecoin and native metric schemas unchanged.
- Add standalone reporting of native and USD CAGR, plus metadata and pipeline provenance.
- Document the rate convention, bounded-fill behaviour, and USD lifetime semantics.

## Related issues and PRs

Builds on the private crypto-vaults bundle already present on master.

## Unrelated CI and test fixes

None.