### PR TITLE
fix: NameErrors in broadcast-failure logging and retry middleware shim

### DIFF
--- a/eth_defi/chain.py
+++ b/eth_defi/chain.py
@@ -17,7 +17,7 @@ from web3 import HTTPProvider, Web3
 from web3.providers import BaseProvider, JSONBaseProvider
 from web3.types import RPCEndpoint, RPCResponse
 
-from eth_defi.compat import native_datetime_utc_fromtimestamp
+from eth_defi.compat import install_retry_middleware_compat, native_datetime_utc_fromtimestamp
 from eth_defi.event_reader.conversion import convert_jsonrpc_value_to_int
 from eth_defi.middleware import http_retry_request_with_sleep_middleware
 from eth_defi.provider.named import get_provider_name

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -775,9 +775,9 @@ def _broadcast_multiple_nodes(
                 nonce,
             )
             for provider, exception in exceptions.items():
-                name = get_provider_name(p)
-                logger.error("%s failed with: %s", name, e)
-                logger.exception(e)
+                name = get_provider_name(provider)
+                logger.error("%s failed with: %s", name, exception)
+                logger.exception(exception)
 
             # Raise the last exception
             raise exception


### PR DESCRIPTION
## Summary

Two genuine `NameError` bugs (ruff F821), both on error/compat paths:

1. **`eth_defi/confirmation.py`** — in the *all providers failed to broadcast* branch, the reporting loop references `e` and `p` from an earlier loop:

```python
for provider, exception in exceptions.items():
    name = get_provider_name(p)          # p: leftover from a previous loop — always the last provider
    logger.error("%s failed with: %s", name, e)   # e: DELETED by Python 3 after its except block → NameError
    logger.exception(e)
```

Python 3 unbinds the `except ... as e` target when the except block exits, so the moment every provider fails, this diagnostics path **raises NameError instead of logging the real failures and re-raising** — masking the true broadcast errors exactly when they matter most. Fixed to use the loop's own `provider` / `exception`.

2. **`eth_defi/chain.py`** — `install_retry_muiddleware()` calls `install_retry_middleware_compat`, which is defined in `eth_defi/compat.py` but never imported here, so any call raises `NameError`. Added it to the existing `from eth_defi.compat import ...` line (no cycle: `compat.py` imports only stdlib/eth_abi/eth_typing). Left the function's name as-is (note: it's spelled "muiddleware") since renaming public API is a maintainer call.

## Testing
`python -m py_compile` passes on both files; `ruff check --select F821` on them goes from 4 errors to clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)