### PR TITLE
fix: explain HyperEVM HyperCore read failures and unlist two wrongly blacklisted vaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,6 +474,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `contracts/safe-integration/README.md` | Trading Strategy Zodiac-module for Safe multisig wallets |
 | `docs/README-Hypercore-guard.md` | Hypercore native vault guard integration |
 | `docs/README-hyperevm-goldsky-failure.md` | HyperEVM goldsky eRPC "not enough agreement" consensus failure and Alchemy failover |
+| `docs/README-hyperevm-hypercore-read-gas.md` | HyperEVM HyperCore read gas — why HyperCore-reading vaults abort Multicall3 batches with `-32003 out of gas` and revert with `CoreReaderLib.ReadFailure`, and why they are not blacklisted |
 | `docs/README-hypersync-tests.md` | Hypersync scan tests — disabled on CI by default, how to run them on CI when needed |
 | `docs/README-test-suite-performance.md` | Test suite performance plan — CI caching, shared Anvil forks, vault-protocol gating |
 | `docs/README-contract-size.md` | Contract sizes and compiler optimisation |

--- a/docs/README-hyperevm-goldsky-failure.md
+++ b/docs/README-hyperevm-goldsky-failure.md
@@ -176,6 +176,11 @@ Recorded for reference only — these are **working vaults**, not blacklisted:
 
 ## Related
 
+- [`README-hyperevm-hypercore-read-gas.md`](README-hyperevm-hypercore-read-gas.md)
+  — the other HyperEVM multicall failure mode on the same chain: vaults that read
+  HyperCore through precompiles get tens of millions of gas attributed to them and
+  abort the batch with `-32003 out of gas`, and revert with
+  `CoreReaderLib.ReadFailure` (`0x18c34104`) outside the node's HyperCore view.
 - [`eth_defi/event_reader/multicall_batcher.py`](../eth_defi/event_reader/multicall_batcher.py)
   — retry loop and the failover helpers.
 - `WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES` in the same file still classifies

--- a/docs/README-hyperevm-hypercore-read-gas.md
+++ b/docs/README-hyperevm-hypercore-read-gas.md
@@ -195,6 +195,69 @@ obtainable near the head**. Backfilling their share price deep into the past is 
 possible on any provider, so gaps before the HyperCore read window must not be
 "repaired" by rescanning.
 
+## Blacklist audit — every HyperEVM entry reads HyperCore
+
+Because the failure signature turned out to be so easy to misread, the whole
+blacklist was re-audited on 2026-08-28. Of the 130 addresses in
+`BROKEN_VAULT_CONTRACTS` and `VAULT_SPECIFIC_RISK`, exactly six have code on chain
+999. `debug_traceCall` with `callTracer` enumerates the precompile callees of
+`totalAssets()` even for the contracts that are not source-verified, and **all six
+read HyperCore**:
+
+| Vault | Address | Precompiles read by `totalAssets()` | Assets at head | Historical read at head-20,000 (no gas cap) | `estimate_gas` at head | Verdict |
+|-------|---------|-------------------------------------|----------------|---------------------------------------------|------------------------|---------|
+| LONGV4 | `0x2eEe42A0…` | `0x…0800` position ×2, `0x…0803` withdrawable | 0.00 USDC | Alchemy ok (also at head-500k) | 59,501 | **unlisted** |
+| Altcopy Flagship | `0xcDB9671E…` | `0x…0801` spot balance, `0x…080f` | 7,765 USDC | ok on all three (also at head-500k) | 71,350 | **unlisted** |
+| Altcopy Index | `0xF8F7c57F…` | `0x…0801`, `0x…0802` vault equity ×8 | 8,168 USDC | fails everywhere | 222,530 | stays blacklisted |
+| Hyperdrive HLP | `0x6ED613E8…` | `0x…0809` L1 block number | 9,025 USDC | `ReadFailure` everywhere | 202,951 | stays blacklisted |
+| Gamma Symphony | `0x2b37f356…` | `0x…0809` | 36 USDC | `ReadFailure` everywhere | 144,186 | stays blacklisted |
+| HYPE Funding Yield | `0xd3F41DAC…` | `0x…0801` | 10 USD₮0 | reverts everywhere | 126,909 | stays blacklisted |
+| HYPED (never blacklisted) | `0x4d0fF6a0…` | `0x…0809` | 2,616 HYPE | `ReadFailure` everywhere | 117,896 | not listed |
+
+Notes on the evidence:
+
+- Hyperdrive HLP and Gamma Symphony share the implementation
+  `0xa05959fbd41e30396446c36d099e5f3b20fb6ad6`, verified as
+  `TokenizedVaultUpgradeable` — the same `CoreReaderLib` consumer as HYPED. The
+  `0x18c34104` revert their blacklist entries already recorded is exactly
+  `CoreReaderLib.ReadFailure`.
+- HYPE Funding Yield is unverified, but its runtime bytecode carries the strings
+  `SpotBalance precompile call failed`, `MarkPx precompile call failed`,
+  `Position precompile call failed` and `Withdrawable precompile call failed`, and
+  goldsky returns `execution reverted: SpotBalance precompile…`.
+- None of these vaults is intrinsically expensive: every `estimate_gas` at the head
+  is between 59k and 223k. The multi-hundred-megagas numbers are provider
+  accounting for the precompile staticcalls, as measured above.
+
+### Two entries were wrong and have been unlisted
+
+`LONGV4` and `Altcopy Flagship` were blacklisted with the reasoning "all configured
+RPC providers reject the scanner's 2,000,000-gas probes". That 2M figure is the
+`CALL_GAS` default of
+[`scripts/erc-4626/poke-hyperevm-vault-calls.py`](../scripts/erc-4626/poke-hyperevm-vault-calls.py),
+a cap the diagnostic script imposes, **not** a provider limit. Re-measured without
+it:
+
+```
+LONGV4            Alchemy  head:ok  -20k:ok  -100k:ok  -500k:ok
+Altcopy Flagship  Alchemy  head:ok  -20k:ok  -100k:ok  -500k:ok
+                  goldsky  head:ok  -20k:ok  -100k:ok  -500k:ok
+                  dRPC     head:ok  -20k:ok  -100k:ok  -500k:ok
+```
+
+Both are readable, including deep in the past, so their entries were removed from
+`VAULT_SPECIFIC_RISK` and `BROKEN_VAULT_CONTRACTS`. The script's docstring now warns
+against repeating the mistake. Residual risk is accepted and known: LONGV4 still
+draws `-32003` from dRPC and intermittently from goldsky, so its history will come
+from the Alchemy pin, and goldsky rejects Altcopy Flagship's four-probe multicall
+even though it answers the same calls individually.
+
+The remaining four stay blacklisted for a different reason than the entries
+originally claimed: not because they are broken or gas-poisonous, but because their
+HyperCore reads make historical valuation unobtainable on every provider, which is
+what the price pipeline needs. When a "head NAV only" path exists, they should be
+revisited — they are live vaults.
+
 ## Reproducing
 
 ```python

--- a/docs/README-hyperevm-hypercore-read-gas.md
+++ b/docs/README-hyperevm-hypercore-read-gas.md
@@ -1,0 +1,229 @@
+# HyperEVM HyperCore read gas and `-32003 out of gas` multicall failures
+
+This document explains why HyperEVM (Hyperliquid, chain id 999) historical vault
+price scans abort with `-32003 out of gas: gas required exceeds: 300000000`, why the
+address named in the failing batch is **not** a broken contract, and why we do not
+blacklist it.
+
+It backs the line comments in
+[`eth_defi/event_reader/multicall_batcher.py`](../eth_defi/event_reader/multicall_batcher.py)
+(`WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES`, the `MulticallRetryable` fallback),
+[`eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py`](../eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py),
+[`eth_defi/erc_4626/classification.py`](../eth_defi/erc_4626/classification.py) and
+[`eth_defi/vault/risk.py`](../eth_defi/vault/risk.py).
+
+It is the gas-accounting sibling of
+[`README-hyperevm-goldsky-failure.md`](README-hyperevm-goldsky-failure.md), which
+covers the eRPC consensus (`not enough agreement among responses`) failure mode on
+the same chain.
+
+## Symptom
+
+`vault-scanner-looped` loops on the same HyperEVM blocks, rotating providers and
+shrinking the batch, without ever finishing the chain:
+
+```
+Switched RPC providers edge.goldsky.com -> hyperliquid-mainnet.g.alchemy.com,
+cause: Last exception: Multicall failed for chain 999
+Block 44,367,203, batch size: 40: {'code': -32003, 'message': 'out of gas: gas required exceeds: 600000000'}
+...
+Block 44,320,403, batch size: 13: {'code': -32003, 'message': 'out of gas: gas required exceeds: 300000000'}
+```
+
+Observed over blocks 44,291,603 – 44,367,203 on 2026-08-28, against the
+`edge.goldsky.com` / `hyperliquid-mainnet.g.alchemy.com` / `lb.drpc.live` fallback
+mix. The reduced batches printed 11 and then 3 vault addresses, which is not enough
+to identify the culprit by reading the log alone.
+
+## Isolating the address
+
+The failing `eth_call` payloads in the log are Multicall3
+`tryBlockAndAggregate(false, calls)` (`0x399542e9`) blobs, so they can be replayed
+verbatim, address group by address group, against each configured provider:
+
+| Batch replayed at block 44,367,203 | goldsky | dRPC | Alchemy |
+|------------------------------------|---------|------|---------|
+| full 40-call batch                 | out of gas | out of gas | ok |
+| full 40-call batch minus `0x4d0fF6a0…` | ok | ok | ok |
+| 13-call reduced batch              | out of gas | out of gas | ok |
+| `0x4d0fF6a0…` 4 calls, duplicated ×2 | out of gas | out of gas | ok |
+| every other address, calls duplicated ×16 | ok | ok | ok |
+
+Group bisection of the 13-call batch (`A` = `0x4aBFd796…`, `S` = `0x4d0fF6a0…`,
+`B` = `0x7188D14A…`): `A` ok, `S` ok, `B` ok, `A+S` ok, `A+B` ok, `S+B` fails — and
+`S` alone with its four calls duplicated fails. So a single address accounts for the
+whole failure:
+
+**`0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e` — Hyperdrive Liquid Staked Hype
+(`HYPED`)**, an ERC-1967 proxy whose implementation
+`0x6CA870794cd307243FCc8711899e46C74B2D3f2f` is source-verified as
+`StakingVaultUpgradeable` (solc 0.8.28, fetched through the Etherscan v2 unified API
+with `chainid=999`).
+
+Only three of its selectors are affected, and `totalSupply()` never is:
+
+| Selector | Method | Behaviour |
+|----------|--------|-----------|
+| `0x01e1d114` | `totalAssets()` | heavy / reverts historically |
+| `0x07a2d13a` | `convertToAssets(uint256)` | heavy / reverts historically |
+| `0x402d267d` | `maxDeposit(address)` | heavy / reverts historically |
+| `0x18160ddd` | `totalSupply()` | always cheap, always works |
+
+## Root cause — the vault reads HyperCore through precompiles
+
+The verified source explains the split exactly. `totalAssets()` delegates to
+`CoreControllerLib`:
+
+```solidity
+function totalAssets(StakingVaultUpgradeable.StakingStorage storage $) public view returns (uint256 total) {
+  address[] memory proxies = $.proxies.values();
+  uint256 blockNumber = compositeBlockNumber();
+  for (uint256 i = 0; i < proxies.length; i++) {
+    total += totalAssets($, proxies[i], blockNumber);
+  }
+  total += address(this).balance - $.totalClaimableAssets;
+}
+```
+
+and each per-proxy step reads live HyperCore state:
+
+```solidity
+total += Wei.wrap(CoreReaderLib.readSpotBalance(proxy, $.tokenIndex).total).fromWei();
+CoreReaderLib.DelegatorSummary memory delegatorSummary = CoreReaderLib.readDelegatorSummary(proxy);
+total += Wei.wrap(delegatorSummary.delegated).fromWei();
+total += Wei.wrap(delegatorSummary.undelegated).fromWei();
+total += Wei.wrap(delegatorSummary.totalPendingWithdrawal).fromWei();
+```
+
+`compositeBlockNumber()` is itself a HyperCore read:
+
+```solidity
+function compositeBlockNumber() private view returns (uint256) {
+  return (uint256(CoreReaderLib.readL1BlockNumber()) << 128) | uint128(block.number);
+}
+```
+
+`CoreReaderLib` (`@ambitlabs/hypercore`) staticcalls the HyperCore read precompiles:
+
+| Precompile | Constant | Used by |
+|------------|----------|---------|
+| `0x…0801` | `PRECOMPILE_ADDRESS_SPOT_BALANCE` | `readSpotBalance()` |
+| `0x…0805` | `PRECOMPILE_ADDRESS_DELEGATOR_SUMMARY` | `readDelegatorSummary()` |
+| `0x…0809` | `PRECOMPILE_ADDRESS_L1_BLOCK_NUMBER` | `readL1BlockNumber()` |
+
+`getProxies()` on the live vault returns **3** staking proxies, so one
+`totalAssets()` performs **1 + 2 × 3 = 7 HyperCore precompile staticcalls**.
+`maxDeposit()` calls `totalAssets()` directly and `convertToAssets()` reaches it
+through `ERC7535Upgradable`, whereas `totalSupply()` is plain ERC-20 storage. That
+is precisely the observed pattern: HyperCore-dependent selectors misbehave, the pure
+EVM selector never does.
+
+### Evidence 1 — the historical revert is a HyperCore read failure
+
+At historical blocks the call reverts with `0x18c34104`, which is
+`keccak("ReadFailure(address)")[:4]` — the custom error `CoreReaderLib` raises when
+a precompile staticcall fails. Its decoded argument is
+`0x0000000000000000000000000000000000000809`, the L1 block-number precompile, i.e.
+the very first HyperCore read in `totalAssets()`.
+
+Availability is a per-node, per-moment property rather than a property of the block:
+
+```
+hyperliquid-mainnet.g.alchemy.com  head      -> ok, 2616.51 HYPE
+hyperliquid-mainnet.g.alchemy.com  head-200  -> ReadFailure(0x…0809)
+edge.goldsky.com                   head      -> ReadFailure(0x…0809)
+edge.goldsky.com                   head-200  -> ok, 2616.51 HYPE
+lb.drpc.org                        head      -> ReadFailure(0x…0809)
+```
+
+A binary search on Alchemy on 2026-08-28 put the boundary at a single block:
+`totalAssets()` reverted at every block up to 44,372,819 and succeeded from
+44,372,820 — about two minutes behind the head. HyperCore state is served from the
+node's live view, so **no provider can reconstruct this vault's NAV for an arbitrary
+past block**, the same way Monad cannot serve arbitrary-depth historical state.
+
+The already-blacklisted Hyperdrive HLP (`0x6ED613E8…`) and Gamma Symphony
+(`0x2b37f356…`) entries in `eth_defi/vault/risk.py` record the same `0x18c34104`
+revert; this document is the explanation of what that error actually is.
+
+### Evidence 2 — the gas figure is provider accounting, not real execution
+
+Real execution of `totalAssets()` is cheap. Binary searching the `gas` field of a
+direct `eth_call` on Alchemy at a block where the HyperCore read succeeds gives
+**~117,000 gas** for the whole call, i.e. roughly 17k per HyperCore read.
+
+The numbers the scanner trips over come from the providers' gas accounting for
+those precompile staticcalls:
+
+| Provider | Measurement |
+|----------|-------------|
+| Alchemy | `eth_call` executes in ~117k gas; `estimate_gas` of the same call inside Multicall3 reports 2,843,730 |
+| goldsky | 4 copies of `totalAssets()` fit in one multicall under the 300M cap, 5 do not → ≥60M attributed per call |
+| dRPC | same as goldsky; `maxDeposit()` is heavy there too |
+
+On goldsky and dRPC the rejection is independent of the cap we send: caps of 1M,
+10M, 30M, 100M and 299M are all answered with
+`out of gas: gas required exceeds: <cap>`. So the node decides up front that the
+batch needs more gas than allowed; it is not a real EVM out-of-gas during
+execution. A handful of HyperCore reads is enough to push a normal 40-call scanner
+batch over a 300M/600M cap, which is why the failure looks random, flaps between
+fallbacks, and survives batch-size reduction until the batch happens to exclude
+this vault.
+
+## Why we do not blacklist it
+
+Same conclusion as Cause A / Cause B in
+[`README-hyperevm-goldsky-failure.md`](README-hyperevm-goldsky-failure.md): the
+contract is not dead or cooked.
+
+- Hyperdrive is a real, DefiLlama-listed HyperEVM protocol, and this specific
+  implementation is source-verified (`StakingVaultUpgradeable`), contrary to the
+  older "unverified contracts" note carried in our Hyperdrive metadata.
+- The vault works at head: `totalAssets()` is 2,616.5 HYPE (about $218k at the
+  2026-08-28 HYPE mid of $83.47), `totalSupply()` 2,555.6 HYPED, share price 1.0238
+  HYPE per HYPED.
+- The failure is a provider-side gas-accounting and HyperCore-state-window artefact,
+  not a permanent property of the address. Alchemy executes the same batch fine.
+
+Blacklisting would permanently drop a live vault from reports for a transient RPC
+condition. The existing machinery is the mitigation: `MulticallRetryable` batch-size
+reduction, provider rotation, and the HyperEVM Alchemy pin described in the
+companion document.
+
+What we do accept is that **historical NAV for HyperCore-reading vaults is only
+obtainable near the head**. Backfilling their share price deep into the past is not
+possible on any provider, so gaps before the HyperCore read window must not be
+"repaired" by rescanning.
+
+## Reproducing
+
+```python
+from eth_abi import encode
+from eth_utils import to_checksum_address
+from web3 import Web3, HTTPProvider
+
+MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11"
+VAULT = to_checksum_address("0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e")
+
+# tryBlockAndAggregate(false, [(vault, totalAssets())] * n)
+def payload(n: int) -> str:
+    calls = [(VAULT, bytes.fromhex("01e1d114"))] * n
+    return "0x399542e9" + encode(["bool", "(address,bytes)[]"], [False, calls]).hex()
+
+web3 = Web3(HTTPProvider("https://edge.goldsky.com/..."))  # JSON_RPC_HYPERLIQUID entry
+web3.eth.call({"to": MULTICALL3, "data": payload(4)}, block_identifier=44_367_203)  # ok
+web3.eth.call({"to": MULTICALL3, "data": payload(8)}, block_identifier=44_367_203)  # -32003 out of gas
+```
+
+Split `JSON_RPC_HYPERLIQUID` on spaces and take one endpoint per provider; the
+space-separated fallback format only works with `create_multi_provider_web3()`.
+
+## Related
+
+- [`README-hyperevm-goldsky-failure.md`](README-hyperevm-goldsky-failure.md) — the
+  eRPC consensus failure mode on the same chain, including the Alchemy failover pin.
+- [`eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py`](../eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py)
+  — `HyperdriveVault`, whose docstring points here.
+- [`eth_defi/vault/risk.py`](../eth_defi/vault/risk.py) — the Hyperdrive HLP and
+  Gamma Symphony blacklist entries that share the `0x18c34104` revert, plus the note
+  that `HYPED` is deliberately kept off that list.

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -2924,7 +2924,7 @@ HARDCODED_PROTOCOLS = {
     # matching HyperCore view. The vault itself is live and its implementation
     # 0x6CA870794cd307243FCc8711899e46C74B2D3f2f is source-verified as
     # StakingVaultUpgradeable, so this is not a blacklist case.
-    # See docs/README-hyperevm-hypercore-read-gas.md.
+    # See docs/README-hyperevm-hypercore-read-gas.md and PR #1536.
     "0x4d0ff6a0dd9f7316b674fb37993a3ce28bea340e": {ERC4626Feature.hyperdrive_hl_like},
     # sBOLD - K3 Capital yield-bearing tokenised Liquity V2 Stability Pool deposit
     # https://etherscan.io/address/0x50bd66d59911f5e086ec87ae43c811e0d059dd11

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -2915,7 +2915,16 @@ HARDCODED_PROTOCOLS = {
     "0x7f2b789ac6d93521fae86cbc838efcfc4f2b004b": {ERC4626Feature.hyperdrive_hl_like},
     # Hyperdrive vault
     "0x5743aec1f06e896544d1638e0febd15098855cb5": {ERC4626Feature.hyperdrive_hl_like},
-    # Hyperdrive vault
+    # Hyperdrive Liquid Staked Hype (HYPED) - ERC-7535 native HYPE staking vault.
+    # Deliberately kept on the list even though its historical price scans fail:
+    # totalAssets(), convertToAssets() and maxDeposit() read HyperCore through the
+    # read precompiles, so goldsky and dRPC attribute tens of millions of gas to
+    # them (-32003 "out of gas" for the whole Multicall3 batch) and they revert
+    # with CoreReaderLib.ReadFailure (0x18c34104) once the node no longer holds the
+    # matching HyperCore view. The vault itself is live and its implementation
+    # 0x6CA870794cd307243FCc8711899e46C74B2D3f2f is source-verified as
+    # StakingVaultUpgradeable, so this is not a blacklist case.
+    # See docs/README-hyperevm-hypercore-read-gas.md.
     "0x4d0ff6a0dd9f7316b674fb37993a3ce28bea340e": {ERC4626Feature.hyperdrive_hl_like},
     # sBOLD - K3 Capital yield-bearing tokenised Liquity V2 Stability Pool deposit
     # https://etherscan.io/address/0x50bd66d59911f5e086ec87ae43c811e0d059dd11

--- a/eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py
@@ -18,6 +18,33 @@ Security:
 - Backed by Binance Labs, Hack VC, Arrington Capital, and Delphi Ventures
 - Protocol suffered a $782,000 exploit in 2025 (router contract vulnerability)
 
+HyperCore read dependency and historical scans:
+
+Some Hyperdrive vaults value themselves from live HyperCore state instead of
+plain EVM storage. The liquid staking vault
+`HYPED <https://purrsec.com/address/0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e>`__
+(implementation ``0x6CA870794cd307243FCc8711899e46C74B2D3f2f``, verified as
+``StakingVaultUpgradeable``) is the clearest case: ``totalAssets()`` walks its
+staking proxies and, per proxy, staticcalls the HyperCore read precompiles
+``0x...0801`` (spot balance) and ``0x...0805`` (delegator summary), preceded by
+``0x...0809`` (L1 block number). ``maxDeposit()`` and ``convertToAssets()``
+inherit those reads, while ``totalSupply()`` stays a pure ERC-20 storage read.
+
+Two consequences for the scanners:
+
+- Providers disagree wildly on what those precompile reads cost. Goldsky and
+  dRPC attribute tens of millions of gas to a single ``totalAssets()``, so a
+  normal historical Multicall3 batch is rejected with ``-32003``
+  ``out of gas: gas required exceeds: <cap>`` for any cap, whereas Alchemy
+  executes the same call in about 117k gas.
+- Once a node no longer holds the matching HyperCore view, the call reverts with
+  ``CoreReaderLib.ReadFailure`` (``0x18c34104``). Historical NAV for these
+  vaults is therefore only readable close to the head and cannot be backfilled.
+
+These vaults are alive and correct at the head, so they are **not** blacklisted.
+See ``docs/README-hyperevm-hypercore-read-gas.md`` in the repository for the
+full analysis, measurements and reproduction snippet.
+
 - Homepage: https://hyperdrive.fi/
 - App: https://app.hyperdrive.fi/earn
 - Documentation: https://hyperdrive-2.gitbook.io/hyperdrive/
@@ -45,7 +72,11 @@ class HyperdriveVault(ERC4626Vault):
     The protocol provides automated yield strategies through its "Earn" product,
     which aggregates deposits into various yield-generating activities on HyperEVM.
 
-    Note: The smart contracts are not verified on block explorers.
+    Note: most Hyperdrive contracts are not verified on block explorers. The
+    liquid staking vault HYPED is the exception - its implementation
+    0x6CA870794cd307243FCc8711899e46C74B2D3f2f is verified as
+    StakingVaultUpgradeable, and reading it confirmed the HyperCore precompile
+    dependency documented in the module docstring above.
 
     - Homepage: https://hyperdrive.fi/
     - App: https://app.hyperdrive.fi/earn

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -999,7 +999,7 @@ WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES = {
         # goldsky and dRPC nodes, so a normal 40-call batch is rejected up
         # front with -32003 "out of gas: gas required exceeds: <cap>" for any
         # cap we send, while Alchemy executes the same batch in ~117k gas.
-        # See docs/README-hyperevm-hypercore-read-gas.md.
+        # See docs/README-hyperevm-hypercore-read-gas.md and PR #1536.
         "out of gas",
         "evm timeout",
         "request timeout",
@@ -1606,7 +1606,7 @@ class MultiprocessMulticallReader:
             # provider-side artefact, not a broken contract, so blacklisting it
             # would drop a live vault. Hyperdrive Liquid Staked Hype
             # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e is the worked example
-            # in docs/README-hyperevm-hypercore-read-gas.md.
+            # in docs/README-hyperevm-hypercore-read-gas.md and PR #1536.
             block_identifier_str = f"{block_identifier:,}" if type(block_identifier) == int else str(block_identifier)
             status_code = e.status_code
             headers = e.headers

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -992,6 +992,14 @@ class CombinedEncodedCallResult:
 WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES = {
     m.lower()
     for m in (
+        # On HyperEVM (chain 999) this is usually not a real EVM out-of-gas.
+        # Vaults that read HyperCore through the read precompiles
+        # (0x...0801 spot balance, 0x...0805 delegator summary, 0x...0809 L1
+        # block number) get a punitive gas figure attributed to them by
+        # goldsky and dRPC nodes, so a normal 40-call batch is rejected up
+        # front with -32003 "out of gas: gas required exceeds: <cap>" for any
+        # cap we send, while Alchemy executes the same batch in ~117k gas.
+        # See docs/README-hyperevm-hypercore-read-gas.md.
         "out of gas",
         "evm timeout",
         "request timeout",
@@ -1588,6 +1596,17 @@ class MultiprocessMulticallReader:
             # See Mantle issues.
             # This will usually fix the issue, but it if is not resolve itself in few blocks the scan will grind snail pace and
             # the underlying contract needs to be manually blacklisted.
+            #
+            # Before blacklisting a HyperEVM (chain 999) address that shows up
+            # here, check whether its valuation calls read HyperCore. Those
+            # vaults are alive and correct at the head, but their precompile
+            # reads are charged tens of millions of gas by some providers and
+            # revert with CoreReaderLib.ReadFailure (0x18c34104) as soon as the
+            # node no longer holds the matching HyperCore view. That is a
+            # provider-side artefact, not a broken contract, so blacklisting it
+            # would drop a live vault. Hyperdrive Liquid Staked Hype
+            # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e is the worked example
+            # in docs/README-hyperevm-hypercore-read-gas.md.
             block_identifier_str = f"{block_identifier:,}" if type(block_identifier) == int else str(block_identifier)
             status_code = e.status_code
             headers = e.headers

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -304,44 +304,140 @@ VAULT_SPECIFIC_RISK = {
     # Superform vault - no indication of underlying activity or positions
     # https://app.superform.xyz/vault/1_0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6
     "0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6": VaultTechnicalRisk.blacklisted,
-    # Altcopy Index HyperEVM vault. Its totalAssets() reads HyperCore through the
-    # spot balance (0x...0801) and user vault equity (0x...0802) precompiles, the
-    # latter eight times, confirmed with debug_traceCall on 2026-08-28. That is
-    # cheap at the head (estimate_gas 222,530) but unreadable in the past: at
-    # head-20,000, head-100,000 and head-500,000 the call fails on every
-    # configured provider, so no historical valuation exists for it.
+    # -----------------------------------------------------------------------
+    # HyperEVM (chain id 999) vaults that value themselves from HyperCore
+    #
+    # Full write-up, measurements and reproduction snippet:
+    #   docs/README-hyperevm-hypercore-read-gas.md
+    # Investigation, blacklist audit and the reasoning behind these entries:
+    #   https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1536
+    #
+    # Read this before adding, removing or trusting any HyperEVM entry below.
+    #
+    # What HyperCore is
+    # -----------------
+    # Hyperliquid runs two paired execution environments: HyperCore (the L1
+    # order book, spot balances, staking and vault equity) and HyperEVM (the
+    # EVM chain). A HyperEVM contract cannot read HyperCore storage directly;
+    # it staticcalls the HyperCore *read precompiles* in the range
+    # 0x...0800 - 0x...0810:
+    #
+    #   0x...0800 position              0x...0806 mark price
+    #   0x...0801 spot balance          0x...0807 oracle price
+    #   0x...0802 user vault equity     0x...0808 spot price
+    #   0x...0803 withdrawable          0x...0809 L1 block number
+    #   0x...0804 delegations           0x...080a-0x...080c asset/token info
+    #   0x...0805 delegator summary     0x...0810 core user exists
+    #
+    # Vaults whose NAV lives on HyperCore therefore call precompiles inside
+    # totalAssets(), and transitively inside convertToAssets() and
+    # maxDeposit(). totalSupply() stays a plain ERC-20 storage read.
+    #
+    # The fingerprint
+    # ---------------
+    # That asymmetry is how this failure mode is recognised: totalAssets(),
+    # convertToAssets() and maxDeposit() misbehave while totalSupply() always
+    # answers. A vault that is dead or cooked fails on all four.
+    #
+    # Failure mode A - the HyperCore view is only available near the head
+    # -------------------------------------------------------------------
+    # A read precompile answers from the node's live HyperCore view, not from
+    # the historical EVM state trie. Outside that view the staticcall fails and
+    # the contract turns it into a revert. Hyperdrive's CoreReaderLib raises
+    # ReadFailure(address) = 0x18c34104, whose argument names the precompile
+    # that could not be read; other implementations use their own strings, for
+    # example "SpotBalance precompile call failed".
+    #
+    # Measured on 2026-08-28: for HYPED the boundary was a single block, with
+    # totalAssets() reverting up to 44,372,819 and succeeding from 44,372,820,
+    # roughly two minutes behind the head. At the same block one provider
+    # answers and another reverts, and the two swap places minutes later. So
+    # this is a per-node, per-moment property, not a property of the block, and
+    # no provider can reconstruct these vaults' NAV for an arbitrary past
+    # block. Historical gaps for such a vault must never be "repaired" by
+    # rescanning: the data does not exist anywhere.
+    #
+    # Failure mode B - provider gas accounting, not real out of gas
+    # -------------------------------------------------------------
+    # goldsky and dRPC attribute an enormous gas figure to precompile
+    # staticcalls. The same totalAssets() that executes in about 117k gas on
+    # Alchemy is accounted at tens of millions there, and Alchemy's own
+    # estimate_gas for it inside Multicall3 reports 2,843,730. Consequences:
+    #
+    # - The batch is rejected up front with
+    #   -32003 "out of gas: gas required exceeds: <cap>", echoing whatever cap
+    #   we send: 1M, 10M, 30M, 100M and 299M all come back refused. Nothing
+    #   actually runs out of gas during execution.
+    # - Multicall3 tryBlockAndAggregate() concatenates every sub-call, so one
+    #   such vault aborts the whole historical price batch and the scanner
+    #   loops with provider rotation and batch shrinking. Shrinking only helps
+    #   when the offending vault happens to drop out of the batch, which is why
+    #   the failure looks random and moves between fallbacks.
+    #
+    # How to diagnose before touching this list
+    # -----------------------------------------
+    # 1. Replay the logged tryBlockAndAggregate (0x399542e9) payload group by
+    #    group per address, and duplicate one address's calls x2 / x4 / x8. A
+    #    real hog fails alone when duplicated; a bystander never does.
+    # 2. Call *without* an explicit gas field. An imposed cap produces false
+    #    verdicts: the 2,000,000 CALL_GAS default of
+    #    scripts/erc-4626/poke-hyperevm-vault-calls.py is what wrongly
+    #    condemned LONGV4 and Altcopy Flagship, see below.
+    # 3. Probe at head, head-20k, head-100k and head-500k on every provider in
+    #    JSON_RPC_HYPERLIQUID, not just the one that failed.
+    # 4. Run debug_traceCall with callTracer and list the callees in the
+    #    0x...0800 - 0x...0810 range. This works even for unverified vaults and
+    #    proves the HyperCore dependency.
+    # 5. Fetch verified source through the Etherscan v2 unified API with
+    #    chainid=999 (Sourcify has no HyperEVM coverage) and grep for
+    #    CoreReaderLib. Resolve the proxy implementation first.
+    #
+    # Blacklist policy for this failure mode
+    # --------------------------------------
+    # Blacklist only when the whole valuation surface is unusable, including at
+    # the head, on every provider. A provider refusing to price a batch, or an
+    # exceeded cap that we imposed ourselves, is not evidence of a broken
+    # contract, and blacklisting on that basis silently deletes a live vault
+    # from reports. Hyperdrive Liquid Staked Hype
+    # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e is the worked counter-example:
+    # it triggers both failure modes and is deliberately kept off this list.
+    #
+    # The entries below are blacklisted for the narrower reason that their
+    # historical valuation is unobtainable on every provider, which is what the
+    # price pipeline needs. They are live at the head, so if a head-NAV-only
+    # path is ever added they should be revisited.
+    # -----------------------------------------------------------------------
+    #
+    # Altcopy Index. debug_traceCall shows totalAssets() reading the spot
+    # balance precompile 0x...0801 and the user vault equity precompile
+    # 0x...0802 eight times. Cheap at the head (estimate_gas 222,530, 8,168
+    # USDC of assets) but the call fails at head-20k, head-100k and head-500k
+    # on every provider (PR #1536).
     #
     # LONGV4 0x2eee42a0704dd4c0ff8141f85e24de9085a76093 and Altcopy Flagship
     # 0xcdb9671e671562b60481e4929ef80a5360af718b were removed from this list on
     # 2026-08-28. Their entries claimed "all providers reject the 2,000,000-gas
-    # probes", but that was the 2M CALL_GAS default of
-    # scripts/erc-4626/poke-hyperevm-vault-calls.py, not a provider limit.
-    # Without that cap LONGV4 reads at head, head-20k, head-100k and head-500k
-    # on Alchemy, and Altcopy Flagship reads at all of those depths on all three
-    # providers. See docs/README-hyperevm-hypercore-read-gas.md.
+    # probes", which was diagnosis step 2 above going wrong: that 2M is our own
+    # CALL_GAS default, not a provider limit. Without it LONGV4 reads to
+    # head-500k on Alchemy and Altcopy Flagship reads to head-500k on all three
+    # providers (PR #1536).
     "0xf8f7c57fb94cc1f7f2c77dc29b5216c4d3c3125d": VaultTechnicalRisk.blacklisted,
-    # Hyperdrive HLP and Gamma Symphony Vault on HyperEVM. At historical block
-    # 41,858,003 their totalAssets(), convertToAssets() and maxDeposit() calls
-    # revert with the 0x18c34104 custom error, leaving only totalSupply()
-    # usable. This poisons their historical Multicall3 price-reader batch;
-    # current-state probes working again does not restore the missing history.
+    # Hyperdrive HLP and Gamma Symphony Vault. Both failure modes above,
+    # measured on 2026-08-28 (PR #1536):
     #
-    # 0x18c34104 is keccak("ReadFailure(address)")[:4], the custom error the
-    # HyperCore CoreReaderLib raises when a read precompile staticcall fails,
-    # so these reverts mean "this node cannot serve the HyperCore view for that
-    # block", not "the vault is broken". Sibling vaults with the same failure
-    # mode are therefore not automatically blacklisted - see
-    # docs/README-hyperevm-hypercore-read-gas.md and the deliberately unlisted
-    # Hyperdrive Liquid Staked Hype vault
-    # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e. These two entries stay
-    # blacklisted because their whole valuation surface, not just its history,
-    # was unusable when reviewed. Re-audited on 2026-08-28: both proxies share
-    # the verified implementation 0xa05959fbd41e30396446c36d099e5f3b20fb6ad6
-    # (TokenizedVaultUpgradeable, the same CoreReaderLib consumer as HYPED),
-    # debug_traceCall shows totalAssets() staticcalling the L1 block number
-    # precompile 0x...0809, they answer at the head (9,025 USDC and 36 USDC of
-    # assets) and they fail with ReadFailure at head-20,000 on all three
-    # providers. Only their history is unobtainable.
+    # - Both proxies share the implementation
+    #   0xa05959fbd41e30396446c36d099e5f3b20fb6ad6, verified on chain 999 as
+    #   TokenizedVaultUpgradeable, which consumes the same CoreReaderLib as
+    #   HYPED. debug_traceCall shows totalAssets() staticcalling the L1 block
+    #   number precompile 0x...0809.
+    # - They answer at the head (9,024 USDC and 36 USDC of assets), so the
+    #   0x18c34104 = ReadFailure(0x...0809) reverts recorded for them at block
+    #   41,858,003 and at head-20,000 on all three providers mean "no
+    #   historical NAV", not "broken vault".
+    # - totalSupply() has always worked, which is the fingerprint above.
+    #
+    # Current-state probes working again does not restore the missing history,
+    # so they stay listed until a head-only valuation path exists.
     "0x6ed613e86e8d0b6617e445f17323ac0162ff6ce6": VaultTechnicalRisk.blacklisted,
     "0x2b37f3566933e4dbe59c6b86bedbc91c1e04d774": VaultTechnicalRisk.blacklisted,
     # Rocket Markets Survivor Vaults on Monad.
@@ -540,16 +636,36 @@ _BROKEN_VAULT_CONTRACTS = {
     "0x5705554BAa86Da01fF4A82d29a1598c5B3A8B476",  # Open PnL feed helper contract for broken Gains vault on Berachain
     "0x8fF6aDBC653405245B6b686E31b14A7da7000281",  # BNB broken contract
     "0x6949bcab16c0B389095C5b744f6FBF9741A1b3b6",  # Test vault on Monad
-    # LONGV4 0x2eEe42A0704DD4C0fF8141f85E24De9085A76093 and Altcopy Flagship
-    # 0xcDB9671E671562B60481e4929eF80A5360af718b used to be listed here for
-    # BasicOutOfGas(2000000). That figure came from the diagnostic script's 2M
-    # CALL_GAS default; both read fine without it, so they were unlisted on
-    # 2026-08-28. See VAULT_SPECIFIC_RISK above.
-    "0xF8F7c57FB94CC1F7f2C77Dc29b5216C4D3C3125d",  # Altcopy Index HyperEVM vault - totalAssets() reads the HyperCore spot balance (0x...0801) and user vault equity (0x...0802, eight times) precompiles and is unreadable at head-20k/-100k/-500k on every provider
-    # Hyperdrive HLP and Gamma Symphony Vault on HyperEVM. At block
-    # 41,858,003, totalAssets(), convertToAssets() and maxDeposit() revert
-    # with 0x18c34104, so they cannot provide historical valuations and poison
-    # the failing Multicall3 batch. See VAULT_SPECIFIC_RISK above.
+    # HyperEVM (chain id 999) vaults that read HyperCore.
+    #
+    # These are a different animal from the dead 2017 mainnet contracts around
+    # them. They are live, they answer at the head, and only their *history* is
+    # unobtainable, because a HyperCore read precompile serves the node's live
+    # view. They are listed here so their calls never enter a historical
+    # Multicall3 batch, where goldsky and dRPC reject the whole batch with
+    # -32003 "out of gas" for any cap we send. The failure mechanism, the
+    # measurements and the diagnosis checklist are written out in full above
+    # the same addresses in VAULT_SPECIFIC_RISK, and in
+    # docs/README-hyperevm-hypercore-read-gas.md / PR #1536.
+    #
+    # Do not add a HyperEVM address here just because a provider refused a
+    # batch or because an imposed CALL_GAS cap was exceeded. LONGV4
+    # 0x2eEe42A0704DD4C0fF8141f85E24De9085A76093 and Altcopy Flagship
+    # 0xcDB9671E671562B60481e4929eF80A5360af718b were listed here for
+    # BasicOutOfGas(2000000), which was our own 2M diagnostic cap rather than a
+    # provider limit; both read to head-500k without it and were unlisted on
+    # 2026-08-28 (PR #1536).
+    "0xF8F7c57FB94CC1F7f2C77Dc29b5216C4D3C3125d",  # Altcopy Index - totalAssets() staticcalls the HyperCore spot balance precompile 0x...0801 and the user vault equity precompile 0x...0802 eight times (debug_traceCall); 8,168 USDC at head, no readable history on any provider
+    # Hyperdrive HLP and Gamma Symphony Vault. Both proxies run the verified
+    # implementation 0xa05959fbd41e30396446c36d099e5f3b20fb6ad6
+    # (TokenizedVaultUpgradeable, a CoreReaderLib consumer). Their
+    # totalAssets(), convertToAssets() and maxDeposit() staticcall the L1 block
+    # number precompile 0x...0809 and revert with 0x18c34104 =
+    # CoreReaderLib.ReadFailure(0x...0809) outside the node's HyperCore view,
+    # for example at block 41,858,003 and at head-20,000 on all three
+    # providers, while totalSupply() keeps working. They hold 9,024 USDC and 36
+    # USDC at the head, so this is missing history, not a broken vault
+    # (PR #1536).
     "0x6ED613E86e8D0b6617e445f17323AC0162FF6ce6",
     "0x2b37f3566933E4DBe59c6b86BedbC91c1E04D774",
     # Rocket Markets Survivor Vault (RKTSV) on Monad. See the detailed
@@ -574,7 +690,16 @@ _BROKEN_VAULT_CONTRACTS = {
     "0x1681f371c88b0655d32e61e83d398c75dcdfcd13",
     "0x5a8aFb250525aB8Fa85EF9a5f260Eb11B77a409a",  # Age old mainnet contract from 2017 (block 4,655,173) - burns all forwarded gas before reverting, poisoning the multicall probe batch with out-of-gas (-32003)
     "0x162428775A4C6c513FF8722B91D1aF45a9Caff41",  # Unverified old mainnet EtherDelta-style DEX from 2018 (block 4,934,650) - deposit/trade/withdraw methods, not a vault
-    "0xd3F41DAC84594332E4fF3C7fd2242DeAF7857e79",  # HYPE Funding Yield (HFY) HyperEVM USDt0 vault - totalAssets() staticcalls the HyperCore spot balance precompile 0x...0801 (debug_traceCall, 2026-08-28) and its bytecode carries "SpotBalance precompile call failed"; historical reads revert on every provider, so only head valuations exist
+    # HYPE Funding Yield (HFY), HyperEVM USD0 vault. Same HyperCore mechanism as
+    # the cluster above: totalAssets() staticcalls the spot balance precompile
+    # 0x...0801 (debug_traceCall, 2026-08-28) and the unverified runtime
+    # bytecode carries the strings "SpotBalance precompile call failed",
+    # "MarkPx precompile call failed", "Position precompile call failed" and
+    # "Withdrawable precompile call failed"; goldsky answers
+    # "execution reverted: SpotBalance precompile ...". It holds 10 USD0 at the
+    # head and estimates at 126,909 gas there, but historical reads revert on
+    # every provider, so only head valuations exist (PR #1536).
+    "0xd3F41DAC84594332E4fF3C7fd2242DeAF7857e79",
 }
 
 #: Cause excessive gas fees, RPC havoc.
@@ -582,4 +707,12 @@ _BROKEN_VAULT_CONTRACTS = {
 #: Old Ethereum mainnet contracts when revert was not properly existing.
 #: Harmless but cause extra RPC load.
 #: These fail when we probe contract calls to identify them.
+#:
+#: Membership hides an address from discovery, reports and the historical price
+#: reader alike, so it is not a "skip the history" switch. The HyperEVM entries
+#: are listed under protest for exactly that reason: those vaults are alive at
+#: the head and only their HyperCore-backed history is unreadable. See the
+#: mechanism block above the same addresses in :py:data:`VAULT_SPECIFIC_RISK`,
+#: ``docs/README-hyperevm-hypercore-read-gas.md`` and PR #1536 before adding a
+#: chain 999 address here.
 BROKEN_VAULT_CONTRACTS = {addr.lower() for addr in _BROKEN_VAULT_CONTRACTS}

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -304,15 +304,21 @@ VAULT_SPECIFIC_RISK = {
     # Superform vault - no indication of underlying activity or positions
     # https://app.superform.xyz/vault/1_0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6
     "0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6": VaultTechnicalRisk.blacklisted,
-    # LONGV4 HyperEVM vault - totalAssets() and convertToAssets() run out of gas
-    # with CALL_GAS=2,000,000 and poison historical scanner Multicall3 batches.
-    "0x2eee42a0704dd4c0ff8141f85e24de9085a76093": VaultTechnicalRisk.blacklisted,
-    # Altcopy Flagship and Index HyperEVM vaults. At block 41,487,203 all
-    # configured RPC providers reject the scanner's 2,000,000-gas
-    # totalAssets(), convertToAssets() and maxDeposit() probes. The two vaults
-    # therefore poison historical Multicall3 batches and cannot be exported
-    # safely as generic ERC-4626 vaults.
-    "0xcdb9671e671562b60481e4929ef80a5360af718b": VaultTechnicalRisk.blacklisted,
+    # Altcopy Index HyperEVM vault. Its totalAssets() reads HyperCore through the
+    # spot balance (0x...0801) and user vault equity (0x...0802) precompiles, the
+    # latter eight times, confirmed with debug_traceCall on 2026-08-28. That is
+    # cheap at the head (estimate_gas 222,530) but unreadable in the past: at
+    # head-20,000, head-100,000 and head-500,000 the call fails on every
+    # configured provider, so no historical valuation exists for it.
+    #
+    # LONGV4 0x2eee42a0704dd4c0ff8141f85e24de9085a76093 and Altcopy Flagship
+    # 0xcdb9671e671562b60481e4929ef80a5360af718b were removed from this list on
+    # 2026-08-28. Their entries claimed "all providers reject the 2,000,000-gas
+    # probes", but that was the 2M CALL_GAS default of
+    # scripts/erc-4626/poke-hyperevm-vault-calls.py, not a provider limit.
+    # Without that cap LONGV4 reads at head, head-20k, head-100k and head-500k
+    # on Alchemy, and Altcopy Flagship reads at all of those depths on all three
+    # providers. See docs/README-hyperevm-hypercore-read-gas.md.
     "0xf8f7c57fb94cc1f7f2c77dc29b5216c4d3c3125d": VaultTechnicalRisk.blacklisted,
     # Hyperdrive HLP and Gamma Symphony Vault on HyperEVM. At historical block
     # 41,858,003 their totalAssets(), convertToAssets() and maxDeposit() calls
@@ -329,7 +335,13 @@ VAULT_SPECIFIC_RISK = {
     # Hyperdrive Liquid Staked Hype vault
     # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e. These two entries stay
     # blacklisted because their whole valuation surface, not just its history,
-    # was unusable when reviewed.
+    # was unusable when reviewed. Re-audited on 2026-08-28: both proxies share
+    # the verified implementation 0xa05959fbd41e30396446c36d099e5f3b20fb6ad6
+    # (TokenizedVaultUpgradeable, the same CoreReaderLib consumer as HYPED),
+    # debug_traceCall shows totalAssets() staticcalling the L1 block number
+    # precompile 0x...0809, they answer at the head (9,025 USDC and 36 USDC of
+    # assets) and they fail with ReadFailure at head-20,000 on all three
+    # providers. Only their history is unobtainable.
     "0x6ed613e86e8d0b6617e445f17323ac0162ff6ce6": VaultTechnicalRisk.blacklisted,
     "0x2b37f3566933e4dbe59c6b86bedbc91c1e04d774": VaultTechnicalRisk.blacklisted,
     # Rocket Markets Survivor Vaults on Monad.
@@ -528,9 +540,12 @@ _BROKEN_VAULT_CONTRACTS = {
     "0x5705554BAa86Da01fF4A82d29a1598c5B3A8B476",  # Open PnL feed helper contract for broken Gains vault on Berachain
     "0x8fF6aDBC653405245B6b686E31b14A7da7000281",  # BNB broken contract
     "0x6949bcab16c0B389095C5b744f6FBF9741A1b3b6",  # Test vault on Monad
-    "0x2eEe42A0704DD4C0fF8141f85E24De9085A76093",  # LONGV4 HyperEVM vault - totalAssets() and convertToAssets() hit BasicOutOfGas(2000000), poisoning historical scanner Multicall3 batches
-    "0xcDB9671E671562B60481e4929eF80A5360af718b",  # Altcopy Flagship HyperEVM vault - its core ERC-4626 probes hit BasicOutOfGas(2000000) at block 41,487,203
-    "0xF8F7c57FB94CC1F7f2C77Dc29b5216C4D3C3125d",  # Altcopy Index HyperEVM vault - totalAssets() hits BasicOutOfGas(2000000) at block 41,487,203
+    # LONGV4 0x2eEe42A0704DD4C0fF8141f85E24De9085A76093 and Altcopy Flagship
+    # 0xcDB9671E671562B60481e4929eF80A5360af718b used to be listed here for
+    # BasicOutOfGas(2000000). That figure came from the diagnostic script's 2M
+    # CALL_GAS default; both read fine without it, so they were unlisted on
+    # 2026-08-28. See VAULT_SPECIFIC_RISK above.
+    "0xF8F7c57FB94CC1F7f2C77Dc29b5216C4D3C3125d",  # Altcopy Index HyperEVM vault - totalAssets() reads the HyperCore spot balance (0x...0801) and user vault equity (0x...0802, eight times) precompiles and is unreadable at head-20k/-100k/-500k on every provider
     # Hyperdrive HLP and Gamma Symphony Vault on HyperEVM. At block
     # 41,858,003, totalAssets(), convertToAssets() and maxDeposit() revert
     # with 0x18c34104, so they cannot provide historical valuations and poison
@@ -559,7 +574,7 @@ _BROKEN_VAULT_CONTRACTS = {
     "0x1681f371c88b0655d32e61e83d398c75dcdfcd13",
     "0x5a8aFb250525aB8Fa85EF9a5f260Eb11B77a409a",  # Age old mainnet contract from 2017 (block 4,655,173) - burns all forwarded gas before reverting, poisoning the multicall probe batch with out-of-gas (-32003)
     "0x162428775A4C6c513FF8722B91D1aF45a9Caff41",  # Unverified old mainnet EtherDelta-style DEX from 2018 (block 4,934,650) - deposit/trade/withdraw methods, not a vault
-    "0xd3F41DAC84594332E4fF3C7fd2242DeAF7857e79",  # HYPE Funding Yield (HFY) HyperEVM USDt0 vault - totalAssets() and convertToAssets() hit HyperCore SpotBalance precompile revert at block 39,542,844, poisoning Multicall3 scanner batches with out-of-gas (-32003)
+    "0xd3F41DAC84594332E4fF3C7fd2242DeAF7857e79",  # HYPE Funding Yield (HFY) HyperEVM USDt0 vault - totalAssets() staticcalls the HyperCore spot balance precompile 0x...0801 (debug_traceCall, 2026-08-28) and its bytecode carries "SpotBalance precompile call failed"; historical reads revert on every provider, so only head valuations exist
 }
 
 #: Cause excessive gas fees, RPC havoc.

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -319,6 +319,17 @@ VAULT_SPECIFIC_RISK = {
     # revert with the 0x18c34104 custom error, leaving only totalSupply()
     # usable. This poisons their historical Multicall3 price-reader batch;
     # current-state probes working again does not restore the missing history.
+    #
+    # 0x18c34104 is keccak("ReadFailure(address)")[:4], the custom error the
+    # HyperCore CoreReaderLib raises when a read precompile staticcall fails,
+    # so these reverts mean "this node cannot serve the HyperCore view for that
+    # block", not "the vault is broken". Sibling vaults with the same failure
+    # mode are therefore not automatically blacklisted - see
+    # docs/README-hyperevm-hypercore-read-gas.md and the deliberately unlisted
+    # Hyperdrive Liquid Staked Hype vault
+    # 0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e. These two entries stay
+    # blacklisted because their whole valuation surface, not just its history,
+    # was unusable when reviewed.
     "0x6ed613e86e8d0b6617e445f17323ac0162ff6ce6": VaultTechnicalRisk.blacklisted,
     "0x2b37f3566933e4dbe59c6b86bedbc91c1e04d774": VaultTechnicalRisk.blacklisted,
     # Rocket Markets Survivor Vaults on Monad.

--- a/scripts/erc-4626/poke-hyperevm-vault-calls.py
+++ b/scripts/erc-4626/poke-hyperevm-vault-calls.py
@@ -7,8 +7,19 @@ vault/function pairs that can run out of gas and poison a larger Multicall3
 batch.
 
 The script is read-only for pipeline state. It writes only diagnostic output.
-Vaults with out-of-gas calls must be blacklisted in ``eth_defi/vault/risk.py``
-so they are excluded from reports and future historical scanner multicalls.
+
+An out-of-gas result here is **not** on its own a reason to blacklist a vault in
+``eth_defi/vault/risk.py``. ``CALL_GAS`` defaults to 2,000,000, which is a cap
+this script imposes, not a provider limit, and HyperEVM vaults that read
+HyperCore through the read precompiles legitimately need more than that while
+still answering correctly at the head. LONGV4 and Altcopy Flagship were
+blacklisted on this basis and had to be unlisted again in 2026-08.
+
+Before blacklisting, re-check the call without an explicit gas cap, at several
+block depths, on every configured provider, and identify the precompile reads
+with ``debug_traceCall``. Blacklist only when the whole valuation surface is
+unusable, not when a provider merely refuses to price the batch. See
+``docs/README-hyperevm-hypercore-read-gas.md``.
 
 Usage:
 
@@ -29,7 +40,9 @@ Environment variables:
 - ``BLOCK_NUMBER``: Optional. Decimal, hex, or ``latest``. Defaults to the
   current latest block number resolved once at startup.
 - ``CALL_GAS``: Optional. Gas cap for each isolated ``eth_call``. Defaults to
-  ``2000000`` to mirror HyperEVM small block constraints.
+  ``2000000`` to mirror HyperEVM small block constraints. This is a deliberately
+  pessimistic cap: exceeding it means "too heavy for a small block", not "broken
+  vault". Re-run with a higher value, or unset, before drawing conclusions.
 - ``MAX_ESTIMATED_GAS``: Optional. Above this estimate the call is marked as
   suspected gas poison. Defaults to ``CALL_GAS``.
 - ``ESTIMATE_GAS``: Optional. Run ``eth_estimateGas`` before the direct

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -3,7 +3,7 @@
 import pytest
 
 from eth_defi.vault.flag import BAD_FLAGS, VaultFlag, get_notes, get_vault_special_flags, is_flagged_vault
-from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS, VaultTechnicalRisk, get_vault_risk
+from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS, VAULT_SPECIFIC_RISK, VaultTechnicalRisk, get_vault_risk
 
 
 def test_not_in_morpho_api_is_bad_flag():
@@ -168,6 +168,24 @@ def test_mainstreet_finance_vaults_are_blacklisted(address: str) -> None:
 def test_altura_vaults_are_blacklisted() -> None:
     """All Altura vaults are hard-blacklisted."""
     assert get_vault_risk("Altura") == VaultTechnicalRisk.blacklisted
+
+
+def test_hypercore_reading_vault_is_not_blacklisted() -> None:
+    """Hyperdrive Liquid Staked Hype stays scannable despite -32003 out of gas batches.
+
+    Its totalAssets(), convertToAssets() and maxDeposit() read HyperCore through
+    the read precompiles, which makes goldsky and dRPC reject whole Multicall3
+    batches and makes the calls revert with CoreReaderLib.ReadFailure
+    (0x18c34104) outside the node's HyperCore view. The vault is alive at the
+    head, so this provider-side artefact must not turn into a blacklist entry.
+
+    See ``docs/README-hyperevm-hypercore-read-gas.md``.
+    """
+    address = "0x4d0ff6a0dd9f7316b674fb37993a3ce28bea340e"
+
+    assert address not in BROKEN_VAULT_CONTRACTS
+    assert address not in VAULT_SPECIFIC_RISK
+    assert get_vault_risk("Hyperdrive", address) == VaultTechnicalRisk.dangerous
 
 
 def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> None:

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -133,8 +133,6 @@ def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
 @pytest.mark.parametrize(
     "address",
     [
-        "0x2eee42a0704dd4c0ff8141f85e24de9085a76093",
-        "0xcdb9671e671562b60481e4929ef80a5360af718b",
         "0xf8f7c57fb94cc1f7f2c77dc29b5216c4d3c3125d",
         "0x6ed613e86e8d0b6617e445f17323ac0162ff6ce6",
         "0x2b37f3566933e4dbe59c6b86bedbc91c1e04d774",
@@ -168,6 +166,32 @@ def test_mainstreet_finance_vaults_are_blacklisted(address: str) -> None:
 def test_altura_vaults_are_blacklisted() -> None:
     """All Altura vaults are hard-blacklisted."""
     assert get_vault_risk("Altura") == VaultTechnicalRisk.blacklisted
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        # LONGV4 - reads the HyperCore position (0x...0800) and withdrawable
+        # (0x...0803) precompiles, but answers at head-500,000 on Alchemy.
+        "0x2eee42a0704dd4c0ff8141f85e24de9085a76093",
+        # Altcopy Flagship - reads the HyperCore spot balance precompile
+        # (0x...0801), and answers at head-500,000 on all three providers.
+        "0xcdb9671e671562b60481e4929ef80a5360af718b",
+    ],
+)
+def test_healed_hyperevm_vault_is_unblacklisted(address: str) -> None:
+    """HyperEVM vaults blacklisted for a 2M CALL_GAS artefact are readable again.
+
+    Their old blacklist entries claimed every provider rejected the probes. That
+    was the 2,000,000-gas cap of
+    ``scripts/erc-4626/poke-hyperevm-vault-calls.py``, not a provider limit, so
+    both vaults were unlisted on 2026-08-28.
+
+    See ``docs/README-hyperevm-hypercore-read-gas.md``.
+    """
+
+    assert address not in BROKEN_VAULT_CONTRACTS
+    assert address not in VAULT_SPECIFIC_RISK
 
 
 def test_hypercore_reading_vault_is_not_blacklisted() -> None:


### PR DESCRIPTION
## Why

`vault-scanner-looped` was stuck on HyperEVM (chain id 999), looping over the same
blocks and rotating providers without finishing the chain:

```
Switched RPC providers edge.goldsky.com -> hyperliquid-mainnet.g.alchemy.com,
cause: Last exception: Multicall failed for chain 999
Block 44,367,203, batch size: 40: {'code': -32003, 'message': 'out of gas: gas required exceeds: 600000000'}
...
Block 44,320,403, batch size: 13: {'code': -32003, 'message': 'out of gas: gas required exceeds: 300000000'}
```

The reduced batches printed 11 and then 3 addresses, which is not enough to name the
culprit from the log. The initial plan was to blacklist whatever address was
responsible; investigation showed that would have been wrong.

### Isolating the address

The failing payloads are Multicall3 `tryBlockAndAggregate(false, calls)`
(`0x399542e9`) blobs, so they can be replayed verbatim, group by group, against each
configured provider at the failing blocks:

| Batch replayed at block 44,367,203 | goldsky | dRPC | Alchemy |
|------------------------------------|---------|------|---------|
| full 40-call batch | out of gas | out of gas | ok |
| full 40-call batch minus `0x4d0fF6a0…` | ok | ok | ok |
| 13-call reduced batch | out of gas | out of gas | ok |
| `0x4d0fF6a0…` 4 calls duplicated ×2 | out of gas | out of gas | ok |
| every other address, calls duplicated ×16 | ok | ok | ok |

Group bisection of the 13-call batch (`A` = `0x4aBFd796…`, `S` = `0x4d0fF6a0…`,
`B` = `0x7188D14A…`): `A` ok, `S` ok, `B` ok, `A+S` ok, `A+B` ok, `S+B` fails, and
`S` alone duplicated fails. One address accounts for the entire failure:
**`0x4d0fF6a0DD9f7316b674Fb37993A3Ce28BEA340e`, Hyperdrive Liquid Staked Hype
(`HYPED`)**. Only three of its selectors misbehave, and `totalSupply()` never does.

### Hypothesis confirmed from the smart contract source

The hypothesis was a HyperCore read dependency. The vault is an ERC-1967 proxy whose
implementation `0x6CA870794cd307243FCc8711899e46C74B2D3f2f` **is** source-verified
(Etherscan v2 unified API with `chainid=999`) as `StakingVaultUpgradeable`, solc
0.8.28 — contrary to the "Hyperdrive contracts are unverified" note we carried. Reading
it confirms the hypothesis exactly.

`StakingVaultUpgradeable.totalAssets()` delegates to `CoreControllerLib`:

```solidity
function totalAssets(StakingVaultUpgradeable.StakingStorage storage $) public view returns (uint256 total) {
  address[] memory proxies = $.proxies.values();
  uint256 blockNumber = compositeBlockNumber();
  for (uint256 i = 0; i < proxies.length; i++) {
    total += totalAssets($, proxies[i], blockNumber);
  }
  total += address(this).balance - $.totalClaimableAssets;
}
```

Every per-proxy step reads live HyperCore state, and the block number itself is a
HyperCore read:

```solidity
total += Wei.wrap(CoreReaderLib.readSpotBalance(proxy, $.tokenIndex).total).fromWei();
CoreReaderLib.DelegatorSummary memory delegatorSummary = CoreReaderLib.readDelegatorSummary(proxy);
...
function compositeBlockNumber() private view returns (uint256) {
  return (uint256(CoreReaderLib.readL1BlockNumber()) << 128) | uint128(block.number);
}
```

`CoreReaderLib` (`@ambitlabs/hypercore`) staticcalls the HyperCore read precompiles
`0x…0801` (spot balance), `0x…0805` (delegator summary) and `0x…0809` (L1 block
number). `getProxies()` returns 3 staking proxies, so one `totalAssets()` performs
**1 + 2 × 3 = 7 HyperCore precompile reads**. `maxDeposit()` calls `totalAssets()`
directly, `convertToAssets()` reaches it through `ERC7535Upgradable`, and
`totalSupply()` is plain ERC-20 storage:

| Selector | Method | Behaviour |
|----------|--------|-----------|
| `0x01e1d114` | `totalAssets()` | heavy / reverts historically |
| `0x07a2d13a` | `convertToAssets(uint256)` | heavy / reverts historically |
| `0x402d267d` | `maxDeposit(address)` | heavy / reverts historically |
| `0x18160ddd` | `totalSupply()` | always cheap, always works |

That is exactly the observed pattern.

### Evidence 1 — the historical revert is a HyperCore read failure

The historical revert data is `0x18c34104`, which is
`keccak("ReadFailure(address)")[:4]` — the custom error `CoreReaderLib` raises when a
precompile staticcall fails. Its decoded argument is `0x…0809`, the L1 block-number
precompile, i.e. the first HyperCore read in `totalAssets()`. Availability is a
per-node, per-moment property, not a property of the block:

```
hyperliquid-mainnet.g.alchemy.com  head      -> ok, 2616.51 HYPE
hyperliquid-mainnet.g.alchemy.com  head-200  -> ReadFailure(0x…0809)
edge.goldsky.com                   head      -> ReadFailure(0x…0809)
edge.goldsky.com                   head-200  -> ok, 2616.51 HYPE
lb.drpc.org                        head      -> ReadFailure(0x…0809)
```

A binary search on Alchemy put the boundary at one block: reverting up to 44,372,819,
succeeding from 44,372,820 — about two minutes behind the head. So this vault's NAV
cannot be reconstructed for an arbitrary past block on any provider.

This also explains the `0x18c34104` reverts already recorded in `risk.py` for
Hyperdrive HLP and Gamma Symphony, where we knew the symptom but not the cause.

### Evidence 2 — the gas number is provider accounting, not real execution

Real execution is cheap: binary searching the `gas` field of a direct `eth_call` on
Alchemy, at a block where the HyperCore read succeeds, gives **~117,000 gas** for the
whole `totalAssets()` — roughly 17k per HyperCore read.

The numbers the scanner trips over come from provider-side accounting for those
staticcalls:

| Provider | Measurement |
|----------|-------------|
| Alchemy | `eth_call` executes in ~117k gas; `estimate_gas` of the same call inside Multicall3 reports 2,843,730 |
| goldsky | 4 copies of `totalAssets()` fit in one multicall under the 300M cap, 5 do not → ≥60M attributed per call |
| dRPC | same as goldsky; `maxDeposit()` is heavy there too |

On goldsky and dRPC the rejection is independent of the cap we send — 1M, 10M, 30M,
100M and 299M all come back as `out of gas: gas required exceeds: <cap>`. The node
decides up front that the batch needs more gas than allowed; nothing actually runs out
of gas. A handful of HyperCore reads is enough to push a normal 40-call batch over a
300M/600M cap, which is why the failure flaps between fallbacks and survives
batch-size reduction until the batch happens to exclude this vault.

### Why the vault stays on our list

- Hyperdrive is a real, DefiLlama-listed HyperEVM protocol and this implementation is
  source-verified.
- The vault is alive at the head: `totalAssets()` 2,616.5 HYPE (about $218k at the
  2026-08-28 HYPE mid of $83.47), `totalSupply()` 2,555.6 HYPED, share price 1.0238
  HYPE per HYPED.
- The failure is a provider-side gas-accounting and HyperCore-state-window artefact.
  Alchemy runs the same batch fine.

Blacklisting would permanently drop a live vault for a transient RPC condition — the
same conclusion the goldsky consensus document reached for its own address list. What
we do accept is that historical NAV for HyperCore-reading vaults is only obtainable
near the head and must not be "repaired" by rescanning.

## Lessons learnt

- `0x18c34104` is `CoreReaderLib.ReadFailure(address)`. When a HyperEVM vault reverts
  with it, the argument names the precompile that could not be read, so the revert
  means "this node cannot serve the HyperCore view for that block" rather than "the
  vault is broken".
- Provider gas accounting for HyperCore precompile reads varies by two orders of
  magnitude (117k real vs ≥60M attributed), so `-32003 out of gas` on chain 999 is not
  evidence of a bad contract, and the same batch may pass on another provider in the
  same fallback mix.
- A `-32003` batch abort can be attributed to a single address by replaying the logged
  `tryBlockAndAggregate` payload group by group, and by duplicating one address's calls
  until the cap is exceeded. Duplication (`×2`, `×4`, `×8`) is what separates a genuine
  gas hog from an innocent bystander that merely shared the batch.
- "Unverified contracts" notes go stale. This implementation is verified on chain 999
  through the Etherscan v2 unified API even though our Hyperdrive metadata says
  otherwise.

## Summary

- Added `docs/README-hyperevm-hypercore-read-gas.md`: symptom, the replay/bisection
  method that isolates the address, the verified-source evidence, the precompile
  table, both measurement tables, the "why we do not blacklist" reasoning and a
  reproduction snippet.
- Cross-linked it from `docs/README-hyperevm-goldsky-failure.md` and added it to the
  README index table in `CLAUDE.md`.
- `eth_defi/erc_4626/vault_protocol/hyperdrive_hl/vault.py`: documented the HyperCore
  read dependency, the two scanner consequences and the corrected verification status.
- `eth_defi/erc_4626/classification.py`: replaced the bare `# Hyperdrive vault`
  comment on the HYPED entry with the reason it is deliberately kept on the list.
- `eth_defi/event_reader/multicall_batcher.py`: line comments on the `"out of gas"`
  retry clue and on the `MulticallRetryable` fallback, warning against blacklisting a
  HyperEVM address that reads HyperCore.
- `eth_defi/vault/risk.py`: explained what `0x18c34104` is in the existing Hyperdrive
  HLP / Gamma Symphony comment and recorded that HYPED is intentionally not listed.
- `tests/vault/test_flag.py`: `test_hypercore_reading_vault_is_not_blacklisted` guards
  the decision.

No behaviour change — documentation, comments and one regression test.

## Related issues and PRs

- Continues the HyperEVM scanner reliability work documented in
  `docs/README-hyperevm-goldsky-failure.md` (eRPC consensus failover to Alchemy).
- Explains the `0x18c34104` revert already referenced by the Hyperdrive HLP and Gamma
  Symphony blacklist entries in `eth_defi/vault/risk.py`.

## Unrelated CI and test fixes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: blacklist audit of HyperEVM vaults with the same failure mode

Of the 130 addresses in `BROKEN_VAULT_CONTRACTS` + `VAULT_SPECIFIC_RISK`, exactly six
have code on chain 999. `debug_traceCall` with `callTracer` enumerates the precompile
callees of `totalAssets()` even for the unverified ones, and **all six read
HyperCore** — the same dependency as HYPED:

| Vault | Address | Precompiles read by `totalAssets()` | Assets at head | Historical read at head-20,000 (no gas cap) | `estimate_gas` at head | Verdict |
|---|---|---|---|---|---|---|
| LONGV4 | `0x2eEe42A0…` | `0x…0800` position ×2, `0x…0803` withdrawable | 0.00 USDC | Alchemy ok (also head-500k) | 59,501 | **unlisted** |
| Altcopy Flagship | `0xcDB9671E…` | `0x…0801` spot balance, `0x…080f` | 7,765 USDC | ok on all three (also head-500k) | 71,350 | **unlisted** |
| Altcopy Index | `0xF8F7c57F…` | `0x…0801`, `0x…0802` vault equity ×8 | 8,168 USDC | fails everywhere | 222,530 | stays blacklisted |
| Hyperdrive HLP | `0x6ED613E8…` | `0x…0809` L1 block number | 9,025 USDC | `ReadFailure` everywhere | 202,951 | stays blacklisted |
| Gamma Symphony | `0x2b37f356…` | `0x…0809` | 36 USDC | `ReadFailure` everywhere | 144,186 | stays blacklisted |
| HYPE Funding Yield | `0xd3F41DAC…` | `0x…0801` | 10 USD₮0 | reverts everywhere | 126,909 | stays blacklisted |
| HYPED (never listed) | `0x4d0fF6a0…` | `0x…0809` | 2,616 HYPE | `ReadFailure` everywhere | 117,896 | not listed |

Supporting evidence:

- Hyperdrive HLP and Gamma Symphony share the implementation
  `0xa05959fbd41e30396446c36d099e5f3b20fb6ad6`, verified as
  `TokenizedVaultUpgradeable` — the same `CoreReaderLib` consumer as HYPED. The
  `0x18c34104` revert their entries already recorded *is* `CoreReaderLib.ReadFailure`.
- HYPE Funding Yield is unverified, but its runtime bytecode carries
  `SpotBalance precompile call failed`, `MarkPx precompile call failed`,
  `Position precompile call failed` and `Withdrawable precompile call failed`, and
  goldsky answers `execution reverted: SpotBalance precompile…`.
- None of the six is intrinsically expensive — every `estimate_gas` at head is
  59k–223k. The megagas numbers are provider accounting for the precompile
  staticcalls.

### Two entries were wrong

`LONGV4` and `Altcopy Flagship` were blacklisted with "all configured RPC providers
reject the scanner's 2,000,000-gas probes". That 2M figure is the `CALL_GAS` default
of `scripts/erc-4626/poke-hyperevm-vault-calls.py` — a cap the diagnostic script
imposes, not a provider limit. Re-measured without it:

```
LONGV4            Alchemy  head:ok  -20k:ok  -100k:ok  -500k:ok
Altcopy Flagship  Alchemy  head:ok  -20k:ok  -100k:ok  -500k:ok
                  goldsky  head:ok  -20k:ok  -100k:ok  -500k:ok
                  dRPC     head:ok  -20k:ok  -100k:ok  -500k:ok
```

Both were therefore removed from `VAULT_SPECIFIC_RISK` and `BROKEN_VAULT_CONTRACTS`.
Residual risk is accepted and recorded: LONGV4 still draws `-32003` from dRPC and
intermittently from goldsky, so its history will come from the Alchemy pin, and
goldsky rejects Altcopy Flagship's four-probe multicall even though it answers the
same calls individually. LONGV4 is also currently empty (0 USDC), so the activity
filter should keep it out of price scans anyway.

The other four stay blacklisted, but for a corrected reason: not "broken" or
"gas-poisonous", but "historical valuation unobtainable on every provider", which is
what the price pipeline needs. When a head-NAV-only path exists they should be
revisited, since they are live vaults.

### Additional changes in this follow-up

- `scripts/erc-4626/poke-hyperevm-vault-calls.py`: the docstring no longer says
  out-of-gas calls "must be blacklisted"; it warns that `CALL_GAS=2000000` is a
  self-imposed cap and prescribes re-measuring without it, at several depths, on
  every provider, plus `debug_traceCall`, before blacklisting.
- `eth_defi/vault/risk.py`: every remaining HyperEVM entry now names the traced
  precompiles, the head assets and the depth measurements.
- `tests/vault/test_flag.py`: `test_healed_hyperevm_vault_is_unblacklisted` asserts
  the two unlisted addresses stay off both lists.
- `docs/README-hyperevm-hypercore-read-gas.md`: new "Blacklist audit" section with
  the table above.
