### PR TITLE
Add Darkmatter Labs as drkmttr curator

### DIFF
--- a/eth_defi/data/feeds/curators/darkmatter-labs.yaml
+++ b/eth_defi/data/feeds/curators/darkmatter-labs.yaml
@@ -1,0 +1,13 @@
+feeder-id: darkmatter-labs
+name: Darkmatter Labs
+role: curator
+short_description: Darkmatter Labs curates the drkmttr automated market-making vault on Hyperliquid.
+long_description: |
+  Darkmatter Labs is the curator associated with the [drkmttr vault](https://tradingstrategy.ai/vaults/drkmttr), a native perpetual trading vault on Hyperliquid.
+  The public vault listing describes a hybrid strategy with market-making automation. The curator's public identity is provided through its [X profile](https://x.com/_darkmatterlabs).
+twitter: _darkmatterlabs
+
+# Evidence and background references.
+other-links:
+  - title: Trading Strategy vault page - drkmttr Hyperliquid vault, attributed to Darkmatter Labs
+    url: https://tradingstrategy.ai/vaults/drkmttr

--- a/eth_defi/hyperliquid/tags.py
+++ b/eth_defi/hyperliquid/tags.py
@@ -8,6 +8,21 @@ DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual
 #: Address-specific strategy classifications maintained in addition to the
 #: native perpetual-futures default. Addresses are lowercase.
 STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
+    #: Vault: drkmttr.
+    #: Added: 2026-08-30.
+    #: Decision material: The public vault description calls the strategy
+    #: hybrid and identifies market-making automation. This supports the
+    #: algorithmic trading and market-making classifications.
+    #: Sources:
+    #: - https://tradingstrategy.ai/vaults/drkmttr
+    #: - https://app.hyperliquid.xyz/vaults/0xc179e03922afe8fa9533d3f896338b9fb87ce0c8
+    "0xc179e03922afe8fa9533d3f896338b9fb87ce0c8": {
+        StrategyTag.algorithmic_trading,
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+        StrategyTag.multistrategy,
+    },
     #: Vault: pmalt.
     #: Added: 2026-08-17.
     #: Decision material: Maintainer classification marks pmalt's former

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -418,6 +418,12 @@ CURATOR_ADDRESS_OVERRIDES: dict[tuple[int, str], str] = {
     # https://3f.xyz/
     # https://app.morpho.org/ethereum/vault/0xBEEf3f3A04e28895f3D5163d910474901981183D/3f-x-steakhouse-usdc
     (1, "0xbeef3f3a04e28895f3d5163d910474901981183d"): "3f",
+    # Darkmatter Labs' supplied public X profile identifies the curator of
+    # drkmttr. The Hyperliquid-native vault name does not contain a reusable
+    # organisation name, so preserve the attribution as an exact override.
+    # https://tradingstrategy.ai/vaults/drkmttr
+    # https://x.com/_darkmatterlabs
+    (9999, "0xc179e03922afe8fa9533d3f896338b9fb87ce0c8"): "darkmatter-labs",
     # Growi's official lending page identifies this HyperEVM Morpho Vault V2
     # as Growi Lending / Growi USDC Core.
     # https://growi.fi/lending/

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -6,6 +6,8 @@ from PIL import Image
 
 from eth_defi.erc_4626.vault_protocol.flying_tulip.constants import FLYING_TULIP_SFTUSD_BY_CHAIN
 from eth_defi.erc_4626.vault_protocol.pallas.constants import HYPERLIQUID_CHAIN_ID, PALLAS_BASIS_TRADING_HIP_3_VAULT, PALLAS_DIRECTIONAL_VOLATILITY_VAULT
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
+from eth_defi.hyperliquid.tags import get_strategy_tags
 from eth_defi.midas.registry import iter_midas_registry_products
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_AOABT_HASHKEY, ASSETO_CURATORS
 from eth_defi.tokenised_fund.fdit.constants import FDIT_ETHEREUM
@@ -13,6 +15,7 @@ from eth_defi.tokenised_fund.kaio.constants import CASHX_ETHEREUM
 from eth_defi.tokenised_fund.libeara.constants import LIBEARA_PRODUCTS
 from eth_defi.tokenised_fund.sygnum.constants import FILQ_CURATOR_SLUG, SYGNUM_PRODUCTS_BY_CHAIN
 from eth_defi.vault.curator import build_curator_metadata_json, get_curator_available_logos, get_curator_name, identify_curator, is_protocol_curator, load_curator_map
+from eth_defi.vault.strategy_tag import StrategyTag
 
 
 def test_identify_pallas_vaults_as_protocol_curated() -> None:
@@ -56,6 +59,23 @@ def test_identify_flying_tulip_vaults_as_protocol_curated() -> None:
     assert metadata["protocol_curator"] is True
     assert metadata["canonical_feeder_id"] == "flying-tulip"
     assert any(metadata["logos"].values())
+
+
+def test_identify_darkmatter_labs_hyperliquid_vault() -> None:
+    """Attribute drkmttr to Darkmatter Labs and retain its strategy tags."""
+
+    address = "0xc179e03922afe8fa9533d3f896338b9fb87ce0c8"
+
+    assert identify_curator(HYPERCORE_CHAIN_ID, "drkmttr", "drkmttr", address, "hyperliquid") == "darkmatter-labs"
+    assert get_curator_name("darkmatter-labs") == "Darkmatter Labs"
+    assert get_strategy_tags(address) == {
+        StrategyTag.algorithmic_trading,
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+        StrategyTag.multistrategy,
+        StrategyTag.perpetual_futures,
+    }
 
 
 DARK_UI_BACKGROUND_LUMINANCE = 0.0098


### PR DESCRIPTION
## Why

Add the verified Darkmatter Labs attribution for the drkmttr Hyperliquid vault, whose abbreviated vault name cannot be reliably matched from curator names.

## Lessons learnt

Hyperliquid native vaults use the HyperCore synthetic chain ID 9999, not the HyperEVM chain ID.

## Summary

- Add Darkmatter Labs curator metadata and its supplied X profile.
- Attribute the exact drkmttr vault address to Darkmatter Labs.
- Classify the vault's documented automated hybrid market-making strategy.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.