### PR TITLE
fix(gmx): restore get_on_chain_index_tokens on-chain enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- fix: Restore `GMX.get_on_chain_index_tokens()`'s oracle-decoupled whitelist enumeration by calling `Markets._fetch_markets_from_onchain()` instead of a method deleted in the same commit that added this enumerator (2026-08-29)
 - feat: Export cleaned exchange-rate Parquet and USD-denominated period metrics for private ETH/BTC vault records (2026-08-28)
 - feat: Add a private crypto-vaults Parquet bundle for stablecoin, ETH and BTC-denominated vaults (2026-08-27)
 - feat: Mark GMX GM and GLV vaults as automated-market-maker pool shares (2026-08-26)

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -1553,6 +1553,15 @@ class GMX(ExchangeCompatible):
         issue-#67 deep-dive: a transient oracle gap must never silently
         shrink the production whitelist again.
 
+        Uses :meth:`Markets._fetch_markets_from_onchain` — a pure on-chain
+        ``SyntheticsReader.getMarkets()`` read with a DataStore
+        ``IS_MARKET_DISABLED`` filter, no REST endpoint and no
+        :class:`~eth_defi.gmx.core.oracle.OraclePrices` dependency at all.
+        (The private ``Markets._get_available_markets_raw`` this method used
+        to call was removed by the same issue-#67 refactor that introduced
+        this method, without updating this call site — see
+        ``tradingstrategy-ai/freqtrade-multistrategy-orchestrator#519``.)
+
         :returns: EIP-55 checksummed Ethereum addresses of every listed index
             token on the configured chain.  Zero-address sentinels (used by
             swap-only markets / the wstETH special-case) are filtered out.
@@ -1562,9 +1571,9 @@ class GMX(ExchangeCompatible):
         """
         from eth_defi.gmx.core.markets import Markets
 
-        raw_markets = Markets(self.config)._get_available_markets_raw()
+        raw_markets = Markets(self.config)._fetch_markets_from_onchain()
         zero = "0x" + "0" * 40
-        return {to_checksum_address(row[1]) for row in raw_markets if row[1] and row[1].lower() != zero}
+        return {to_checksum_address(row["index_token_address"]) for row in raw_markets if row["index_token_address"] and row["index_token_address"].lower() != zero}
 
     def _fetch_position_close_from_event_logs(
         self,

--- a/tests/gmx/test_get_on_chain_index_tokens.py
+++ b/tests/gmx/test_get_on_chain_index_tokens.py
@@ -34,13 +34,28 @@ _BTC_MARKET_ADDR = "0x47c031236e19d024b42f8AE6780E44A573170703"
 _CHZ_MARKET_ADDR = "0x4fDd333FF9cA409df583f306B6F5a7fFdC9573d1"
 
 
-def _raw_market(market: str, index: str) -> tuple[str, str, str, str]:
-    return (market, index, _USDC, _USDC)
+def _raw_market(market: str, index: str) -> dict[str, str]:
+    return {
+        "market_address": market,
+        "index_token_address": index,
+        "long_token_address": _USDC,
+        "short_token_address": _USDC,
+        "is_listed": True,
+    }
 
 
-def _build_gmx_stub(raw_markets: list[tuple[str, str, str, str]]):
+def _build_gmx_stub(raw_markets: list[dict[str, str]]):
     """Build a barely-instantiated ``GMX`` whose ``get_on_chain_index_tokens``
-    can be called against a mocked ``Markets`` instance."""
+    can be called against a mocked ``Markets`` instance.
+
+    Mocks :meth:`Markets._fetch_markets_from_onchain` — the real pure
+    on-chain enumeration path ``get_on_chain_index_tokens`` calls. Its
+    predecessor, ``_get_available_markets_raw``, was deleted from
+    ``Markets`` by the same commit that introduced this method (issue #67
+    combined refactor); this test used to monkeypatch that phantom method
+    back onto the class, which papered over the break instead of catching
+    it — see ``tradingstrategy-ai/freqtrade-multistrategy-orchestrator#519``.
+    """
     from eth_defi.gmx.ccxt.exchange import GMX
     from eth_defi.gmx.core import markets as markets_mod
 
@@ -50,11 +65,16 @@ def _build_gmx_stub(raw_markets: list[tuple[str, str, str, str]]):
     gmx.config.chain = "arbitrum"
     gmx.config.web3 = MagicMock()
 
-    # Patch the Markets._get_available_markets_raw used inside the method.
-    def _fake_raw(_self):
+    # Guard against repeating the exact bug this test suite is named after:
+    # assert the target method already exists before overwriting it, so a
+    # future refactor that renames/removes it fails this test loudly instead
+    # of silently re-creating the phantom-method pattern.
+    assert hasattr(markets_mod.Markets, "_fetch_markets_from_onchain"), "Markets._fetch_markets_from_onchain no longer exists — update GMX.get_on_chain_index_tokens() and this test's mock target together"
+
+    def _fake_onchain(_self):
         return list(raw_markets)
 
-    markets_mod.Markets._get_available_markets_raw = _fake_raw  # type: ignore[assignment]
+    markets_mod.Markets._fetch_markets_from_onchain = _fake_onchain  # type: ignore[assignment]
     return gmx
 
 

--- a/tests/gmx/test_pool_tvl.py
+++ b/tests/gmx/test_pool_tvl.py
@@ -210,11 +210,7 @@ def test_get_pool_tvl_token_addresses(chain_name, get_pool_tvl):
     """
     pool_tvl_data = get_pool_tvl.get_data()
 
-    # Check at least one market
-    if pool_tvl_data:
-        market = next(iter(pool_tvl_data))
-        data = pool_tvl_data[market]
-
+    for market, data in pool_tvl_data.items():
         # Verify address format (0x followed by 40 hex characters)
         assert data["long_token"].startswith("0x"), f"Long token address should start with 0x: {data['long_token']}"
         assert len(data["long_token"]) == 42, f"Long token address should be 42 characters: {data['long_token']}"
@@ -224,9 +220,8 @@ def test_get_pool_tvl_token_addresses(chain_name, get_pool_tvl):
         assert len(data["short_token"]) == 42, f"Short token address should be 42 characters: {data['short_token']}"
         assert all(c in "0123456789abcdefABCDEF" for c in data["short_token"][2:]), f"Short token address should contain only hex characters: {data['short_token']}"
 
-        # Long and short tokens should be different for most markets
-        # Note: For BTC2 and ETH2 markets, long and short tokens are the same
-        if "BTC2" not in market and "ETH2" not in market and "UNKNOWN" not in market:
+        # Any *2 market is a single-token synthetic pool by construction.
+        if not market.endswith("2") and "UNKNOWN" not in market:
             assert data["long_token"] != data["short_token"], f"Long and short tokens should be different: {data['long_token']} == {data['short_token']}"
 
 


### PR DESCRIPTION
## Summary

- Replaced the old `_get_available_markets_raw` private function method call on the `Markets` class with older `GMX.get_on_chain_index_tokens()` call to read the active markets from the `DataStore`.  Earlier it was making silent failures and we had to make additional `API` calls to read the active markets. 
- Also updated the parsing data of from the updated `API` endpoint. 
- Fixed flaky test.
