### PR TITLE
fix: publish pro vault datasets privately

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,8 @@ services:
       R2_VAULT_METADATA_SECRET_ACCESS_KEY: ${R2_VAULT_METADATA_SECRET_ACCESS_KEY:-}
       R2_VAULT_METADATA_PUBLIC_URL: ${R2_VAULT_METADATA_PUBLIC_URL:-}
 
-      # Export prices parquet and pickled metadata to metadata bucket
+      # Export free samples through the public R2 configuration.
+      # Pro price Parquet, pickle and DuckDB files use the private bucket above.
       R2_DATA_BUCKET_NAME: ${R2_VAULT_METADATA_BUCKET_NAME:-}
       R2_DATA_ENDPOINT_URL: ${R2_VAULT_METADATA_ENDPOINT_URL:-}
       R2_DATA_ACCOUNT_ID: ${R2_VAULT_METADATA_ACCOUNT_ID:-}

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -222,8 +222,8 @@ The upload creates a flat R2 object key from the local file name. The default
 objects are therefore `exchange-rates.duckdb` and `exchange-rates.parquet`, next to `vault-prices-1h.parquet`,
 `cleaned-vault-prices-1h.parquet`, the vault metadata pickle, reader state,
 sticky export state, and Core3 DuckDB. When
-`R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` is configured, both files are
-uploaded to the alternative bucket and included in its daily
+`R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` is required, both files are
+uploaded only to that private bucket and included in its daily
 `daily/YYYY-MM-DD/...` backup copy.
 
 Crypto-vault USD metrics consume the same cleaned Parquet snapshot that the

--- a/eth_defi/vault/data_file_export.py
+++ b/eth_defi/vault/data_file_export.py
@@ -1,8 +1,8 @@
 """Export vault database files to Cloudflare R2.
 
-Uploads price databases, metadata pickles, and Core3 risk intelligence
-and exchange-rate DuckDB files so the backtester can download them
-without running the full scan pipeline.
+Uploads price databases, metadata pickles, Core3 risk intelligence and
+exchange-rate files to the private vault-data bucket. Public R2 uploads are
+limited to explicitly generated sample files.
 """
 
 import logging
@@ -122,7 +122,6 @@ def upload_files_to_r2(  # noqa: PLR0917
     access_key_id: str,
     secret_access_key: str,
     key_prefix: str = "",
-    public_url: str = "",
 ) -> int:
     """Upload a list of files to R2 bucket, excluding tmp* files.
 
@@ -138,8 +137,6 @@ def upload_files_to_r2(  # noqa: PLR0917
         R2 secret access key.
     :param key_prefix:
         Prefix for S3 keys, e.g. ``test-`` for test uploads.
-    :param public_url:
-        Public base URL for logging final download URLs.
     :return:
         Number of files uploaded.
     """
@@ -198,10 +195,6 @@ def upload_files_to_r2(  # noqa: PLR0917
         else:
             skipped_count += 1
             logger.info("Skipped unchanged file %s for s3://%s/%s", file_path, bucket_name, s3_key)
-
-        if public_url and uploaded:
-            final_url = f"{public_url.rstrip('/')}/{s3_key}"
-            print(f"  -> {final_url}")
 
     logger.info(
         "Data file upload summary for bucket %s: %d uploaded, %d skipped unchanged",
@@ -265,8 +258,8 @@ def main(
     """Run the data file export script.
 
     Reads R2 configuration from environment variables, uploads vault data
-    files to configured buckets, and creates daily backups in the alternative
-    bucket when enabled. A scheduled caller can supply the exact Parquet
+    files to the private bucket, and creates daily backups there when enabled.
+    A scheduled caller can supply the exact Parquet
     snapshot already used for crypto USD metrics. Standalone use materialises a
     fresh snapshot before upload.
 
@@ -282,24 +275,15 @@ def main(
         clear_log_file=False,
     )
 
-    # Data files use R2_DATA_* env vars, falling back to R2_VAULT_METADATA_*.
-    bucket_name = os.environ.get("R2_DATA_BUCKET_NAME") or os.environ.get("R2_VAULT_METADATA_BUCKET_NAME")
+    # Data-file exports deliberately target only the private bucket. Public
+    # downloads are provided by the separate sample-file export.
+    bucket_name = os.environ.get("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME")
     access_key_id = os.environ.get("R2_DATA_ACCESS_KEY_ID") or os.environ.get("R2_VAULT_METADATA_ACCESS_KEY_ID")
     secret_access_key = os.environ.get("R2_DATA_SECRET_ACCESS_KEY") or os.environ.get("R2_VAULT_METADATA_SECRET_ACCESS_KEY")
     endpoint_url = os.environ.get("R2_DATA_ENDPOINT_URL") or os.environ.get("R2_VAULT_METADATA_ENDPOINT_URL")
-    public_url = os.environ.get("R2_DATA_PUBLIC_URL") or os.environ.get("R2_VAULT_METADATA_PUBLIC_URL")
     upload_prefix = os.environ.get("UPLOAD_PREFIX", "")
 
-    assert bucket_name, "R2_DATA_BUCKET_NAME (or R2_VAULT_METADATA_BUCKET_NAME) environment variable is required"
-
-    # The alternative bucket is for the upcoming private commercial
-    # professional vault data bucket. When set, data files are uploaded to
-    # both the primary and alternative buckets using the same credentials.
-    bucket_names = [bucket_name]
-    alt_bucket_name = os.environ.get("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME")
-    if alt_bucket_name:
-        bucket_names.append(alt_bucket_name)
-        logger.info("Alternative bucket configured: %s", alt_bucket_name)
+    assert bucket_name, "R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME environment variable is required"
 
     base_path = get_pipeline_data_dir()
     if exchange_rate_parquet_path is None and exchange_rate_parquet_error is None:
@@ -319,58 +303,44 @@ def main(
     )
     checkpoint_vault_settlement_database_if_exists(base_path / VAULT_SETTLEMENT_DATABASE_FILENAME)
 
-    print("\nExporting data files to R2")
-    print(f"  Bucket: {bucket_name}")
-    if alt_bucket_name:
-        print(f"  Alternative bucket: {alt_bucket_name}")
-    print(f"  Endpoint: {endpoint_url}")
-    print(f"  Public URL: {public_url}")
-    print(f"  Key prefix: '{upload_prefix}'" if upload_prefix else "  Key prefix: (none)")
-    print(f"  Files: {len(paths)}")
+    logger.info("Exporting %d data files to private R2 bucket %s via %s", len(paths), bucket_name, endpoint_url)
+    logger.info("Data-file key prefix: %s", upload_prefix or "(none)")
     for path in paths:
         exists = path.exists()
         size = f"{path.stat().st_size / 1024 / 1024:.1f} MB" if exists else "MISSING"
-        print(f"    - {path.name}: {size}")
+        logger.info("Data file: %s (%s)", path.name, size)
 
-    daily_backup_enabled = os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false"
+    upload_files_to_r2(
+        file_paths=paths,
+        bucket_name=bucket_name,
+        endpoint_url=endpoint_url,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        key_prefix=upload_prefix,
+    )
 
-    for current_bucket in bucket_names:
-        if len(bucket_names) > 1:
-            logger.info("Uploading data files to bucket: %s", current_bucket)
-
-        upload_files_to_r2(
-            file_paths=paths,
-            bucket_name=current_bucket,
+    if os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false":
+        s3_client = create_r2_client(
             endpoint_url=endpoint_url,
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
-            key_prefix=upload_prefix,
-            public_url=public_url,
         )
-
-        # Create daily timestamped backups in the alternative (private) bucket only.
-        if current_bucket == alt_bucket_name and daily_backup_enabled:
-            s3_client = create_r2_client(
-                endpoint_url=endpoint_url,
-                access_key_id=access_key_id,
-                secret_access_key=secret_access_key,
-            )
-            backup_created = 0
-            backup_skipped = 0
-            for file_path in paths:
-                if not file_path.exists():
-                    continue
-                source_key = f"{upload_prefix}{file_path.name}"
-                if copy_r2_object_daily_backup(s3_client, current_bucket, source_key):
-                    backup_created += 1
-                else:
-                    backup_skipped += 1
-            logger.info(
-                "Daily backup summary for bucket %s: %d created, %d skipped",
-                current_bucket,
-                backup_created,
-                backup_skipped,
-            )
+        backup_created = 0
+        backup_skipped = 0
+        for file_path in paths:
+            if not file_path.exists():
+                continue
+            source_key = f"{upload_prefix}{file_path.name}"
+            if copy_r2_object_daily_backup(s3_client, bucket_name, source_key):
+                backup_created += 1
+            else:
+                backup_skipped += 1
+        logger.info(
+            "Daily backup summary for private bucket %s: %d created, %d skipped",
+            bucket_name,
+            backup_created,
+            backup_skipped,
+        )
 
     if exchange_rate_parquet_error is not None:
         raise exchange_rate_parquet_error

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -165,8 +165,8 @@ def _upload_top_vaults_json_to_bucket(  # noqa: PLR0917 - internal upload payloa
         Human-readable label such as ``primary`` or ``alternative``.
 
     :return:
-        ``True`` if the bucket upload succeeded or was skipped as
-        unchanged, ``False`` on failure.
+        ``True`` if the bucket upload succeeded or was skipped as unchanged,
+        otherwise ``False``.
     """
     try:
         uploaded = upload_file_to_r2(
@@ -245,34 +245,26 @@ def _upload_top_vaults_json_to_configured_buckets(  # noqa: PLR0917 - internal R
 ) -> bool:
     """Upload the generated top-vaults JSON to all configured buckets.
 
-    The primary and alternative buckets are attempted independently.
-    This means a permission issue on one bucket does not stop the other
-    upload attempt or later post-processing steps.
+    The primary and alternative buckets are attempted independently. This
+    means a permission issue on one bucket does not stop the other upload or
+    later post-processing steps.
 
     :param s3_client:
         Authenticated boto3 S3 client.
-
     :param output_path:
         Generated JSON file path.
-
     :param bucket_name:
         Primary bucket name.
-
     :param endpoint_url:
         R2 endpoint URL for logging.
-
     :param object_key:
         Destination object key.
-
     :param access_key_id:
         R2 access key ID for masked logging.
-
     :param public_url:
         Optional public URL for the primary bucket.
-
     :param alt_bucket_name:
         Optional alternative bucket name.
-
     :return:
         ``True`` if all configured uploads succeeded or were skipped as
         unchanged, otherwise ``False``.
@@ -1021,9 +1013,8 @@ def export_top_vaults_json(  # noqa: PLR0914 - R2 export settings are resolved t
     Runs :py:mod:`eth_defi.vault.top_vaults_json` against the
     active pipeline data directory to produce
     ``top_vaults_by_chain.json``, then uploads the result to the
-    primary (public) ``R2_TOP_VAULTS_*`` bucket and, if configured,
-    also to the alternative (private) bucket via
-    ``R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME``.
+    primary (public) ``R2_TOP_VAULTS_*`` bucket and, if configured, also to the
+    alternative (private) bucket via ``R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME``.
 
     This is a drop-in replacement for the standalone ``vault-analysis``
     docker image: the JSON generation and the R2 upload now both live
@@ -1043,9 +1034,9 @@ def export_top_vaults_json(  # noqa: PLR0914 - R2 export settings are resolved t
 
     :param output_path:
         Override for the generated JSON file. Defaults to
-        ``get_pipeline_data_dir() / "top_vaults_by_chain.json"``. The
-        filename is intentionally kept identical to the existing public
-        URL ``https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json``.
+        ``get_pipeline_data_dir() / "top_vaults_by_chain.json"``. The filename
+        is intentionally kept identical to the existing public URL
+        ``https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json``.
 
     :param core3_db_path:
         Override for the Core3 risk intelligence DuckDB path. When ``None``,
@@ -1105,9 +1096,8 @@ def export_top_vaults_json(  # noqa: PLR0914 - R2 export settings are resolved t
             secret_access_key=secret_access_key,
         )
 
-        # TODO: phase out public R2_TOP_VAULTS_BUCKET_NAME later once
-        # downstream consumers (classification.py, add-vault-note skill,
-        # deploy-lagoon-multichain.py) migrate to the private bucket.
+        # This public feed has downstream operational consumers, so retain its
+        # established primary and optional alternative publication paths.
         alt_bucket_name = os.environ.get("R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME")
         uploads_ok = _upload_top_vaults_json_to_configured_buckets(
             s3_client=s3_client,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1669,7 +1669,7 @@ poetry run python scripts/erc-4626/export-protocol-metadata.py
 | `R2_VAULT_METADATA_SECRET_ACCESS_KEY` | Required. R2 secret key. |
 | `R2_VAULT_METADATA_ENDPOINT_URL` | Required. R2 endpoint URL. |
 | `R2_VAULT_METADATA_PUBLIC_URL` | Required. R2 public URL. |
-| `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` | Optional. Alternative R2 bucket for the upcoming private commercial professional vault data bucket. Uses same credentials as primary. |
+| `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` | Optional. Mirrors protocol metadata into the alternative bucket. |
 | `MAX_WORKERS` | Optional. Default: 20. |
 
 ### export-data-files.py
@@ -1682,11 +1682,13 @@ files, Core3 risk intelligence DuckDB, and exchange-rate DuckDB.
 source .local-test.env && poetry run python scripts/erc-4626/export-data-files.py
 ```
 
-When `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` is configured, files are
-uploaded to both buckets. Daily `daily/YYYY-MM-DD/...` backup copies are created
-only in the alternative bucket. Missing files, including the Core3 and exchange-rate
-DuckDB files, are logged and skipped. Existing `vault-export-state.json` is included
+Files are uploaded only to `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME`. Daily
+`daily/YYYY-MM-DD/...` backup copies are created in that private bucket. Missing
+files, including the Core3 and exchange-rate DuckDB files, are logged and skipped.
+Existing `vault-export-state.json` is included
 so sticky qualification history is backed up with the rest of the production data set.
+This exporter does not remove any historic objects from other buckets; remove
+legacy public Pro artefacts separately through a controlled R2 operation.
 The exchange-rate DuckDB path uses the same `CURRENCY_API_DB_PATH` /
 `CURRENCY_API_DATABASE_PATH` configuration as the scheduled currency-rate scanner;
 without an override it is read from `$PIPELINE_DATA_DIR/exchange-rates.duckdb`.
@@ -1695,12 +1697,10 @@ fixed `vault-metadata-db.pickle` is published.
 
 | Variable | Description |
 |----------|-------------|
-| `R2_DATA_BUCKET_NAME` | R2 bucket for data files (falls back to `R2_VAULT_METADATA_BUCKET_NAME`). |
+| `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` | Required. Private R2 bucket for data files. |
 | `R2_DATA_ACCESS_KEY_ID` | R2 access key (falls back to `R2_VAULT_METADATA_ACCESS_KEY_ID`). |
 | `R2_DATA_SECRET_ACCESS_KEY` | R2 secret (falls back to `R2_VAULT_METADATA_SECRET_ACCESS_KEY`). |
 | `R2_DATA_ENDPOINT_URL` | R2 endpoint (falls back to `R2_VAULT_METADATA_ENDPOINT_URL`). |
-| `R2_DATA_PUBLIC_URL` | Public base URL (falls back to `R2_VAULT_METADATA_PUBLIC_URL`). |
-| `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` | Optional. Alternative bucket for private/professional data. |
 | `R2_DAILY_BACKUP` | Optional. Set to `false` to disable daily backup copies. Default: true. |
 | `CORE3_DATABASE_PATH` | Optional. Core3 DuckDB path. Default: `~/.tradingstrategy/vaults/core3/core3.duckdb`. |
 | `CURRENCY_API_DB_PATH` / `CURRENCY_API_DATABASE_PATH` | Optional. Exchange-rate DuckDB bundle path. Default: `$PIPELINE_DATA_DIR/exchange-rates.duckdb`. |
@@ -1758,6 +1758,12 @@ poetry run python scripts/erc-4626/scan-vault-posts.py
 | `LOG_LEVEL` | Optional. Default: warning. |
 
 ## Docker usage
+
+Pro vault datasets—price Parquet, local metadata pickle, data DuckDB files,
+export-state JSON and the crypto bundle—are uploaded only to their configured
+private R2 bucket. The public top-vaults feed, protocol metadata, logos and
+sparklines retain their established publication configuration. The Ethereum-only
+sample files remain the free download artefacts.
 
 The vault scanner is packaged as a Docker image via `Dockerfile.vault-scanner`.
 The default entrypoint is `scan-vaults-all-chains.py`, which scans **all chains**.

--- a/scripts/erc-4626/export-data-files.py
+++ b/scripts/erc-4626/export-data-files.py
@@ -1,8 +1,7 @@
 """Export vault database files (parquet, pickle, DuckDB) to Cloudflare R2.
 
-Uploads price databases, metadata pickles, Core3 risk intelligence
-DuckDB, and exchange-rate DuckDB so the backtester can download them
-without running the full scan pipeline.
+Uploads price databases, metadata pickles, Core3 risk intelligence DuckDB and
+exchange-rate files to the private vault-data bucket.
 
 Example:
 
@@ -11,13 +10,10 @@ Example:
     source .local-test.env && poetry run python scripts/erc-4626/export-data-files.py
 
 Environment variables:
-    - R2_DATA_BUCKET_NAME: R2 bucket for data files (falls back to R2_VAULT_METADATA_BUCKET_NAME)
+    - R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME: Private R2 bucket for data files
     - R2_DATA_ACCESS_KEY_ID: R2 access key ID (falls back to R2_VAULT_METADATA_ACCESS_KEY_ID)
     - R2_DATA_SECRET_ACCESS_KEY: R2 secret access key (falls back to R2_VAULT_METADATA_SECRET_ACCESS_KEY)
     - R2_DATA_ENDPOINT_URL: R2 endpoint URL (falls back to R2_VAULT_METADATA_ENDPOINT_URL)
-    - R2_DATA_PUBLIC_URL: Public base URL for data files (falls back to R2_VAULT_METADATA_PUBLIC_URL)
-    - R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME: Alternative R2 bucket for the upcoming private
-      commercial professional vault data bucket (optional, uses same credentials as primary)
     - CORE3_DATABASE_PATH: Path to Core3 DuckDB export (default: ~/.tradingstrategy/vaults/core3/core3.duckdb)
     - CURRENCY_API_DB_PATH / CURRENCY_API_DATABASE_PATH: Path to exchange-rate DuckDB export
       (default: $PIPELINE_DATA_DIR/exchange-rates.duckdb)

--- a/scripts/erc-4626/export-protocol-metadata.py
+++ b/scripts/erc-4626/export-protocol-metadata.py
@@ -16,8 +16,6 @@ Environment variables:
     - R2_VAULT_METADATA_SECRET_ACCESS_KEY: R2 secret access key for metadata bucket (required)
     - R2_VAULT_METADATA_ENDPOINT_URL: R2 API endpoint URL for metadata bucket (required)
     - R2_VAULT_METADATA_PUBLIC_URL: Public base URL for logo URLs in metadata (required)
-    - R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME: Alternative R2 bucket for the upcoming private
-      commercial professional vault data bucket (optional, uses same credentials as primary)
     - MAX_WORKERS: Number of parallel upload workers (default: 20)
     - REFRESH_STABLECOIN_RATES: Refresh stablecoin rates before uploading the stablecoin JSON bundle (default: true)
     - FORCE_STABLECOIN_RATE_REFRESH: Bypass the per-entry same-day stablecoin rate gate (default: false)
@@ -177,8 +175,6 @@ def main():  # noqa: PLR0914
     assert public_url, "R2_VAULT_METADATA_PUBLIC_URL environment variable is required"
 
     # Build list of target buckets.
-    # The alternative bucket is for the upcoming private commercial professional vault data bucket.
-    # When set, all uploads go to both the primary and alternative buckets using the same credentials.
     bucket_names = [bucket_name]
     alt_bucket_name = os.environ.get("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME")
     if alt_bucket_name:

--- a/scripts/erc-4626/post-process-prices.py
+++ b/scripts/erc-4626/post-process-prices.py
@@ -76,15 +76,15 @@ Protocol metadata R2 bucket (required unless ``SKIP_METADATA=true``):
 - ``R2_VAULT_METADATA_ENDPOINT_URL``: R2 endpoint URL for metadata bucket
 - ``R2_VAULT_METADATA_PUBLIC_URL``: Public base URL for logo URLs in metadata
 
-Alternative R2 bucket (optional, for the upcoming private commercial professional vault data bucket):
+Private R2 bucket (required for Pro vault datasets):
 
-- ``R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME``: When set, metadata and data files are uploaded
-  to both the primary and this alternative bucket using the same credentials
+- ``R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME``: Full vault price Parquet,
+  local metadata pickle, data DuckDB files, export-state JSON and the crypto
+  bundle are uploaded only here.
 
-Private crypto-vaults R2 bundle (required for successful private publication):
+Crypto-vaults R2 bundle:
 
-- ``R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME``: Private bundle bucket. Unlike
-  the legacy alternative export, the crypto bundle is uploaded only here.
+- ``R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME``: Private bundle bucket.
 - ``R2_DATA_ENDPOINT_URL`` / ``R2_VAULT_METADATA_ENDPOINT_URL``: R2 endpoint.
 - ``R2_DATA_ACCESS_KEY_ID`` / ``R2_VAULT_METADATA_ACCESS_KEY_ID``: R2 access key.
 - ``R2_DATA_SECRET_ACCESS_KEY`` / ``R2_VAULT_METADATA_SECRET_ACCESS_KEY``: R2 secret.
@@ -94,22 +94,24 @@ There is deliberately no ``SKIP_CRYPTO_VAULTS`` switch. Crypto failures are
 recorded as failed post-processing steps and do not stop the public export
 steps, but the standalone command exits non-zero when any recorded step fails.
 
-Data files R2 bucket (falls back to ``R2_VAULT_METADATA_*`` if not set):
+Private data-files R2 bucket:
 
-- ``R2_DATA_BUCKET_NAME``: R2 bucket for parquet/pickle data files
+- ``R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME``: Private R2 bucket for
+  Parquet, pickle and DuckDB data files
 - ``R2_DATA_ACCESS_KEY_ID``: R2 access key ID for data bucket
 - ``R2_DATA_SECRET_ACCESS_KEY``: R2 secret access key for data bucket
 - ``R2_DATA_ENDPOINT_URL``: R2 endpoint URL for data bucket
-- ``R2_DATA_PUBLIC_URL``: Public base URL for data files
 
 Top-vaults JSON R2 bucket (required unless ``SKIP_TOP_VAULTS=true``):
 
-- ``R2_TOP_VAULTS_BUCKET_NAME``: R2 bucket for ``top_vaults_by_chain.json`` (primary public bucket, e.g. ``top-defi-vaults.tradingstrategy.ai``)
+- ``R2_TOP_VAULTS_BUCKET_NAME``: Public R2 bucket for
+  ``top_vaults_by_chain.json``
 - ``R2_TOP_VAULTS_ACCESS_KEY_ID``: R2 access key ID for top-vaults bucket
 - ``R2_TOP_VAULTS_SECRET_ACCESS_KEY``: R2 secret access key for top-vaults bucket
 - ``R2_TOP_VAULTS_ENDPOINT_URL``: R2 endpoint URL for top-vaults bucket
 - ``R2_TOP_VAULTS_PUBLIC_URL``: Optional public base URL for the top-vaults JSON
-- ``R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME``: Optional alternative (private) bucket. When set, the JSON is uploaded to both primary and alternative using the same credentials.
+- ``R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME``: Optional alternative R2 bucket
+  retaining the established backup copy.
 """
 
 import logging

--- a/tests/erc_4626/test_export_data_files.py
+++ b/tests/erc_4626/test_export_data_files.py
@@ -121,19 +121,32 @@ def test_missing_core3_duckdb_is_skipped_without_failure(tmp_path: Path, caplog:
     assert "File does not exist, skipping" in caplog.text
 
 
-def test_core3_duckdb_upload_gets_alternative_daily_backup(
+def test_data_file_export_requires_private_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pro data cannot fall back to the public vault-data bucket.
+
+    :param monkeypatch:
+        Pytest environment-variable fixture.
+    :return:
+        ``None``.
+    """
+    monkeypatch.setenv("R2_DATA_BUCKET_NAME", "public-bucket")
+    monkeypatch.delenv("R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME", raising=False)
+
+    with pytest.raises(AssertionError, match="R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME"):
+        data_file_export.main()
+
+
+def test_core3_duckdb_upload_targets_private_bucket_and_gets_daily_backup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ):
-    """Core3 DuckDB uploads to all data buckets and backs up only in alternative bucket.
+    """Core3 DuckDB uploads and backs up only in the private bucket.
 
     Steps:
 
     1. Create all data export files, including the Core3 DuckDB.
     2. Mock R2 upload and daily backup calls.
-    3. Assert Core3 uploads to both buckets but daily backup only runs in the
-       alternative bucket.
+    3. Assert Core3 uploads and daily backup only run in the private bucket.
     """
     core3_path = tmp_path / "core3" / "core3.duckdb"
     core3_path.parent.mkdir(parents=True)
@@ -143,7 +156,6 @@ def test_core3_duckdb_upload_gets_alternative_daily_backup(
 
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("CORE3_DATABASE_PATH", str(core3_path))
-    monkeypatch.setenv("R2_DATA_BUCKET_NAME", "public-bucket")
     monkeypatch.setenv("R2_DATA_ACCESS_KEY_ID", "access")
     monkeypatch.setenv("R2_DATA_SECRET_ACCESS_KEY", "secret")
     monkeypatch.setenv("R2_DATA_ENDPOINT_URL", "https://example.invalid")
@@ -166,27 +178,24 @@ def test_core3_duckdb_upload_gets_alternative_daily_backup(
     monkeypatch.setattr(data_file_export, "copy_r2_object_daily_backup", fake_copy_r2_object_daily_backup)
 
     data_file_export.main()
-    capsys.readouterr()
-
-    assert ("public-bucket", "core3.duckdb") in uploaded
     assert ("private-bucket", "core3.duckdb") in uploaded
     assert ("private-bucket", "core3.duckdb") in backups
+    assert all(bucket == "private-bucket" for bucket, _ in uploaded)
     assert all(bucket == "private-bucket" for bucket, _ in backups)
 
 
-def test_exchange_rate_duckdb_upload_gets_alternative_daily_backup(
+def test_exchange_rate_duckdb_upload_targets_private_bucket_and_gets_daily_backup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ):
-    """Exchange-rate DuckDB uploads to all data buckets and backs up only in alternative bucket.
+    """Exchange-rate DuckDB uploads and backs up only in the private bucket.
 
     Steps:
 
     1. Create all data export files, including the exchange-rate DuckDB.
     2. Mock R2 upload and daily backup calls.
-    3. Assert exchange rates upload to both buckets but daily backup only
-       runs in the alternative bucket.
+    3. Assert exchange rates upload and daily backup only run in the private
+       bucket.
     """
     core3_path = tmp_path / "core3" / "core3.duckdb"
     exchange_rate_path = tmp_path / "exchange" / "exchange-rates.duckdb"
@@ -201,7 +210,6 @@ def test_exchange_rate_duckdb_upload_gets_alternative_daily_backup(
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("CORE3_DATABASE_PATH", str(core3_path))
     monkeypatch.setenv("CURRENCY_API_DB_PATH", str(exchange_rate_path))
-    monkeypatch.setenv("R2_DATA_BUCKET_NAME", "public-bucket")
     monkeypatch.setenv("R2_DATA_ACCESS_KEY_ID", "access")
     monkeypatch.setenv("R2_DATA_SECRET_ACCESS_KEY", "secret")
     monkeypatch.setenv("R2_DATA_ENDPOINT_URL", "https://example.invalid")
@@ -224,20 +232,17 @@ def test_exchange_rate_duckdb_upload_gets_alternative_daily_backup(
     monkeypatch.setattr(data_file_export, "copy_r2_object_daily_backup", fake_copy_r2_object_daily_backup)
 
     data_file_export.main()
-    capsys.readouterr()
-
-    assert ("public-bucket", "exchange-rates.duckdb") in uploaded
     assert ("private-bucket", "exchange-rates.duckdb") in uploaded
     assert ("private-bucket", "exchange-rates.duckdb") in backups
+    assert all(bucket == "private-bucket" for bucket, _ in uploaded)
     assert all(bucket == "private-bucket" for bucket, _ in backups)
 
 
-def test_exchange_rate_parquet_upload_gets_alternative_daily_backup(
+def test_exchange_rate_parquet_upload_targets_private_bucket_and_gets_daily_backup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """The verified Parquet snapshot follows the existing private backup path."""
+    """The verified Parquet snapshot is only uploaded and backed up privately."""
     exchange_rate_parquet_path = tmp_path / "exchange-rates.parquet"
     exchange_rate_parquet_path.write_bytes(b"verified rate snapshot")
     core3_path = tmp_path / "core3" / "core3.duckdb"
@@ -250,7 +255,6 @@ def test_exchange_rate_parquet_upload_gets_alternative_daily_backup(
             write_export_test_file(path)
 
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
-    monkeypatch.setenv("R2_DATA_BUCKET_NAME", "public-bucket")
     monkeypatch.setenv("R2_DATA_ACCESS_KEY_ID", "access")
     monkeypatch.setenv("R2_DATA_SECRET_ACCESS_KEY", "secret")
     monkeypatch.setenv("R2_DATA_ENDPOINT_URL", "https://example.invalid")
@@ -273,8 +277,6 @@ def test_exchange_rate_parquet_upload_gets_alternative_daily_backup(
     monkeypatch.setattr(data_file_export, "copy_r2_object_daily_backup", fake_copy_r2_object_daily_backup)
 
     data_file_export.main(exchange_rate_parquet_path=exchange_rate_parquet_path)
-    capsys.readouterr()
-
-    assert ("public-bucket", "exchange-rates.parquet") in uploaded
     assert ("private-bucket", "exchange-rates.parquet") in uploaded
     assert ("private-bucket", "exchange-rates.parquet") in backups
+    assert all(bucket == "private-bucket" for bucket, _ in uploaded)


### PR DESCRIPTION
## Why

Keep full Pro vault datasets out of the public R2 export path while retaining the established free samples and operational public feeds.

## Lessons learnt

A primary R2 destination plus an optional alternative made it too easy for the same Pro artefacts to be published to both buckets. Publication policy needs to be explicit per artefact class.

## Summary

- Publish full vault data-file exports and daily backups only to `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME`.
- Keep the public top-vaults feed, protocol metadata, logos, sparklines and Ethereum-only samples on their established paths.
- Remove obsolete public URL handling from the Pro data exporter and use structured logging.
- Document the private/public boundary and that historic public Pro objects require a controlled R2 clean-up operation.
- Add coverage for the private-bucket requirement and private-only backups.
- Deployment prerequisite: set `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` in `~/vault-scanner/vault-rpc.env` before the next scanner cycle.

## Related issues and PRs

Follow-up to #1534, which introduced the crypto vault export bundle.

## Unrelated CI and test fixes

None.