### PR TITLE
fix: publish vault sparklines after two weeks

### DIFF
--- a/eth_defi/research/sparkline.py
+++ b/eth_defi/research/sparkline.py
@@ -1,26 +1,50 @@
-"""Render sparkline charts for ERC-4626 vault data.
-
-- Sparkline is a mini price chart, popularised by CoinMarketCap
-- Charts contain share price and TVL
-"""
+"""Prepare, render and upload share-price sparklines for vault data."""
 
 import gzip
 import warnings
+from dataclasses import dataclass
 from io import BytesIO
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 import pandas as pd
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 from eth_defi.cloudflare_r2 import calculate_bytes_digest, create_r2_client, upload_bytes_to_r2
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.vault.base import VaultSpec
 
+#: Width of the time axis used by published vault sparklines.
+DEFAULT_SPARKLINE_WINDOW = pd.Timedelta(days=90)
 
-def _filter_finite_share_prices(vault_prices_df: pd.DataFrame) -> pd.DataFrame:
+#: Minimum elapsed finite share-price history required for publication.
+MIN_SPARKLINE_HISTORY = pd.Timedelta(days=14)
+
+
+@dataclass(slots=True)
+class SparklineData:
+    """Daily share prices and their fixed chart bounds.
+
+    Every chart spans :data:`DEFAULT_SPARKLINE_WINDOW` and ends on the latest
+    UTC day containing a finite observation. A vault younger than the window
+    occupies only the right-hand side; the period before its first observation
+    remains blank.
+    """
+
+    #: Daily finite share-price observations. Established sparse vaults include
+    #: one carried observation at ``start_at``.
+    prices_df: pd.DataFrame
+
+    #: Inclusive left edge of the chart.
+    start_at: pd.Timestamp
+
+    #: Inclusive right edge and latest UTC day containing an observation.
+    end_at: pd.Timestamp
+
+
+def filter_finite_share_prices(vault_prices_df: pd.DataFrame) -> pd.DataFrame:
     """Return chart data with only finite, float share prices.
 
     PyArrow-backed parquet data can expose ``share_price`` as a nullable or
@@ -47,6 +71,61 @@ def _filter_finite_share_prices(vault_prices_df: pd.DataFrame) -> pd.DataFrame:
     filtered = vault_prices_df.iloc[finite_mask].copy()
     filtered["share_price"] = numeric_values[finite_mask]
     return filtered
+
+
+def prepare_sparkline_data(
+    vault_prices_df: pd.DataFrame,
+    minimum_history: pd.Timedelta = MIN_SPARKLINE_HISTORY,
+    window: pd.Timedelta = DEFAULT_SPARKLINE_WINDOW,
+) -> SparklineData | None:
+    """Prepare one vault's observations for a fixed-width sparkline.
+
+    Eligibility is based on elapsed time between the first and latest finite
+    source observations, not row count. Once that span reaches two weeks by
+    default, observations are reduced to daily points. Charts always retain a
+    90-day axis by default. Young vaults leave the period before their first
+    observation blank, while older sparse vaults carry their last pre-window
+    value to the left boundary.
+
+    :param vault_prices_df:
+        Single-vault data indexed by naive UTC timestamps with a
+        ``share_price`` column.
+    :param minimum_history:
+        Minimum elapsed finite share-price history required for publication.
+    :param window:
+        Full elapsed time represented by the horizontal axis.
+    :return:
+        Daily observations and chart bounds, or ``None`` when the finite price
+        history is shorter than ``minimum_history``.
+    """
+    assert isinstance(vault_prices_df.index, pd.DatetimeIndex), f"Expected DatetimeIndex, got {type(vault_prices_df.index)}"
+    assert minimum_history > pd.Timedelta(0), f"Minimum history must be positive, got {minimum_history}"
+    assert window >= minimum_history, f"Sparkline window {window} must cover minimum history {minimum_history}"
+
+    try:
+        finite_prices_df = filter_finite_share_prices(vault_prices_df).sort_index()
+    except ValueError:
+        return None
+
+    if finite_prices_df.index[-1] - finite_prices_df.index[0] < minimum_history:
+        return None
+
+    # Eligibility uses exact source timestamps. Published charts use day
+    # boundaries so the final plotted point reaches the fixed axis edge.
+    daily_prices_df = finite_prices_df.resample("D").last().dropna(subset=["share_price"])
+    end_at = daily_prices_df.index[-1]
+    start_at = end_at - window
+    visible_prices_df = daily_prices_df.loc[(daily_prices_df.index > start_at) & (daily_prices_df.index <= end_at)]
+
+    # Forward filling cannot carry a value that was cropped away. Seed an
+    # established vault at the boundary without inventing history for a vault
+    # whose first observation is inside the window.
+    previous_prices_df = daily_prices_df.loc[daily_prices_df.index <= start_at].tail(1)
+    if not previous_prices_df.empty:
+        previous_prices_df.index = pd.DatetimeIndex([start_at], name=vault_prices_df.index.name)
+        visible_prices_df = pd.concat((previous_prices_df, visible_prices_df))
+
+    return SparklineData(prices_df=visible_prices_df, start_at=start_at, end_at=end_at)
 
 
 def extract_vault_price_data(
@@ -76,25 +155,28 @@ def render_sparkline_simple(
     vault_prices_df: pd.DataFrame,
     width: int = 256,
     height: int = 64,
-    ffill=True,
+    ffill: bool = True,  # noqa: FBT001, FBT002
 ) -> plt.Figure:
-    """Render a sparkline chart for a single vault.
+    """Render a simple share-price sparkline for one vault.
 
-    :param spec:
-        chain-vault address identifier
-
+    :param vault_prices_df:
+        Single-vault prices indexed by naive UTC timestamps.
+    :param width:
+        Output width in pixels.
+    :param height:
+        Output height in pixels.
     :param ffill:
-        Forward-fill the sparse source data
+        Forward-fill sparse observations to an hourly line before rendering.
+    :return:
+        Matplotlib figure ready for export.
     """
+    assert not vault_prices_df.empty, "Cannot render an empty vault price series"
+    assert isinstance(vault_prices_df.index, pd.DatetimeIndex), f"Expected DatetimeIndex, got: {type(vault_prices_df.index)}"
 
     vault_data = vault_prices_df
-
-    assert len(vault_data) > 0, f"No data for vault: {id}"
-    assert isinstance(vault_data.index, pd.DatetimeIndex), f"Expected DatetimeIndex, got: {type(vault_data.index)}"
-
     if ffill:
-        # old_data = vault_data.copy()
         vault_data = forward_fill_vault(vault_data)
+    vault_data = filter_finite_share_prices(vault_data)
 
     # Convert pixels to inches (matplotlib uses inches)
     dpi = 100
@@ -106,48 +188,66 @@ def render_sparkline_simple(
     ax1.patch.set_alpha(0.0)
     ax1.plot(vault_data.index, vault_data["share_price"], color="#a6a4a0", linewidth=2)
 
-    # Alpha = 0 = hidden for now
-    ax2 = ax1.twinx()
-    # ax2.patch.set_alpha(0.0)
-    # ax2.plot(vault_data.index, vault_data["total_assets"], color="#999999", linewidth=2, alpha=0.0)
-
     # Remove all spines, ticks, labels
-    for ax in (ax1, ax2):
-        for spine in ax.spines.values():
-            spine.set_visible(False)
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.get_xaxis().set_visible(False)
-        ax.get_yaxis().set_visible(False)
-        ax.margins(x=0, y=0)  # eliminate data padding
-
-    # Fill entire canvas
-    fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
-
-    fig.patch.set_facecolor("black")
-    ax1.patch.set_facecolor("black")
+    for spine in ax1.spines.values():
+        spine.set_visible(False)
+    ax1.set_axis_off()
+    ax1.margins(x=0, y=0)
 
     return fig
 
 
-def render_sparkline_gradient(
+def render_sparkline_gradient(  # noqa: PLR0917
     vault_prices_df: pd.DataFrame,
     width: int = 300,
     height: int = 300,
-    ffill=True,
-    line_color="#22B452",
-    bg_color="#282827",
+    ffill: bool = True,  # noqa: FBT001, FBT002
+    line_color: str = "#22B452",
+    bg_color: str = "#282827",
     line_width: int = 2,
-    margin_ratio=50,
+    margin_ratio: int = 50,
+    x_axis_range: tuple[pd.Timestamp, pd.Timestamp] | None = None,
 ) -> plt.Figure:
-    """Render a sparkline chart with green-to-black gradient fill."""
+    """Render a sparkline chart with green-to-black gradient fill.
+
+    The optional explicit horizontal range lets callers render a short price
+    history within a longer fixed chart period. Matplotlib leaves time before
+    the first observation blank instead of stretching the available data to
+    fill the canvas.
+
+    :param vault_prices_df:
+        Single-vault prices indexed by naive UTC timestamps. ``share_price``
+        must contain at least one finite observation.
+    :param width:
+        Output figure width in pixels.
+    :param height:
+        Output figure height in pixels.
+    :param ffill:
+        Forward-fill sparse observations to an hourly line before rendering.
+    :param line_color:
+        Colour at the top of the gradient fill.
+    :param bg_color:
+        Figure and axes background colour.
+    :param line_width:
+        Price line width in pixels.
+    :param margin_ratio:
+        Vertical margin in pixels relative to the output height.
+    :param x_axis_range:
+        Optional inclusive chart bounds. The first value must precede the
+        second and both must be naive UTC timestamps.
+    :return:
+        Matplotlib figure ready for PNG or SVG export.
+    """
+
+    if x_axis_range is not None:
+        assert x_axis_range[0] < x_axis_range[1], f"Invalid sparkline x-axis range: {x_axis_range}"
 
     vault_data = vault_prices_df
 
     if ffill:
         vault_data = forward_fill_vault(vault_data)
 
-    vault_data = _filter_finite_share_prices(vault_data)
+    vault_data = filter_finite_share_prices(vault_data)
 
     dpi = 100
     fig = plt.figure(figsize=(width / dpi, height / dpi), dpi=dpi)
@@ -162,52 +262,38 @@ def render_sparkline_gradient(
     y_range = y_max - y_min
 
     # Calculate margin in data units (50px / height * y_range)
-    margin_ratio = margin_ratio / height
+    margin_ratio /= height
     y_margin = y_range * margin_ratio
 
-    # Apply margins (top only)
+    # Apply equal vertical margins.
     y_min_with_margin = y_min - y_margin
-
-    # y_min_with_margin = y_min
     y_max_with_margin = y_max + y_margin
 
-    # Set y-axis limits with margin
-    # UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
+    # Constant-price series produce identical y limits. Matplotlib expands them
+    # automatically; the warning is expected and does not affect the image.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         ax1.set_ylim(y_min_with_margin, y_max_with_margin)
 
-        # Rest of the code remains the same, but use original y_min for gradient extent
-        gradient = np.linspace(0, 1, 256).reshape(256, 1)
-        im = ax1.imshow(
-            gradient,
-            extent=[vault_data.index[0], vault_data.index[-1], y_min, y_max],
-            aspect="auto",
-            cmap=plt.cm.colors.LinearSegmentedColormap.from_list("green_black", [line_color, bg_color]),
-            alpha=0.4,
-            zorder=0,
-        )
+    gradient = np.linspace(0, 1, 256).reshape(256, 1)
+    im = ax1.imshow(
+        gradient,
+        extent=[vault_data.index[0], vault_data.index[-1], y_min, y_max],
+        aspect="auto",
+        cmap=plt.cm.colors.LinearSegmentedColormap.from_list("green_black", [line_color, bg_color]),
+        alpha=0.4,
+        zorder=0,
+    )
+    collection = ax1.fill_between(vault_data.index, vault_data["share_price"], y_min, alpha=0)
+    im.set_clip_path(collection.get_paths()[0], transform=ax1.transData)
+    ax1.plot(vault_data.index, vault_data["share_price"], color="#00ff88", linewidth=line_width, zorder=2)
 
-        collection = ax1.fill_between(vault_data.index, vault_data["share_price"], y_min, alpha=0)
-        im.set_clip_path(collection.get_paths()[0], transform=ax1.transData)
-
-        ax1.plot(
-            vault_data.index,
-            vault_data["share_price"],
-            color="#00ff88",
-            linewidth=line_width,
-            zorder=2,
-        )
-
-        for spine in ax1.spines.values():
-            spine.set_visible(False)
-        ax1.set_xticks([])
-        ax1.set_yticks([])
-        ax1.get_xaxis().set_visible(False)
-        ax1.get_yaxis().set_visible(False)
-        ax1.margins(x=0, y=0)
-
-        fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+    for spine in ax1.spines.values():
+        spine.set_visible(False)
+    ax1.set_axis_off()
+    ax1.margins(x=0, y=0)
+    if x_axis_range is not None:
+        ax1.set_xlim(x_axis_range)
 
     return fig
 
@@ -217,16 +303,10 @@ def export_sparkline_as_png(
 ) -> bytes:
     """Render a sparkline chart and return as PNG bytes."""
 
-    # Create a BytesIO buffer to save the PNG
     buffer = BytesIO()
     fig.savefig(buffer, format="png", dpi=100, transparent=False)
     plt.close(fig)
-
-    # Get the PNG bytes
-    buffer.seek(0)
-    png_bytes = buffer.read()
-
-    return png_bytes
+    return buffer.getvalue()
 
 
 def export_sparkline_as_svg(
@@ -234,19 +314,16 @@ def export_sparkline_as_svg(
 ) -> bytes:
     """Render a sparkline chart and return as SVG bytes."""
 
-    # Create a BytesIO buffer to save the SVG
     buffer = BytesIO()
-    fig.savefig(buffer, format="svg", transparent=True)
+    # Matplotlib otherwise embeds the current time and randomises SVG element
+    # identifiers, making an unchanged chart look different to R2 on each run.
+    with mpl.rc_context({"svg.hashsalt": "eth-defi-sparkline"}):
+        fig.savefig(buffer, format="svg", transparent=True, metadata={"Date": None})
     plt.close(fig)
-
-    # Get the SVG bytes
-    buffer.seek(0)
-    svg_bytes = buffer.read()
-
-    return svg_bytes
+    return buffer.getvalue()
 
 
-def upload_to_r2_compressed(  # noqa: PLR0917, FBT001, FBT002
+def upload_to_r2_compressed(  # noqa: PLR0917
     payload: bytes,
     bucket_name: str,
     object_name: str,
@@ -254,17 +331,16 @@ def upload_to_r2_compressed(  # noqa: PLR0917, FBT001, FBT002
     access_key_id: str,
     secret_access_key: str,
     content_type: str,
-    skip_if_current: bool = False,
-):
-    """Uploads a the vault sparklines payload to a Cloudflare R2 bucket.
+    skip_if_current: bool = False,  # noqa: FBT001, FBT002
+) -> bool:
+    """Upload a gzip-compressed sparkline image to Cloudflare R2.
 
-    - Exported to the frontend listings
-    - Compress SVGs with gzip
+    The source checksum is calculated before compression so deterministic
+    chart bytes can skip an unchanged remote object.
 
     :param payload: The bytes data to upload.
     :param bucket_name: The name of the R2 bucket.
     :param object_name: The destination object name (e.g., "my-image.png").
-    :param account_id: Your Cloudflare R2 account ID.
     :param access_key_id: Your R2 access key ID.
     :param secret_access_key: Your R2 secret access key.
     :param content_type: The MIME type of the file.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1626,7 +1626,21 @@ poetry run python scripts/erc-4626/clean-prices.py
 
 ### export-sparklines.py
 
-Export all vault sparklines to Cloudflare R2. Run after cleaned prices are generated.
+Export eligible vault share-price sparklines to Cloudflare R2. Run after
+`cleaned-vault-prices-1h.parquet` is generated.
+
+A vault is eligible when its denomination is stablecoin-like, its historical
+peak TVL reaches USD 5,000 (USD 500 for the temporary ApeX exemption), and its
+first and latest finite share-price observations span at least 14 days. The
+threshold is elapsed history, not a requirement for 14 daily samples.
+
+Every published chart has a 90-day horizontal axis ending on the vault's own
+latest observation day. A vault with 14–89 days of history is drawn on the
+right, while the period before its first observation stays blank. An inactive
+vault whose latest observation is older than the dataset-wide latest timestamp
+is still rendered from its own history. The exporter publishes a listing SVG
+and social-card PNG for each vault. Both are gzip-compressed, and unchanged
+source images are skipped using checksum metadata.
 
 ```shell
 poetry run python scripts/erc-4626/export-sparklines.py
@@ -1634,7 +1648,11 @@ poetry run python scripts/erc-4626/export-sparklines.py
 
 | Variable | Description |
 |----------|-------------|
-| `MAX_WORKERS` | Optional. Parallel workers. |
+| `R2_SPARKLINE_BUCKET_NAME` | Required. Destination R2 bucket name. |
+| `R2_SPARKLINE_ENDPOINT_URL` | Required. R2 S3-compatible endpoint URL. |
+| `R2_SPARKLINE_ACCESS_KEY_ID` | Required. R2 access key ID. |
+| `R2_SPARKLINE_SECRET_ACCESS_KEY` | Required. R2 secret access key. |
+| `MAX_WORKERS` | Optional. Rendering processes and upload threads. Default: 20. |
 
 ### export-protocol-metadata.py
 
@@ -2503,7 +2521,10 @@ poetry run python scripts/erc-4626/vault-price-stats.py
 
 ### render-sparkline.py
 
-Test rendering a sparkline for a single vault and open the result in a browser.
+Render one vault with the same 14-day eligibility and fixed 90-day axis as the
+production exporter, then open the PNG in a browser. Set `VAULT_ID` to override
+the example vault. If `R2_SPARKLINE_BUCKET_NAME` is configured, the script also
+uploads the PNG under a `test-<vault-id>.png` object name.
 
 ```shell
 poetry run python scripts/erc-4626/render-sparkline.py

--- a/scripts/erc-4626/export-sparklines.py
+++ b/scripts/erc-4626/export-sparklines.py
@@ -1,38 +1,42 @@
-"""Export all sparklines to Cloudflare R2.
+"""Export eligible vault share-price sparklines to Cloudflare R2.
 
-- Run after cleaned prices 1h is generated
+Run after ``cleaned-vault-prices-1h.parquet`` has been generated.
 
 Example:
 
 .. code-block:: shell
 
-    python scripts/erc-4626/export-sparklines.py
+    poetry run python scripts/erc-4626/export-sparklines.py
 
 """
 
 import gzip
+import logging
 import os
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, TypedDict
 
 import pandas as pd
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
-from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, render_sparkline_gradient
+from eth_defi.cloudflare_r2 import calculate_bytes_digest, create_r2_client, upload_bytes_to_r2
+from eth_defi.research.sparkline import MIN_SPARKLINE_HISTORY, SparklineData, export_sparkline_as_png, export_sparkline_as_svg, prepare_sparkline_data, render_sparkline_gradient
 from eth_defi.token import is_stablecoin_like
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.vaultdb import VaultDatabase, get_pipeline_data_dir
 
-#: What's the threshold to render the spark line for the vault
+logger = logging.getLogger(__name__)
+
+#: Minimum historical peak TVL in USD for general vault sparkline publication.
 #:
-#: Must match the value in vault-analysis-json.py
+#: Keep aligned with ``scripts/erc-4626/vault-analysis-json.py``.
 MIN_PEAK_TVL = 5000
 
 #: Temporary rollout threshold for ApeX native vaults.
 #:
 #: ApeX is a new protocol with very little TVL, so its otherwise useful vault
-#: history would not receive sparklines under the general USDT 5,000 threshold.
+#: history would not receive sparklines under the general USD 5,000 threshold.
 #: Keep this exemption scoped to ApeX until the protocol has established TVL.
 APEX_MIN_PEAK_TVL = 500
 
@@ -43,24 +47,25 @@ APEX_PROTOCOL_NAME = "ApeX"
 def resolve_sparkline_peak_tvl_threshold(vault_row: dict) -> int:
     """Resolve the peak-TVL requirement for one vault's sparkline.
 
-    Most vaults use the shared USDT 5,000 threshold. ApeX receives a temporary
-    USDT 500 exemption because it is a new protocol whose small native vaults
+    Most vaults use the shared USD 5,000 threshold. ApeX receives a temporary
+    USD 500 exemption because it is a new protocol whose small native vaults
     would otherwise have no sparklines despite having useful history.
 
     :param vault_row:
         Vault metadata row from :class:`eth_defi.vault.vaultdb.VaultDatabase`.
     :return:
-        Minimum historical total assets in USDT needed to render a sparkline.
+        Minimum historical USD total assets needed to publish a sparkline.
     """
     if vault_row.get("Protocol") == APEX_PROTOCOL_NAME:
         return APEX_MIN_PEAK_TVL
     return MIN_PEAK_TVL
 
 
-@dataclass
-class RenderData:
+class RenderData(TypedDict):
+    """Plain worker-process result for one rendered image."""
+
     vault_id: str
-    svg_bytes: bytes
+    payload: bytes
     content_type: str
     extension: str
 
@@ -71,13 +76,20 @@ def get_included_vault_ids(
 ) -> set[str]:
     """Pre-compute which vault IDs pass the inclusion filter.
 
-    Uses a single groupby aggregation instead of per-vault get_group() calls,
-    which avoids expensive pyarrow ChunkedArray.take() on every iteration.
+    A vault must be denominated in a stablecoin-like asset and have crossed its
+    protocol-specific historical peak-TVL threshold. The aggregation is done
+    once to avoid repeated PyArrow ``ChunkedArray.take()`` calls.
+
+    :param vault_db:
+        Vault metadata used for denomination, protocol and identity.
+    :param prices_df:
+        All cleaned prices with ``id`` and ``total_assets`` columns.
+    :return:
+        Vault string IDs eligible for history preparation.
     """
-    # Compute peak TVL per vault in one pass
     peak_tvl = prices_df.groupby("id")["total_assets"].max()
 
-    included = set()
+    included: set[str] = set()
     for row in vault_db.rows.values():
         vault_id = row["_detection_data"].get_spec().as_string_id()
         denomination = row.get("Denomination") or ""
@@ -89,9 +101,157 @@ def get_included_vault_ids(
     return included
 
 
-def main():
-    logger = setup_console_logging(
-        log_file=Path(f"logs/export-spark-lines.log"),
+def prepare_vault_sparklines(
+    prices_df: pd.DataFrame,
+    included_ids: set[str],
+) -> tuple[list[tuple[str, SparklineData]], int]:
+    """Prepare all eligible vault histories for process workers.
+
+    Full per-vault histories are retained until each vault has established its
+    own latest finite observation. This is necessary for inactive vaults whose
+    valid history ends before the dataset-wide 90-day period.
+
+    :param prices_df:
+        Cleaned prices indexed by ``timestamp`` with ``id``, ``share_price``
+        and ``total_assets`` columns.
+    :param included_ids:
+        Vault IDs that passed denomination and peak-TVL policy.
+    :return:
+        Prepared worker inputs and the number skipped for insufficient finite
+        share-price history.
+    """
+    selected_prices_df = prices_df.loc[prices_df["id"].isin(included_ids), ["id", "share_price", "total_assets"]]
+    selected_prices_df = selected_prices_df.reset_index().set_index(["id", "timestamp"]).sort_index()
+
+    prepared: list[tuple[str, SparklineData]] = []
+    skipped = 0
+    for vault_id in sorted(included_ids):
+        sparkline_data = prepare_sparkline_data(selected_prices_df.loc[vault_id])
+        if sparkline_data is None:
+            skipped += 1
+            logger.debug("Skipping sparkline for vault %s: less than %s of finite share-price history", vault_id, MIN_SPARKLINE_HISTORY)
+            continue
+        prepared.append((vault_id, sparkline_data))
+
+    return prepared, skipped
+
+
+def render_vault_sparklines(vault_id: str, sparkline_data: SparklineData) -> list[RenderData]:
+    """Render listing SVG and social-card PNG images for one vault.
+
+    Plain dictionaries cross Joblib's standalone-script process boundary
+    without requiring a custom class to be reconstructed from ``__main__``.
+
+    :param vault_id:
+        Vault string ID used in published filenames.
+    :param sparkline_data:
+        Prepared daily observations and fixed chart bounds.
+    :return:
+        Two rendered image dictionaries, or an empty list if rendering rejects
+        the data.
+    """
+    try:
+        fig_svg = render_sparkline_gradient(
+            sparkline_data.prices_df,
+            width=100,
+            height=25,
+            line_width=1,
+            margin_ratio=4,
+            x_axis_range=(sparkline_data.start_at, sparkline_data.end_at),
+        )
+        fig_png = render_sparkline_gradient(
+            sparkline_data.prices_df,
+            width=300,
+            height=300,
+            x_axis_range=(sparkline_data.start_at, sparkline_data.end_at),
+        )
+        return [
+            {"vault_id": vault_id, "payload": export_sparkline_as_svg(fig_svg), "content_type": "image/svg+xml", "extension": "svg"},
+            {"vault_id": vault_id, "payload": export_sparkline_as_png(fig_png), "content_type": "image/png", "extension": "png"},
+        ]
+    except ValueError as exc:
+        logger.warning("Skipping sparkline for vault %s: %s", vault_id, exc)
+        return []
+
+
+def render_sparklines(
+    vault_data: list[tuple[str, SparklineData]],
+    max_workers: int,
+) -> list[RenderData]:
+    """Render prepared vaults in worker processes.
+
+    :param vault_data:
+        Prepared vault IDs and chart data.
+    :param max_workers:
+        Number of Joblib worker processes.
+    :return:
+        Flattened SVG and PNG render results.
+    """
+    tasks = (delayed(render_vault_sparklines)(vault_id, sparkline_data) for vault_id, sparkline_data in vault_data)
+    results = Parallel(n_jobs=max_workers, prefer="processes")(tqdm(tasks, total=len(vault_data), desc="Rendering sparklines"))
+    return [image for vault_images in results for image in vault_images]
+
+
+def upload_sparkline(
+    s3_client: Any,
+    bucket_name: str,
+    render_data: RenderData,
+) -> bool:
+    """Upload one changed image to R2.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+    :param bucket_name:
+        Destination R2 bucket.
+    :param render_data:
+        Uncompressed rendered image and its publication metadata.
+    :return:
+        ``True`` when uploaded, ``False`` when the remote source checksum
+        already matches.
+    """
+    payload = render_data["payload"]
+    object_name = f"sparkline-90d-{render_data['vault_id']}.{render_data['extension']}"
+    return upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=gzip.compress(payload, mtime=0),
+        bucket_name=bucket_name,
+        object_name=object_name,
+        content_type=render_data["content_type"],
+        content_encoding="gzip",
+        skip_if_current=True,
+        source_digest=calculate_bytes_digest(payload),
+    )
+
+
+def upload_sparklines(
+    s3_client: Any,
+    bucket_name: str,
+    render_data: list[RenderData],
+    max_workers: int,
+) -> tuple[int, int]:
+    """Upload rendered images concurrently.
+
+    :param s3_client:
+        Authenticated boto3 S3 client shared by upload threads.
+    :param bucket_name:
+        Destination R2 bucket.
+    :param render_data:
+        Rendered SVG and PNG images.
+    :param max_workers:
+        Number of Joblib upload threads.
+    :return:
+        Uploaded and unchanged image counts.
+    """
+    tasks = (delayed(upload_sparkline)(s3_client, bucket_name, image) for image in render_data)
+    results = Parallel(n_jobs=max_workers, prefer="threads")(tqdm(tasks, total=len(render_data), desc=f"Uploading sparklines to R2 bucket {bucket_name}"))
+    uploaded = sum(results)
+    return uploaded, len(results) - uploaded
+
+
+def main() -> None:
+    """Render and publish all eligible vault sparklines."""
+    setup_console_logging(
+        log_file=Path("logs/export-spark-lines.log"),
         only_log_file=False,
         clear_log_file=False,
     )
@@ -103,124 +263,30 @@ def main():
     max_workers = int(os.environ.get("MAX_WORKERS", "20"))
 
     assert bucket_name, "R2_SPARKLINE_BUCKET_NAME environment variable is required"
+    assert endpoint_url, "R2_SPARKLINE_ENDPOINT_URL environment variable is required"
+    assert access_key_id, "R2_SPARKLINE_ACCESS_KEY_ID environment variable is required"
+    assert secret_access_key, "R2_SPARKLINE_SECRET_ACCESS_KEY environment variable is required"
 
     data_dir = get_pipeline_data_dir()
     vault_db = VaultDatabase.read(data_dir / "vault-metadata-db.pickle")
-    prices_df = pd.read_parquet(data_dir / "cleaned-vault-prices-1h.parquet")
+    prices_df = pd.read_parquet(data_dir / "cleaned-vault-prices-1h.parquet", columns=["id", "share_price", "total_assets"])
 
-    # Select entries with peak TVL threshold - uses single aggregation pass
     included_ids = get_included_vault_ids(vault_db, prices_df)
-    vault_rows = [r for r in vault_db.rows.values() if r["_detection_data"].get_spec().as_string_id() in included_ids]
-
-    logger.info(f"Exporting sparklines for {len(vault_rows)} vaults to R2 bucket '{bucket_name}'")
-
-    # Export last 90 days
-
-    last_day = prices_df.index.max()
-
-    prices_df = prices_df[prices_df.index >= (last_day - pd.Timedelta(days=90))]
-    prices_df = prices_df.reset_index().set_index(["id", "timestamp"]).sort_index()
-
-    # Pre-extract per-vault DataFrames so workers receive small data, not the full prices_df
-    vault_data_items = []
-    for row in vault_rows:
-        detection_data = row["_detection_data"]
-        spec = detection_data.get_spec()
-        vault_id = spec.as_string_id()
-        try:
-            vault_prices_df = prices_df.loc[vault_id]
-        except KeyError:
-            continue
-        # Resample to daily data points once
-        vault_prices_df = vault_prices_df.resample("D").last()[["share_price", "total_assets"]]
-        vault_data_items.append((vault_id, vault_prices_df))
-
-    logger.info("Rendering sparklines for %s vaults with %s workers", len(vault_data_items), max_workers)
-
-    # Render both SVG and PNG for a single vault - uses Agg backend, safe in worker processes
-    def _render_vault(vault_id: str, vault_prices_df: pd.DataFrame) -> list[RenderData]:
-        results = []
-
-        try:
-            # Small SVG sparkline for listings
-            fig_svg = render_sparkline_gradient(
-                vault_prices_df,
-                width=100,
-                height=25,
-                line_width=1,
-                margin_ratio=4,
-            )
-            svg_bytes = export_sparkline_as_svg(fig_svg)
-            results.append(
-                RenderData(
-                    vault_id=vault_id,
-                    svg_bytes=svg_bytes,
-                    content_type="image/svg+xml",
-                    extension="svg",
-                )
-            )
-
-            # Large PNG sparkline for Twitter Summary Cards
-            fig_png = render_sparkline_gradient(
-                vault_prices_df,
-                width=300,
-                height=300,
-            )
-            png_bytes = export_sparkline_as_png(fig_png)
-            results.append(
-                RenderData(
-                    vault_id=vault_id,
-                    svg_bytes=png_bytes,
-                    content_type="image/png",
-                    extension="png",
-                )
-            )
-        except ValueError as e:
-            logger.warning("Skipping sparkline for vault %s: %s", vault_id, e)
-
-        return results
-
-    # Parallelise rendering across processes - each gets its own matplotlib instance
-    render_tasks = (delayed(_render_vault)(vid, df) for vid, df in vault_data_items)
-    render_results = Parallel(n_jobs=max_workers, prefer="processes")(tqdm(render_tasks, total=len(vault_data_items), desc="Rendering sparklines"))
-    render_data = [item for sublist in render_results for item in sublist]
+    logger.info("Preparing sparklines for %s vaults for R2 bucket '%s'", len(included_ids), bucket_name)
+    vault_data, skipped = prepare_vault_sparklines(prices_df, included_ids)
+    logger.info("Skipped %s vaults without at least %s of finite share-price history", skipped, MIN_SPARKLINE_HISTORY)
+    logger.info("Rendering sparklines for %s vaults with %s workers", len(vault_data), max_workers)
+    render_data = render_sparklines(vault_data, max_workers)
 
     logger.info("Uploading %s sparkline images to R2", len(render_data))
-
-    # Create boto3 client once, reuse for all uploads.
-    # Set max_pool_connections to match worker count so urllib3
-    # doesn't discard connections under concurrent thread load.
-    import boto3
-    from botocore.config import Config
-    from botocore.exceptions import ClientError
-
-    s3_client = boto3.client(
-        "s3",
+    s3_client = create_r2_client(
         endpoint_url=endpoint_url,
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
-        region_name="auto",
-        config=Config(max_pool_connections=max_workers),
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        max_pool_connections=max_workers,
     )
-
-    def _upload_row(render_data: RenderData):
-        object_name = f"sparkline-90d-{render_data.vault_id}.{render_data.extension}"
-        try:
-            s3_client.put_object(
-                Bucket=bucket_name,
-                Key=object_name,
-                Body=gzip.compress(render_data.svg_bytes),
-                ContentType=render_data.content_type,
-                ContentEncoding="gzip",
-            )
-        except ClientError as e:
-            raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name} (endpoint: {endpoint_url}, access_key_id: {access_key_id}): {e}") from e
-
-    # Upload in parallel using threads (I/O bound)
-    upload_tasks = (delayed(_upload_row)(row) for row in render_data)
-    Parallel(n_jobs=max_workers, prefer="threads")(tqdm(upload_tasks, total=len(render_data), desc=f"Uploading sparklines to R2 bucket {bucket_name}"))
-
-    print("Sparkline export complete")
+    uploaded, unchanged = upload_sparklines(s3_client, bucket_name, render_data, max_workers)
+    logger.info("Uploaded %s changed sparkline images and skipped %s unchanged images", uploaded, unchanged)
 
 
 if __name__ == "__main__":

--- a/scripts/erc-4626/render-sparkline.py
+++ b/scripts/erc-4626/render-sparkline.py
@@ -1,22 +1,24 @@
-"""Test rendering a sparkline for a single vault.
-
-- Open the result in a browser
-"""
+"""Render one production-style vault sparkline and open its PNG in a browser."""
 
 import base64
 import os
 import tempfile
 import webbrowser
 
+from eth_defi.research.sparkline import export_sparkline_as_png, extract_vault_price_data, prepare_sparkline_data, render_sparkline_gradient, upload_to_r2_compressed
 from eth_defi.vault.base import VaultSpec
-from eth_defi.research.sparkline import extract_vault_price_data, render_sparkline_simple, export_sparkline_as_svg, render_sparkline_gradient, export_sparkline_as_png
 from eth_defi.vault.vaultdb import VaultDatabase, read_default_vault_prices
 
 
-def display_png_in_browser(title: str, png_bytes: bytes):
+def display_png_in_browser(title: str, png_bytes: bytes) -> None:
     """Display PNG bytes in the default web browser.
 
-    :param png_bytes: PNG image as bytes
+    :param title:
+        Browser page title.
+    :param png_bytes:
+        PNG image bytes.
+    :return:
+        None.
     """
     # Encode PNG bytes as base64
     base64_png = base64.b64encode(png_bytes).decode("utf-8")
@@ -35,7 +37,7 @@ def display_png_in_browser(title: str, png_bytes: bytes):
     """
 
     # Write to temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", encoding="utf-8", delete=False) as f:
         f.write(html_content)
         temp_path = f.name
 
@@ -43,38 +45,8 @@ def display_png_in_browser(title: str, png_bytes: bytes):
     webbrowser.open(f"file://{temp_path}")
 
 
-def display_svg_in_browser(title: str, svg_bytes: bytes):
-    """Display SVG bytes in the default web browser.
-
-    :param title: The title for the HTML page.
-    :param svg_bytes: SVG image as bytes.
-    """
-    # Encode SVG bytes as base64
-    base64_svg = base64.b64encode(svg_bytes).decode("utf-8")
-
-    # Create HTML with embedded image
-    html_content = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Sparkline Chart for {title}</title>
-    </head>
-    <body bgcolor="#000000">
-        <img src="data:image/svg+xml;base64,{base64_svg}" />
-    </body>
-    </html>
-    """
-
-    # Write to temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
-        f.write(html_content)
-        temp_path = f.name
-
-    # Open in browser
-    webbrowser.open(f"file://{temp_path}")
-
-
-def main():
+def main() -> None:
+    """Render the configured vault using the publication preparation policy."""
     vault_db = VaultDatabase.read()
     prices_df = read_default_vault_prices()
 
@@ -91,29 +63,16 @@ def main():
         prices_df=prices_df,
     )
 
-    # Listing sparklien
-    # See export-sparklines.py
+    sparkline_data = prepare_sparkline_data(vault_prices_df[["share_price", "total_assets"]])
+    assert sparkline_data is not None, f"Vault needs at least 14 days of finite share-price history: {vault_id}"
+
     fig = render_sparkline_gradient(
-        vault_prices_df,
-        width=100,
-        height=25,
-        line_width=1,
-        margin_ratio=4,
+        sparkline_data.prices_df,
+        width=300,
+        height=300,
+        x_axis_range=(sparkline_data.start_at, sparkline_data.end_at),
     )
-
-    # Twitter Summary CArd
-    # https://developer.x.com/en/docs/x-for-websites/cards/overview/summary-card-with-large-image
-    # fig = render_sparkline_gradient(
-    #     vault_prices_df,
-    # )
-    #
-    svg_bytes = export_sparkline_as_svg(
-        fig,
-    )
-
-    png_bytes = export_sparkline_as_png(
-        fig,
-    )
+    png_bytes = export_sparkline_as_png(fig)
 
     display_png_in_browser(
         f"Vault {vault['Name']}: {vault_id}",
@@ -124,28 +83,28 @@ def main():
     object_name = f"test-{spec.as_string_id()}.png"
 
     bucket_name = os.environ.get("R2_SPARKLINE_BUCKET_NAME")
-    account_id = os.environ.get("R2_SPARKLINE_ACCOUNT_ID")
     access_key_id = os.environ.get("R2_SPARKLINE_ACCESS_KEY_ID")
     secret_access_key = os.environ.get("R2_SPARKLINE_SECRET_ACCESS_KEY")
     endpoint_url = os.environ.get("R2_SPARKLINE_ENDPOINT_URL")
 
     if bucket_name:
-        from eth_defi.research.sparkline import upload_to_r2_compressed
-
-        print(f"Uploading sparkline to R2 bucket '{bucket_name}' as '{object_name}', access key is {access_key_id}, account is {account_id}")
+        assert access_key_id, "R2_SPARKLINE_ACCESS_KEY_ID is required for upload"
+        assert secret_access_key, "R2_SPARKLINE_SECRET_ACCESS_KEY is required for upload"
+        assert endpoint_url, "R2_SPARKLINE_ENDPOINT_URL is required for upload"
+        print(f"Uploading sparkline to R2 bucket '{bucket_name}' as '{object_name}'")
 
         upload_to_r2_compressed(
-            payload=svg_bytes,
+            payload=png_bytes,
             bucket_name=bucket_name,
             object_name=object_name,
             endpoint_url=endpoint_url,
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
-            content_type="image/svg+xml",
+            content_type="image/png",
         )
         print(f"Uploaded sparkline to R2 bucket '{bucket_name}' as '{object_name}'")
     else:
-        print(f"R2_SPARKLINE_BUCKET_NAME not set, skipping upload")
+        print("R2_SPARKLINE_BUCKET_NAME not set, skipping upload")
 
 
 if __name__ == "__main__":

--- a/tests/erc_4626/test_export_sparklines.py
+++ b/tests/erc_4626/test_export_sparklines.py
@@ -1,21 +1,22 @@
-"""Test sparkline export inclusion policy."""
+"""Test standalone sparkline export orchestration."""
 
 from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pandas as pd
+import pytest
+from joblib import Parallel, delayed
 
+from eth_defi.research.sparkline import prepare_sparkline_data
 from eth_defi.vault.base import VaultSpec
 
 
-def _load_export_sparklines_module():
-    """Load the standalone sparkline export script as a Python module.
-
-    The production scanner imports this script dynamically, so this test loads
-    the same file rather than duplicating its inclusion policy.
+@pytest.fixture(scope="module")
+def export_sparklines_module() -> ModuleType:
+    """Load the standalone exporter using the production import mechanism.
 
     :return:
         Imported sparkline export module.
@@ -31,15 +32,12 @@ def _load_export_sparklines_module():
 
 
 def _make_vault_row(spec: VaultSpec, protocol: str) -> dict:
-    """Create a minimal stablecoin vault row for sparkline selection tests.
-
-    The selector needs only a persisted specification, protocol display name,
-    and denomination; other scanner metadata is unrelated to TVL eligibility.
+    """Create a minimal stablecoin vault row for inclusion tests.
 
     :param spec:
         Synthetic vault identity.
     :param protocol:
-        Protocol display name emitted by the scanner.
+        Protocol display name.
     :return:
         Minimal compatible vault metadata row.
     """
@@ -50,17 +48,15 @@ def _make_vault_row(spec: VaultSpec, protocol: str) -> dict:
     }
 
 
-def test_apex_sparkline_threshold_exemption() -> None:
-    """Include USDT 500 ApeX vaults without lowering the global threshold.
+def test_apex_sparkline_threshold_exemption(export_sparklines_module: ModuleType) -> None:
+    """Include USD 500 ApeX vaults without lowering the global threshold.
 
-    ApeX is intentionally exempt while it is new and has little TVL. A
-    non-ApeX vault at the same TVL remains below the standard threshold, and
-    ApeX still needs to reach the lower USDT 500 floor.
-
+    :param export_sparklines_module:
+        Dynamically loaded standalone exporter module.
     :return:
         None. Assertions validate the peak-TVL inclusion policy.
     """
-    module = _load_export_sparklines_module()
+    module = export_sparklines_module
     apex_eligible = VaultSpec(9995, "apex-vault-eligible")
     apex_below_floor = VaultSpec(9995, "apex-vault-below-floor")
     non_apex_small = VaultSpec(1, "0x0000000000000000000000000000000000000001")
@@ -88,3 +84,27 @@ def test_apex_sparkline_threshold_exemption() -> None:
     included = module.get_included_vault_ids(vault_db, prices_df)
 
     assert included == {apex_eligible.as_string_id(), non_apex_large.as_string_id()}
+
+
+def test_rendered_images_cross_joblib_process_boundary(export_sparklines_module: ModuleType) -> None:
+    """Return SVG and PNG dictionaries from standalone-script workers.
+
+    :param export_sparklines_module:
+        Dynamically loaded standalone exporter module.
+    :return:
+        None. Assertions validate Loky serialisation and image formats.
+    """
+    module = export_sparklines_module
+    index = pd.date_range("2026-08-01", periods=15, freq="D", name="timestamp")
+    prices_df = pd.DataFrame(
+        {"share_price": [1.0] * len(index), "total_assets": [10_000.0] * len(index)},
+        index=index,
+    )
+    sparkline_data = prepare_sparkline_data(prices_df)
+    assert sparkline_data is not None
+
+    results = Parallel(n_jobs=2, prefer="processes")(delayed(module.render_vault_sparklines)(f"vault-{index}", sparkline_data) for index in range(2))
+
+    assert [[image["extension"] for image in vault_images] for vault_images in results] == [["svg", "png"], ["svg", "png"]]
+    assert all(vault_images[0]["payload"].startswith(b"<?xml") for vault_images in results)
+    assert all(vault_images[1]["payload"].startswith(b"\x89PNG") for vault_images in results)

--- a/tests/research/test_sparkline.py
+++ b/tests/research/test_sparkline.py
@@ -1,19 +1,15 @@
-"""Regression tests for nullable values in vault sparklines."""
+"""Regression tests for vault sparkline preparation and rendering."""
 
+import matplotlib.dates as mdates
 import numpy as np
 import pandas as pd
 import pytest
 
-from eth_defi.research.sparkline import export_sparkline_as_png, render_sparkline_gradient
+from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, prepare_sparkline_data, render_sparkline_gradient
 
 
 def test_gradient_sparkline_ignores_nullable_share_prices() -> None:
-    """Nullable share prices do not reach Matplotlib's y-axis bounds.
-
-    Production Parquet data may contain ``pd.NA`` before the first valid price.
-    The renderer must retain finite points and generate an image rather than
-    raising the ambiguous-boolean TypeError from Matplotlib.
-    """
+    """Nullable share prices do not reach Matplotlib's y-axis bounds."""
     index = pd.date_range("2026-07-01", periods=3, freq="D")
     vault_prices_df = pd.DataFrame(
         {
@@ -42,3 +38,96 @@ def test_gradient_sparkline_rejects_vault_without_finite_share_prices() -> None:
 
     with pytest.raises(ValueError, match="without finite share prices"):
         render_sparkline_gradient(vault_prices_df, ffill=False)
+
+
+def test_gradient_sparkline_svg_is_deterministic() -> None:
+    """Identical chart inputs produce identical bytes for upload deduplication."""
+    index = pd.date_range("2026-07-01", periods=3, freq="D")
+    vault_prices_df = pd.DataFrame(
+        {
+            "share_price": [1.0, 1.01, 1.02],
+            "total_assets": [10_000.0, 10_100.0, 10_200.0],
+        },
+        index=index,
+    )
+
+    first_svg = export_sparkline_as_svg(render_sparkline_gradient(vault_prices_df, ffill=False))
+    second_svg = export_sparkline_as_svg(render_sparkline_gradient(vault_prices_df, ffill=False))
+
+    assert first_svg == second_svg
+
+
+def test_sparkline_requires_two_weeks_of_finite_price_history() -> None:
+    """Publish at exactly two weeks, but not before the threshold."""
+    start_at = pd.Timestamp("2026-08-01 12:00:00")
+    index = pd.DatetimeIndex(
+        [start_at, start_at + pd.Timedelta(days=13), start_at + pd.Timedelta(days=14)],
+        name="timestamp",
+    )
+    prices_df = pd.DataFrame(
+        {"share_price": [1.0, float("inf"), 1.02], "total_assets": [10_000.0, 10_100.0, 10_200.0]},
+        index=index,
+    )
+
+    eligible = prepare_sparkline_data(prices_df)
+
+    assert eligible is not None
+    assert eligible.end_at - eligible.prices_df.index[0] == pd.Timedelta(days=14)
+    assert prepare_sparkline_data(prices_df.iloc[:2]) is None
+
+
+def test_short_sparkline_uses_full_90_day_axis_with_blank_left_side() -> None:
+    """A new vault's two-week line occupies only the chart's right edge."""
+    end_at = pd.Timestamp("2026-08-15 12:00:00")
+    index = pd.date_range(end=end_at, periods=15, freq="D", name="timestamp")
+    prices_df = pd.DataFrame(
+        {"share_price": [1 + day / 1_000 for day in range(len(index))], "total_assets": [10_000.0] * len(index)},
+        index=index,
+    )
+    sparkline_data = prepare_sparkline_data(prices_df)
+    assert sparkline_data is not None
+
+    fig = render_sparkline_gradient(
+        sparkline_data.prices_df,
+        x_axis_range=(sparkline_data.start_at, sparkline_data.end_at),
+    )
+    axis_start, axis_end = (pd.Timestamp(mdates.num2date(value)).tz_localize(None) for value in fig.axes[0].get_xlim())
+    plotted_start = pd.Timestamp(fig.axes[0].lines[0].get_xdata()[0])
+    plotted_end = pd.Timestamp(fig.axes[0].lines[0].get_xdata()[-1])
+
+    assert sparkline_data.start_at == end_at.normalize() - pd.Timedelta(days=90)
+    assert sparkline_data.prices_df.index[0] == (end_at - pd.Timedelta(days=14)).normalize()
+    assert axis_start.floor("s") == sparkline_data.start_at
+    assert axis_end.floor("s") == sparkline_data.end_at
+    assert plotted_start == sparkline_data.prices_df.index[0]
+    assert plotted_end == sparkline_data.end_at
+    export_sparkline_as_png(fig)
+
+
+def test_established_sparse_sparkline_carries_price_to_window_start() -> None:
+    """Retain a pre-window value when an old vault has sparse scans."""
+    index = pd.DatetimeIndex([pd.Timestamp("2025-01-01"), pd.Timestamp("2026-01-01")], name="timestamp")
+    prices_df = pd.DataFrame({"share_price": [1.0, 1.1], "total_assets": [10_000.0, 11_000.0]}, index=index)
+
+    sparkline_data = prepare_sparkline_data(prices_df)
+
+    assert sparkline_data is not None
+    assert sparkline_data.start_at == pd.Timestamp("2025-10-03")
+    assert sparkline_data.prices_df.index.tolist() == [sparkline_data.start_at, sparkline_data.end_at]
+    assert sparkline_data.prices_df["share_price"].tolist() == [1.0, 1.1]
+
+
+def test_sparkline_preparation_sorts_input_and_rejects_missing_prices() -> None:
+    """Handle unordered source rows and nullable data without rendering errors."""
+    index = pd.DatetimeIndex([pd.Timestamp("2026-01-15 12:00:00"), pd.Timestamp("2026-01-01 12:00:00")], name="timestamp")
+    unordered_prices_df = pd.DataFrame(
+        {"share_price": [1.1, 1.0], "total_assets": [11_000.0, 10_000.0]},
+        index=index,
+    )
+    missing_prices_df = unordered_prices_df.assign(share_price=pd.Series([pd.NA, pd.NA], index=index, dtype="Float64"))
+
+    prepared = prepare_sparkline_data(unordered_prices_df)
+
+    assert prepared is not None
+    assert prepared.prices_df.index.is_monotonic_increasing
+    assert prepare_sparkline_data(missing_prices_df) is None


### PR DESCRIPTION
## Why

Vault sparklines incorrectly depended on a dataset-wide 90-day cutoff. New vaults therefore waited for roughly three months before receiving an asset, while inactive vaults with valid older histories could disappear from the export. This left 18 otherwise eligible GMX pools without the static SVG and PNG objects requested by the frontend.

## Lessons learnt

Sparkline publication eligibility and the displayed chart window are separate concerns: two weeks of finite observations is enough to publish, while the chart can retain a fixed 90-day axis with an intentionally blank left side. Bounds must be derived after daily resampling, and standalone Joblib workers should return plain serialisable values rather than slotted classes reconstructed from `__main__`. Deterministic SVG metadata and gzip timestamps are also required for checksum-based upload skipping.

## Summary

- Publish stablecoin-denominated vault sparklines after 14 elapsed days of finite share-price history.
- Keep a 90-day axis ending on each vault’s own latest observation day, leaving pre-history blank and retaining inactive vault histories.
- Move reusable preparation into `eth_defi.research.sparkline` and simplify exporter rendering, multiprocessing and R2 upload orchestration.
- Make SVG and gzip output deterministic and skip unchanged R2 objects by source checksum.
- Correct the manual renderer so it uploads PNG bytes under its PNG object name without logging credential identifiers.
- Document the actual eligibility, axis, stale-history and upload behaviour.
- Cover exact 14-day eligibility, nullable prices, blank-left rendering, sparse histories, deterministic SVGs and the real Joblib process boundary.

A manual production export created all 18 previously missing GMX SVG/PNG pairs. Direct R2 downloads confirmed valid image contents, and all 155 GMX vaults currently meeting the complete publication policy rendered successfully.

## Related issues and PRs

None linked.

## Unrelated CI and test fixes

None.