### PR TITLE
fix: filter invalid vault share prices

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -34,7 +34,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAna
 from eth_defi.feed.stablecoin_rate import DenominationTokenRate, StablecoinRateFeeder
 from eth_defi.perp_dex.export import build_perp_dex_other_data
 from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid
-from eth_defi.research.wrangle_vault_prices import forward_fill_vault
+from eth_defi.research.wrangle_vault_prices import forward_fill_vault, sanitise_share_price_observations
 from eth_defi.token import is_stablecoin_like, normalise_token_symbol
 from eth_defi.vault.base import VaultSpec, WithdrawalPeriod
 from eth_defi.vault.curator import get_curator_name, identify_curator, is_protocol_curator
@@ -864,7 +864,7 @@ def calculate_net_profit(
     if sample_count is not None and sample_count < 2:
         return 0
 
-    assert share_price_end >= 0, "End share price must be non-negative"
+    assert math.isfinite(share_price_end) and share_price_end >= 0, "End share price must be finite and non-negative"
     management_fee_annual = _normalise_fee_for_calculation(management_fee_annual, "Management fee")
     performance_fee = _normalise_fee_for_calculation(performance_fee, "Performance fee")
     deposit_fee = _normalise_fee_for_calculation(deposit_fee, "Deposit fee")
@@ -1065,7 +1065,7 @@ def prepare_daily_share_price_series(
 
     assert isinstance(share_price_observations, pd.Series)
     assert isinstance(share_price_observations.index, pd.DatetimeIndex)
-    observations = pd.to_numeric(share_price_observations, errors="coerce").dropna().sort_index(kind="stable")
+    observations = sanitise_share_price_observations(share_price_observations).dropna().sort_index(kind="stable")
     if observations.empty:
         empty = pd.Series(index=pd.DatetimeIndex([], name=share_price_observations.index.name), dtype="float64")
         return empty, empty.copy()
@@ -1717,7 +1717,7 @@ def calculate_crypto_usd_period_results(
     sparse_dates = native_share_price_observations.index.normalize()
     sparse_rates = rates.reindex(sparse_dates)
     sparse_mask = (sparse_dates >= segment_start) & (sparse_dates <= segment_end) & sparse_rates.notna().to_numpy()
-    native_sparse = native_share_price_observations.loc[sparse_mask]
+    native_sparse = sanitise_share_price_observations(native_share_price_observations.loc[sparse_mask]).dropna()
     # Price rows occasionally have several observations with the same block
     # timestamp. Preserve the last value, matching daily resampling semantics,
     # before endpoint lookups use timestamp labels.
@@ -2219,20 +2219,6 @@ def calculate_vault_record(
         flags=flags,
     )
 
-    current_share_price = prices_df.iloc[-1]["share_price"]
-    risk, notes, flags = apply_abnormal_value_checks(
-        risk=risk,
-        notes=notes,
-        flags=flags,
-        current_nav=current_nav,
-        current_share_price=current_share_price,
-    )
-    risk, notes, flags = apply_morpho_not_in_api_check(
-        risk=risk,
-        notes=notes,
-        flags=flags,
-    )
-
     vault_slug = vault_metadata["vault_slug"]
     protocol_slug = vault_metadata["protocol_slug"]
     risk_numeric = risk.value if isinstance(risk, VaultTechnicalRisk) else None
@@ -2537,7 +2523,10 @@ def calculate_vault_record(
     # historical ``share_price_hourly`` variable name. Forward filling is an
     # accepted approximation, including for operation-observed GMX curves:
     # missing days are flat and the next event day carries accumulated movement.
-    share_price_hourly = pd.to_numeric(prices_df["share_price"], errors="coerce").dropna()
+    share_price_observations = sanitise_share_price_observations(prices_df["share_price"])
+    valid_share_price = share_price_observations.notna()
+    valid_price_rows = prices_df.loc[valid_share_price]
+    share_price_hourly = share_price_observations.loc[valid_share_price]
     share_price_daily, daily_returns = prepare_daily_share_price_series(share_price_hourly)
     tvl_series = prices_df["total_assets"]
     utilisation_series = None
@@ -2556,9 +2545,8 @@ def calculate_vault_record(
         now_=now_,
         utilisation=utilisation_series,
     )
-    periodic_metrics_usd = None
-    if crypto_usd_conversion_context is not None:
-        periodic_metrics_usd = calculate_crypto_usd_period_results(
+    periodic_metrics_usd = (
+        calculate_crypto_usd_period_results(
             context=crypto_usd_conversion_context,
             vault_id=id_val,
             native_share_price_observations=share_price_hourly,
@@ -2567,6 +2555,23 @@ def calculate_vault_record(
             gross_fee_data=gross_fee_data,
             net_fee_data=net_fee_data,
         )
+        if crypto_usd_conversion_context is not None
+        else None
+    )
+
+    current_share_price = share_price_hourly.iloc[-1]
+    risk, notes, flags = apply_abnormal_value_checks(
+        risk=risk,
+        notes=notes,
+        flags=flags,
+        current_nav=current_nav,
+        current_share_price=current_share_price,
+    )
+    risk, notes, flags = apply_morpho_not_in_api_check(
+        risk=risk,
+        notes=notes,
+        flags=flags,
+    )
 
     # Extract period metrics for backward compatibility
     lifetime_pm = get_period_metrics(period_results, "lifetime")
@@ -2574,9 +2579,9 @@ def calculate_vault_record(
     one_month_pm = get_period_metrics(period_results, "1M")
 
     # Lifetime metrics
-    lifetime_start_date = prices_df.index[0]
-    lifetime_end_date = prices_df.index[-1]
-    lifetime_samples = len(prices_df)
+    lifetime_start_date = share_price_hourly.index[0]
+    lifetime_end_date = share_price_hourly.index[-1]
+    lifetime_samples = len(share_price_hourly)
     age = (lifetime_end_date - lifetime_start_date).days / 365.25
 
     # Legacy: Lifetime metrics
@@ -2661,11 +2666,13 @@ def calculate_vault_record(
 
     fee_label = create_fee_label(fee_data)
 
-    last_updated_at = prices_df.index.max()
-    last_updated_block = prices_df.loc[last_updated_at]["block_number"]
-    last_share_price = prices_df.iloc[-1]["share_price"]
-    first_updated_at = prices_df.index.min()
-    first_updated_block = prices_df.iloc[0]["block_number"]
+    last_price_row = valid_price_rows.iloc[-1]
+    first_price_row = valid_price_rows.iloc[0]
+    last_updated_at = last_price_row.name
+    last_updated_block = last_price_row["block_number"]
+    last_share_price = share_price_hourly.iloc[-1]
+    first_updated_at = first_price_row.name
+    first_updated_block = first_price_row["block_number"]
     risk_numeric = risk.value if isinstance(risk, VaultTechnicalRisk) else None
 
     return pd.Series(
@@ -4170,7 +4177,7 @@ def export_lifetime_row(row: pd.Series) -> dict:
             return None
         # Numpy scalar
         if isinstance(value, (np.floating, np.integer)):
-            return value.item()
+            value = value.item()
         # Decimal values occur in scanned vault metadata, including fee fields.
         # JSON has one numeric representation, so retain the public export's
         # established float convention. JSON cannot represent Decimal NaN or

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -686,7 +686,7 @@ def calculate_vault_returns(
 ) -> pd.DataFrame:
     """Calculate returns for each vault.
 
-    Filter out reads without a share price and add the compatibility
+    Discard invalid share-price observations and add the compatibility
     ``returns_1h`` column. Consecutive zero prices after a complete loss carry
     a zero return: the loss was already recorded by the first transition to
     zero, and leaving later ``0 / 0`` changes as NaN makes the terminal curve
@@ -709,13 +709,14 @@ def calculate_vault_returns(
     """
     assert isinstance(prices_df, pd.DataFrame), "prices_df must be a pandas DataFrame"
 
-    missing_share_price_mask = prices_df["share_price"].isna()
-    bad_share_price_df = prices_df[missing_share_price_mask]
-    if len(bad_share_price_df) > 0:
-        logger(f"We have NaN share price for {len(bad_share_price_df):,} rows, these will be dropped")
-        prices_df = prices_df[~missing_share_price_mask]
-
-    assert prices_df["share_price"].isna().sum() == 0, "share_price column must not contain NaN values"
+    share_prices = sanitise_share_price_observations(prices_df["share_price"])
+    invalid_share_price_mask = share_prices.isna()
+    invalid_share_price_count = invalid_share_price_mask.sum()
+    if invalid_share_price_count:
+        logger(f"Dropping {invalid_share_price_count:,} invalid share-price observations")
+        prices_df = prices_df.loc[~invalid_share_price_mask].copy()
+        share_prices = share_prices.loc[~invalid_share_price_mask]
+    prices_df["share_price"] = share_prices
     # NOTE: ``returns_1h`` is a misnomer.  The column is ``pct_change()``
     # between consecutive rows regardless of their actual time delta.
     # For EVM chains scanned at 1h frequency the name is accurate, but
@@ -728,6 +729,27 @@ def calculate_vault_returns(
     repeated_zero_price = (prices_df["share_price"] == 0) & (previous_share_price == 0)
     prices_df.loc[repeated_zero_price, "returns_1h"] = 0.0
     return prices_df
+
+
+def sanitise_share_price_observations(share_price_observations: pd.Series) -> pd.Series:
+    """Normalise share prices and mark unusable observations as missing.
+
+    Scanner failures may be persisted as IEEE ``NaN`` values in a PyArrow
+    ``double`` column. Unlike Arrow nulls, these values are not consistently
+    removed by :meth:`pandas.Series.dropna` until they are converted to a
+    NumPy-backed floating-point series. Negative share prices are invalid as
+    well, whereas zero is a valid complete-loss value.
+
+    :param share_price_observations:
+        Sparse share prices indexed by naive UTC timestamps. Values are
+        expected to be non-negative denomination-token amounts.
+    :return:
+        Float64 series preserving the original index and order. Invalid,
+        non-finite, and negative values are represented as ``NaN``.
+    """
+    prices = pd.to_numeric(share_price_observations, errors="coerce").astype("float64")
+    valid = np.isfinite(prices.to_numpy()) & (prices >= 0)
+    return prices.where(valid)
 
 
 def clean_returns(  # noqa: PLR0917 - stable cleaner API used by scripts and notebooks

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -734,6 +734,29 @@ def test_approximate_hypercore_carries_rows_after_terminal_wipe_out() -> None:
     ]
 
 
+def test_calculate_vault_returns_drops_invalid_share_price_observations() -> None:
+    """Drop null, non-finite, and negative prices while retaining a wipe-out."""
+    messages: list[str] = []
+    index = pd.date_range("2026-01-01", periods=5, freq="D")
+    prices = pd.DataFrame(
+        {
+            "id": ["1-0xvault"] * 5,
+            "share_price": pd.Series(
+                pd.arrays.ArrowExtensionArray(pa.array([1.0, float("nan"), float("inf"), -1.0, 0.0], type=pa.float64())),
+                index=index,
+            ),
+        },
+        index=index,
+    )
+
+    assert prices["share_price"].isna().sum() == 0
+
+    result = calculate_vault_returns(prices, logger=messages.append)
+
+    assert result["share_price"].tolist() == [1.0, 0.0]
+    assert messages == ["Dropping 3 invalid share-price observations"]
+
+
 def test_approximate_hypercore_prevents_partial_repair_spike() -> None:
     """One repaired and one raw synthetic unit cannot create a clean return."""
     prices_df = pd.DataFrame(

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -7,8 +7,11 @@ import pickle
 from dataclasses import replace
 from decimal import Decimal
 from pathlib import Path
+from types import MappingProxyType
 
+import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 import zstandard as zstd
 from plotly.graph_objects import Figure
@@ -335,6 +338,84 @@ def test_calculate_lifetime_metrics_skips_invalid_vault_record(
 
     assert metrics["id"].tolist() == [valid_id]
     assert f"Skipping invalid vault metrics record for {invalid_id}" in caplog.text
+
+
+def test_calculate_lifetime_metrics_filters_pyarrow_nan_share_price(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """An IEEE NaN scanner result does not discard an otherwise valid vault.
+
+    PyArrow stores an IEEE NaN as a double value instead of a nullable Arrow
+    cell. The metric preparation must therefore explicitly use finite-value
+    validation rather than relying on ``dropna()``.
+    """
+    vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    vault_spec = VaultSpec.parse_string(vault_id)
+    prices = price_df.loc[price_df["id"] == vault_id].copy()
+    share_prices = prices["share_price"].astype("float64").to_numpy(copy=True)
+    share_prices[-1] = float("nan")
+    prices["share_price"] = pd.Series(pd.arrays.ArrowExtensionArray(pa.array(share_prices, type=pa.float64())), index=prices.index)
+    assert prices["share_price"].isna().sum() == 0
+
+    metrics = calculate_lifetime_metrics(prices, {vault_spec: dict(vault_db.rows[vault_spec])})
+
+    assert metrics["id"].tolist() == [vault_id]
+    lifetime = vault_metrics.get_period_metrics(metrics.iloc[0]["period_results"], "lifetime")
+    assert lifetime is not None
+    assert lifetime.error_reason is None
+    assert lifetime.raw_samples == len(prices) - 1
+    assert metrics.iloc[0]["last_share_price"] == pytest.approx(share_prices[-2])
+    assert metrics.iloc[0]["last_updated_block"] == prices.iloc[-2]["block_number"]
+
+
+def test_calculate_crypto_usd_period_results_filters_pyarrow_nan_share_price() -> None:
+    """USD conversion uses valid endpoint prices after a PyArrow NaN read failure."""
+    vault_id = "1-0x0000000000000000000000000000000000000001"
+    dates = pd.date_range("2026-01-01", periods=5, freq="D")
+    native_prices = pd.Series(
+        pd.arrays.ArrowExtensionArray(pa.array([1.0, float("nan"), 1.02, 1.03, 1.04], type=pa.float64())),
+        index=dates,
+    )
+    assert native_prices.isna().sum() == 0
+    native_daily, _daily_returns = prepare_daily_share_price_series(native_prices)
+    context = CryptoUSDConversionContext(
+        rates_by_family=MappingProxyType({"eth": pd.Series(2_000.0, index=dates)}),
+        errors_by_family=MappingProxyType({}),
+        vault_families=MappingProxyType({vault_id: "eth"}),
+    )
+    fees = FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=0.0,
+        performance=0.0,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+
+    metrics = calculate_crypto_usd_period_results(
+        context=context,
+        vault_id=vault_id,
+        native_share_price_observations=native_prices,
+        native_daily_share_prices=native_daily,
+        native_total_assets=pd.Series(10.0, index=dates),
+        gross_fee_data=fees,
+        net_fee_data=fees,
+    )
+
+    assert metrics is not None
+    lifetime = vault_metrics.get_period_metrics(metrics, "lifetime")
+    assert lifetime is not None
+    assert lifetime.error_reason is None
+    assert lifetime.raw_samples == len(native_prices) - 1
+    assert lifetime.share_price_end == pytest.approx(2_080.0)
+
+
+def test_export_lifetime_row_converts_non_finite_numpy_scalars_to_null() -> None:
+    """Strict JSON export cannot be blocked by NumPy share-price sentinels."""
+    exported = export_lifetime_row(pd.Series({"last_share_price": np.float64("nan"), "current_nav": np.float64("inf")}))
+
+    assert exported["last_share_price"] is None
+    assert exported["current_nav"] is None
 
 
 def test_calculate_lifetime_metrics_prepares_daily_series_once_per_vault(


### PR DESCRIPTION
## Why

PyArrow-backed IEEE NaN values could bypass the cleaner and reach return calculations, where the assertion inaccurately reported them as negative prices.

## Lessons learnt

Normalise Arrow numeric columns to NumPy-backed floats before applying finite-value validation; Arrow null handling alone does not cover IEEE NaN.

## Summary

- Centralised invalid share-price sanitisation for cleaning and metrics.
- Drop null, non-finite and negative prices while preserving zero-value wipe-outs.
- Corrected the assertion and cleaner diagnostic, and make strict JSON serialisation convert non-finite NumPy scalars to null.
- Added regression coverage and verified a full local, no-upload crypto vault export.

## Related issues and PRs

- Addresses the vault scanner metric failures logged on 2026-08-28.

## Unrelated CI and test fixes

- None.