### PR TITLE
notes: explain Arcus pToken vault economics

### DIFF
--- a/docs/source/vaults/arcus/index.rst
+++ b/docs/source/vaults/arcus/index.rst
@@ -22,10 +22,10 @@ threshold-based rebalancing are described in Arcus's public product
 announcement; they are not independently inferred from the product labels.
 
 All reviewed pTokens return the same unlabelled EOA from ``manager()``. The
-library leaves the generic manager name unset rather than assigning an
-unsupported identity to that address. Protocol attribution comes from the
-reviewed Arcus contract-family classification, not from the ``manager()``
-accessor.
+library displays Arcus as the protocol-level curator and manager for these
+address-scoped products. This attribution comes from the reviewed Arcus
+contract-family classification and curator registry; it does not identify the
+operator behind the generic ``manager()`` address.
 
 .. autosummary::
    :toctree: _autosummary_arcus

--- a/docs/source/vaults/arcus/index.rst
+++ b/docs/source/vaults/arcus/index.rst
@@ -12,19 +12,20 @@ and `HOOD (3x Long) <https://robinhoodchain.blockscout.com/address/0xe24CABDf76D
 contracts return the same bridge-vault value. Both are BeaconProxy contracts;
 their current implementation is not source-verified.
 
-The resulting reader provides standard ERC-4626 read operations only. It does
-not advertise a deposit/redeem manager, a binding withdrawal time, or a
-management/performance fee because those behaviours have not been certified.
-The product labels alone do not prove leverage maintenance, rebalancing, fees,
-or redemption terms. The reader uses small, reviewed address-scoped copy for
-BTC and HOOD and does not use Arcus's unrelated exchange-market API as a pToken
-data or NAV source.
+The resulting reader provides standard ERC-4626 read operations and reviewed,
+address-scoped product metadata for BTC and HOOD. The metadata includes a
+reviewed snapshot of the deposit fee and profit share published by Arcus's
+public pToken vault API without making runtime API requests. It does not
+advertise a deposit/redeem manager or binding withdrawal time because those
+behaviours have not been certified. The pToken mechanics and automatic
+threshold-based rebalancing are described in Arcus's public product
+announcement; they are not independently inferred from the product labels.
 
 All reviewed pTokens return the same unlabelled EOA from ``manager()``. The
-library therefore attributes them to Arcus as protocol-curated products, rather
-than creating an unsupported third-party curator identity. This attribution is
-limited to the reviewed Arcus contract family; it is not derived from that
-generic accessor.
+library leaves the generic manager name unset rather than assigning an
+unsupported identity to that address. Protocol attribution comes from the
+reviewed Arcus contract-family classification, not from the ``manager()``
+accessor.
 
 .. autosummary::
    :toctree: _autosummary_arcus

--- a/eth_defi/data/feeds/curators/arcus.yaml
+++ b/eth_defi/data/feeds/curators/arcus.yaml
@@ -9,21 +9,21 @@
 # Description sources:
 # - https://arcus.xyz/
 # - https://arcus.xyz/blog/arcus-x-robinhood-trade-stocks-perpetuals-24-7
-# - https://globaldollar.com/about-usdg
+# - https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus
 feeder-id: arcus
 name: Arcus
 role: curator
 canonical-feeder-id: arcus
-short_description: Arcus is listed as the curator of its pToken strategies on Robinhood Chain.
+short_description: Arcus is the protocol curator of its pToken strategies on Robinhood Chain.
 long_description: |
   [Arcus](https://arcus.xyz/) is a self-custodial exchange on Robinhood Chain
-  for Stock Tokens, cryptoassets and perpetual futures. Its
-  [launch announcement](https://arcus.xyz/blog/arcus-x-robinhood-trade-stocks-perpetuals-24-7)
-  describes 24/7 Stock Token trading, while product access remains subject to
-  eligibility and applicable terms.
+  for Stock Tokens, cryptoassets and perpetual futures. Its [pToken
+  announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus)
+  describes tokenised shares of automatically rebalanced Arcus perpetual
+  accounts.
 
-  Arcus is listed as curator for the pToken strategies shown here; no separate
-  third-party curator has been publicly named. They are denominated in
-  [USDG](https://globaldollar.com/about-usdg), a dollar stablecoin that Global
-  Dollar says can be redeemed one-to-one with Paxos. Assess the strategy,
-  stablecoin and product-specific liquidity and redemption terms separately.
+  Arcus is the protocol curator for the pToken strategies shown here; no
+  separate third-party curator has been publicly named.
+other-links:
+  - title: Arcus - pTokens, a new primitive on Arcus
+    url: https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus

--- a/eth_defi/data/vaults/metadata/arcus.yaml
+++ b/eth_defi/data/vaults/metadata/arcus.yaml
@@ -3,30 +3,28 @@ slug: arcus
 short_description: |
   Self-custodial trading venue on Robinhood Chain for Stock Tokens and perpetual futures.
 long_description: |
-  Arcus is a self-custodial trading venue on Robinhood Chain. Its pTokens
-  announcement describes pTokens as transferable ERC-20 representations of a
-  proportionate interest in an Arcus perpetuals account configured for a
-  particular market and leverage level. This packages a perpetual position into
-  a token that can be held, transferred or traded without the holder separately
-  managing the account's margin and collateral.
+  Arcus is a self-custodial trading venue on Robinhood Chain. Its [pToken
+  announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus)
+  describes pTokens as transferable ERC-20 shares of an Arcus perpetuals
+  account configured for a particular market and target leverage. The account
+  automatically rebalances when exposure drifts beyond a set threshold, so the
+  holder does not separately manage its margin or collateral.
 fee_description: |
-  Arcus says it does not charge a fee on Stock Token spot trades. That statement
-  does not establish the costs of holding, trading or redeeming every Arcus
-  product: spreads, funding, conversion, withdrawal or redemption costs may
-  still apply. Arcus has not published a separate pToken management or
-  performance fee schedule; check current quotes, product terms and the
-  [launch announcement](https://arcus.xyz/blog/arcus-x-robinhood-trade-stocks-perpetuals-24-7)
-  before trading.
+  A pToken's NAV includes hourly perpetual funding and the trading costs of
+  rebalancing towards its target exposure. The current [pBTC3x vault
+  data](https://api.vaults.arcus.xyz/v1/vaults/0x4472c69d299382f8847ebce4fc6ed8e295510e3e)
+  reports a 25 basis point deposit fee and no profit share. These settings may
+  change; check current product data before trading.
 links:
   homepage: https://arcus.xyz/
   app: https://app.arcus.xyz/
   twitter: https://x.com/arcus_xyz
   github: ''
   documentation: https://docs.arcus.xyz/
-  fact_sheet: https://arcus.xyz/blog/arcus-x-robinhood-trade-stocks-perpetuals-24-7
+  fact_sheet: https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus
   defillama: ''
   audits: ''
-  fees: https://arcus.xyz/blog/arcus-x-robinhood-trade-stocks-perpetuals-24-7
+  fees: https://docs.arcus.xyz/concepts/perpetuals/fees
   trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/arcus
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/arcus/index.html
 example_smart_contracts:

--- a/eth_defi/data/vaults/metadata/arcus.yaml
+++ b/eth_defi/data/vaults/metadata/arcus.yaml
@@ -13,8 +13,9 @@ fee_description: |
   A pToken's NAV includes hourly perpetual funding and the trading costs of
   rebalancing towards its target exposure. The current [pBTC3x vault
   data](https://api.vaults.arcus.xyz/v1/vaults/0x4472c69d299382f8847ebce4fc6ed8e295510e3e)
-  reports a 25 basis point deposit fee and no profit share. These settings may
-  change; check current product data before trading.
+  and [pHOOD3x vault data](https://api.vaults.arcus.xyz/v1/vaults/0xe24cabdf76dd1c2576049167eb1755c84b985c36)
+  each report a 25 basis point deposit fee and no profit share. These settings
+  may change; check current product data before trading.
 links:
   homepage: https://arcus.xyz/
   app: https://app.arcus.xyz/
@@ -24,7 +25,7 @@ links:
   fact_sheet: https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus
   defillama: ''
   audits: ''
-  fees: https://docs.arcus.xyz/concepts/perpetuals/fees
+  fees: https://api.vaults.arcus.xyz/v1/vaults
   trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/arcus
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/arcus/index.html
 example_smart_contracts:

--- a/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
@@ -1,12 +1,13 @@
 """Reviewed Arcus pToken display data.
 
-Arcus's public market API describes exchange markets, not pToken contracts or
-pToken accounting.  In particular, it must not supply a pToken NAV, strategy,
-fee, or curator value.  Keep the small set of reviewed product descriptions
-local and address-scoped instead of coupling vault reads to unrelated API data.
+Arcus documents pToken mechanics in its `product announcement
+<https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus>`__ and exposes live
+values through its public vault API. The scanner keeps reviewed address-scoped
+copy locally so metadata reads stay deterministic and do not depend on an
+offchain service.
 
-The ``curator_name`` is a protocol attribution.  It is not inferred from the
-unlabelled address returned by the generic ``manager()`` accessor.
+Arcus does not identify the operator behind the address returned by the
+``manager()`` accessor, so this module does not attribute a manager name.
 """
 
 from typing import Final, TypedDict
@@ -15,35 +16,36 @@ from eth_typing import HexAddress
 
 from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_BTC_3X_LONG_VAULT, ARCUS_HOOD_3X_LONG_VAULT
 
+ARCUS_PTOKEN_NOTES_TEMPLATE: Final[str] = "A pToken holder's return follows the token's NAV per share, representing a proportionate claim on the vault's USDG collateral and {market} perpetual position after funding, fees and slippage. It is not simply {leverage} times the asset's total return, as automatic threshold-based rebalancing makes performance path-dependent. The pooled account, rather than individual holders, maintains the collateral required for the position. Read the [announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus) for more details."
+
 
 class ArcusVaultOffchainData(TypedDict):
     """Reviewed display data for one production Arcus pToken."""
 
-    #: Protocol-level curator attribution.
-    curator_name: str
-
     #: Listing-friendly pToken summary.
     short_description: str
 
-    #: Longer, conservative pToken explanation.
+    #: Longer pToken strategy summary.
     description: str
+
+    #: Explanation of pToken return and collateral mechanics.
+    notes: str
 
 
 #: Address-scoped product copy for reviewed production pTokens.
 #:
 #: The implementation deliberately does not extrapolate this data to every
-#: contract that shares the Arcus detection signal.  Product names alone do not
-#: establish leverage maintenance, rebalancing, fees, or redemption terms.
+#: contract that shares the Arcus detection signal.
 ARCUS_VAULT_DATA: Final[dict[HexAddress, ArcusVaultOffchainData]] = {
     ARCUS_BTC_3X_LONG_VAULT: ArcusVaultOffchainData(
-        curator_name="Arcus",
-        short_description="Arcus pToken labelled BTC (3x Long).",
-        description=("This reviewed Robinhood Chain pToken is labelled **BTC (3x Long)**. The integration does not independently verify its leverage maintenance, rebalancing, fee schedule, or redemption terms."),
+        short_description="Arcus pToken targeting 3x long BTC perpetual exposure.",
+        description="Arcus pBTC3x targets 3x long BTC exposure through perpetual futures. Each token represents a pro-rata claim on the vault's USDG collateral and open BTC perpetual position.",
+        notes=ARCUS_PTOKEN_NOTES_TEMPLATE.format(market="BTC", leverage=3),
     ),
     ARCUS_HOOD_3X_LONG_VAULT: ArcusVaultOffchainData(
-        curator_name="Arcus",
-        short_description="Arcus pToken labelled HOOD (3x Long).",
-        description=("This reviewed Robinhood Chain pToken is labelled **HOOD (3x Long)**. The integration does not independently verify its leverage maintenance, rebalancing, fee schedule, or redemption terms."),
+        short_description="Arcus pToken targeting 3x long HOOD perpetual exposure.",
+        description="Arcus pHOOD3x targets 3x long HOOD exposure through perpetual futures. Each token represents a pro-rata claim on the vault's USDG collateral and open HOOD perpetual position.",
+        notes=ARCUS_PTOKEN_NOTES_TEMPLATE.format(market="HOOD", leverage=3),
     ),
 }
 

--- a/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
@@ -15,6 +15,13 @@ from typing import Final, TypedDict
 from eth_typing import HexAddress
 
 from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_BTC_3X_LONG_VAULT, ARCUS_HOOD_3X_LONG_VAULT
+from eth_defi.types import Percent
+
+#: Entry fee reported by the reviewed production pToken API records.
+ARCUS_PTOKEN_DEPOSIT_FEE: Final[Percent] = 0.0025
+
+#: Profit share reported by the reviewed production pToken API records.
+ARCUS_PTOKEN_PERFORMANCE_FEE: Final[Percent] = 0.0
 
 ARCUS_PTOKEN_NOTES_TEMPLATE: Final[str] = "A pToken holder's return follows the token's NAV per share, representing a proportionate claim on the vault's USDG collateral and {market} perpetual position after funding, fees and slippage. It is not simply {leverage} times the asset's total return, as automatic threshold-based rebalancing makes performance path-dependent. The pooled account, rather than individual holders, maintains the collateral required for the position. Read the [announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus) for more details."
 
@@ -31,6 +38,12 @@ class ArcusVaultOffchainData(TypedDict):
     #: Explanation of pToken return and collateral mechanics.
     notes: str
 
+    #: Entry fee as a fraction of the deposited amount.
+    deposit_fee: Percent
+
+    #: Manager profit share as a fraction of profit.
+    performance_fee: Percent
+
 
 #: Address-scoped product copy for reviewed production pTokens.
 #:
@@ -41,11 +54,15 @@ ARCUS_VAULT_DATA: Final[dict[HexAddress, ArcusVaultOffchainData]] = {
         short_description="Arcus pToken targeting 3x long BTC perpetual exposure.",
         description="Arcus pBTC3x targets 3x long BTC exposure through perpetual futures. Each token represents a pro-rata claim on the vault's USDG collateral and open BTC perpetual position.",
         notes=ARCUS_PTOKEN_NOTES_TEMPLATE.format(market="BTC", leverage=3),
+        deposit_fee=ARCUS_PTOKEN_DEPOSIT_FEE,
+        performance_fee=ARCUS_PTOKEN_PERFORMANCE_FEE,
     ),
     ARCUS_HOOD_3X_LONG_VAULT: ArcusVaultOffchainData(
         short_description="Arcus pToken targeting 3x long HOOD perpetual exposure.",
         description="Arcus pHOOD3x targets 3x long HOOD exposure through perpetual futures. Each token represents a pro-rata claim on the vault's USDG collateral and open HOOD perpetual position.",
         notes=ARCUS_PTOKEN_NOTES_TEMPLATE.format(market="HOOD", leverage=3),
+        deposit_fee=ARCUS_PTOKEN_DEPOSIT_FEE,
+        performance_fee=ARCUS_PTOKEN_PERFORMANCE_FEE,
     ),
 }
 

--- a/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/offchain_data.py
@@ -6,8 +6,9 @@ values through its public vault API. The scanner keeps reviewed address-scoped
 copy locally so metadata reads stay deterministic and do not depend on an
 offchain service.
 
-Arcus does not identify the operator behind the address returned by the
-``manager()`` accessor, so this module does not attribute a manager name.
+Arcus is the protocol-level curator and manager display name for these
+address-scoped products. This attribution does not identify the operator
+behind the unlabelled address returned by the onchain ``manager()`` accessor.
 """
 
 from typing import Final, TypedDict

--- a/eth_defi/erc_4626/vault_protocol/arcus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/vault.py
@@ -6,6 +6,7 @@ from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.arcus.offchain_data import ArcusVaultOffchainData, get_arcus_vault_offchain_data
+from eth_defi.types import Percent
 
 
 class ArcusVault(ERC4626Vault):
@@ -13,8 +14,9 @@ class ArcusVault(ERC4626Vault):
 
     The pToken implementation behind the reviewed BeaconProxy is not
     source-verified. This adapter therefore provides generic ERC-4626 reads
-    only. Product descriptions come from Arcus's public pToken announcement
-    and API; they are not an independent verification of the implementation.
+    plus reviewed, address-scoped product and fee metadata. The metadata comes
+    from Arcus's public pToken announcement and API; it is not an independent
+    verification of the implementation.
 
     See the `Arcus website <https://arcus.xyz/>`__ for product information.
     """
@@ -72,7 +74,7 @@ class ArcusVault(ERC4626Vault):
             return manual_notes
         return self.arcus_offchain_data["notes"] if self.arcus_offchain_data else None
 
-    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:  # noqa: PLR6301
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> Percent | None:  # noqa: PLR6301
         """Return the verified Arcus pToken management fee when available.
 
         No management-fee rate has been verified for the reviewed pTokens.
@@ -86,19 +88,39 @@ class ArcusVault(ERC4626Vault):
         del block_identifier
         return None
 
-    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:  # noqa: PLR6301
-        """Return the verified Arcus pToken performance fee when available.
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return the reviewed Arcus pToken profit share.
 
-        No performance-fee rate has been verified for the reviewed pTokens.
+        Arcus's public vault API reports this value as ``profitShareBps``. The
+        adapter keeps an address-scoped snapshot rather than depending on the
+        API during metadata scans.
 
         :param block_identifier:
-            Block at which fee data would be read.
+            Accepted for the common vault interface. Static offchain fee data
+            is not historical.
 
         :return:
-            ``None`` because no performance-fee value is established.
+            Reviewed profit-share rate, or ``None`` for an unreviewed pToken.
         """
         del block_identifier
-        return None
+        return self.arcus_offchain_data["performance_fee"] if self.arcus_offchain_data else None
+
+    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return the reviewed Arcus pToken entry fee.
+
+        Arcus's public vault API reports this value as ``depositFeeBps``. The
+        adapter keeps an address-scoped snapshot rather than depending on the
+        API during metadata scans.
+
+        :param block_identifier:
+            Accepted for the common vault interface. Static offchain fee data
+            is not historical.
+
+        :return:
+            Reviewed entry-fee rate, or ``None`` for an unreviewed pToken.
+        """
+        del block_identifier
+        return self.arcus_offchain_data["deposit_fee"] if self.arcus_offchain_data else None
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: PLR6301
         """Return Arcus's public application.

--- a/eth_defi/erc_4626/vault_protocol/arcus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/vault.py
@@ -57,6 +57,21 @@ class ArcusVault(ERC4626Vault):
 
         return self.arcus_offchain_data["short_description"] if self.arcus_offchain_data else None
 
+    @property
+    def manager_name(self) -> str | None:
+        """Return Arcus as the protocol-level manager attribution.
+
+        Arcus is the registered protocol curator for the reviewed pToken
+        products. This display name does not identify the unlabelled address
+        returned by the onchain ``manager()`` accessor.
+
+        :return:
+            ``"Arcus"`` for reviewed pTokens, or ``None`` for an unreviewed
+            contract address.
+        """
+
+        return "Arcus" if self.arcus_offchain_data else None
+
     def get_notes(self) -> str | None:
         """Return the reviewed explanation of Arcus pToken mechanics.
 

--- a/eth_defi/erc_4626/vault_protocol/arcus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/arcus/vault.py
@@ -13,9 +13,8 @@ class ArcusVault(ERC4626Vault):
 
     The pToken implementation behind the reviewed BeaconProxy is not
     source-verified. This adapter therefore provides generic ERC-4626 reads
-    only; it does not certify transaction flows, a withdrawal timetable, or a
-    fee schedule. A product name such as ``"BTC (3x Long)"`` is not treated as
-    independent evidence of the product mechanics.
+    only. Product descriptions come from Arcus's public pToken announcement
+    and API; they are not an independent verification of the implementation.
 
     See the `Arcus website <https://arcus.xyz/>`__ for product information.
     """
@@ -24,8 +23,8 @@ class ArcusVault(ERC4626Vault):
     def arcus_offchain_data(self) -> ArcusVaultOffchainData | None:
         """Return reviewed pToken copy.
 
-        The local overlay is address-scoped and does not make public API
-        requests, because Arcus's market catalogue is not pToken data.
+        The local overlay is address-scoped and avoids runtime API requests so
+        vault metadata scans remain deterministic.
 
         :return:
             Reviewed Arcus pToken metadata, or ``None`` for an unsupported
@@ -56,16 +55,22 @@ class ArcusVault(ERC4626Vault):
 
         return self.arcus_offchain_data["short_description"] if self.arcus_offchain_data else None
 
-    @property
-    def manager_name(self) -> str | None:
-        """Return Arcus as the reviewed protocol-level curator attribution.
+    def get_notes(self) -> str | None:
+        """Return the reviewed explanation of Arcus pToken mechanics.
+
+        Manually curated shared notes retain priority. Otherwise, reviewed
+        address-scoped copy explains how NAV, rebalancing and pooled collateral
+        affect pToken holders.
 
         :return:
-            ``"Arcus"`` for reviewed pTokens, or ``None`` when the pToken has
-            not been individually reviewed.
+            Markdown-formatted pToken notes, or ``None`` for an unreviewed
+            contract address.
         """
 
-        return self.arcus_offchain_data["curator_name"] if self.arcus_offchain_data else None
+        manual_notes = super().get_notes()
+        if manual_notes:
+            return manual_notes
+        return self.arcus_offchain_data["notes"] if self.arcus_offchain_data else None
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:  # noqa: PLR6301
         """Return the verified Arcus pToken management fee when available.

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -9,17 +9,17 @@ from eth_typing import HexAddress
 
 
 class VaultFeeMode(enum.Enum):
-    """How vault protocol account its fees.
+    """How a vault protocol accounts for its fees.
 
-    - Externalised fees: fees are deducted from the redemption amount when user withdraws.
+    - Externalised fees: fees are charged explicitly when a user enters or exits a vault.
     - Internalised fees: fees are baked into the share price (asset amount) and continuously taken from the profit.
-      There are no fees on withdraw.
+      There are no fees on withdrawal.
     """
 
     #: Vault fees are baked into the share price (asset amount).
     #:
     #: Fees are taken from the profit at the moment profit is made,
-    #: and send to another address.
+    #: and sent to another address.
     #:
     #: Example protocols: Yearn, Harvest Finance, USDAi.
     internalised_skimming = "internalised_skimming"
@@ -32,7 +32,7 @@ class VaultFeeMode(enum.Enum):
     #: Example protocols: AUTO Finance
     internalised_minting = "internalised_minting"
 
-    #: Vault fees are taken from the user explicitly at the redemption time.
+    #: Vault fees are taken from the user explicitly at deposit or redemption time.
     #:
     #: Example protocols: Lagoon Finance.
     externalised = "externalised"
@@ -204,9 +204,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "USDX Money": VaultFeeMode.internalised_skimming,
     # NaraUSD+ does not publish a universal management or performance fee schedule.
     "Nara": None,
-    # No pToken-specific fee schedule has been verified for reviewed Arcus
-    # products.
-    "Arcus": None,
+    # Arcus pTokens charge their entry fee explicitly instead of incorporating
+    # it into NAV per share.
+    "Arcus": VaultFeeMode.externalised,
     # Hyperlend WHLP - 10% performance fee on yield, internalised in share price
     "Hyperlend": VaultFeeMode.internalised_skimming,
     # Sentiment SuperPools - fees taken from interest earned

--- a/scripts/erc-4626/migrate-arcus-vault-metadata.py
+++ b/scripts/erc-4626/migrate-arcus-vault-metadata.py
@@ -187,7 +187,15 @@ def needs_metadata_refresh(row: VaultRow, detection: ERC4262VaultDetection) -> b
         ``True`` when rebuilding the row is required.
     """
 
-    return row.get("Protocol") != "Arcus" or ERC4626Feature.arcus_like not in detection.features or ERC4626Feature.arcus_like not in row.get("features", set()) or row.get("_manager_name") != "Arcus" or not row.get("_short_description") or not row.get("_description")
+    return any(
+        (
+            row.get("Protocol") != "Arcus",
+            ERC4626Feature.arcus_like not in detection.features,
+            ERC4626Feature.arcus_like not in row.get("features", set()),
+            row.get("_manager_name") is not None,
+            not all(row.get(field) for field in ("_short_description", "_description", "_notes")),
+        )
+    )
 
 
 def create_lead_from_detection(detection: ERC4262VaultDetection) -> PotentialVaultMatch:

--- a/scripts/erc-4626/migrate-arcus-vault-metadata.py
+++ b/scripts/erc-4626/migrate-arcus-vault-metadata.py
@@ -192,7 +192,7 @@ def needs_metadata_refresh(row: VaultRow, detection: ERC4262VaultDetection) -> b
             row.get("Protocol") != "Arcus",
             ERC4626Feature.arcus_like not in detection.features,
             ERC4626Feature.arcus_like not in row.get("features", set()),
-            row.get("_manager_name") == "Arcus",
+            row.get("_manager_name") != "Arcus",
             not all(row.get(field) for field in ("_short_description", "_description", "_notes")),
         )
     )

--- a/scripts/erc-4626/migrate-arcus-vault-metadata.py
+++ b/scripts/erc-4626/migrate-arcus-vault-metadata.py
@@ -192,7 +192,7 @@ def needs_metadata_refresh(row: VaultRow, detection: ERC4262VaultDetection) -> b
             row.get("Protocol") != "Arcus",
             ERC4626Feature.arcus_like not in detection.features,
             ERC4626Feature.arcus_like not in row.get("features", set()),
-            row.get("_manager_name") is not None,
+            row.get("_manager_name") == "Arcus",
             not all(row.get(field) for field in ("_short_description", "_description", "_notes")),
         )
     )
@@ -270,6 +270,8 @@ def migrate_arcus_metadata(
             rebuilt_row = create_vault_scan_record(web3, detection, web3.eth.block_number, token_cache)
             if rebuilt_row.get("Protocol") != "Arcus":
                 raise ValueError(f"Arcus target {spec} rebuilt with unexpected protocol {rebuilt_row.get('Protocol')!r}")
+            if needs_metadata_refresh(rebuilt_row, detection):
+                raise ValueError(f"Arcus target {spec} metadata refresh did not converge")
             replacements[spec] = rebuilt_row
 
         if spec not in vault_db.leads:

--- a/tests/erc_4626/test_migrate_arcus_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_arcus_vault_metadata.py
@@ -109,6 +109,20 @@ def create_refreshed_arcus_row(detection: ERC4262VaultDetection) -> dict:
     }
 
 
+def test_needs_metadata_refresh_matches_only_stale_arcus_fields() -> None:
+    """Refresh legacy Arcus attribution and missing copy without rejecting a future named operator."""
+
+    module = load_migration_module()
+    detection = create_detection(ARCUS_BTC_3X_LONG_VAULT, deposit_count=BTC_DEPOSIT_COUNT, redeem_count=BTC_REDEEM_COUNT)
+    detection.features.add(ERC4626Feature.arcus_like)
+    current_row = create_refreshed_arcus_row(detection)
+
+    assert not module.needs_metadata_refresh(current_row, detection)
+    assert module.needs_metadata_refresh(current_row | {"_manager_name": "Arcus"}, detection)
+    assert module.needs_metadata_refresh(current_row | {"_notes": None}, detection)
+    assert not module.needs_metadata_refresh(current_row | {"_manager_name": "Published operator"}, detection)
+
+
 def test_migrate_arcus_metadata_reclassifies_only_reviewed_rows(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     """Refresh stale Arcus rows without changing unrelated scanner state."""
 

--- a/tests/erc_4626/test_migrate_arcus_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_arcus_vault_metadata.py
@@ -84,6 +84,7 @@ def create_stale_arcus_row(detection: ERC4262VaultDetection) -> dict:
         "_manager_name": None,
         "_short_description": None,
         "_description": None,
+        "_notes": None,
     }
 
 
@@ -101,9 +102,10 @@ def create_refreshed_arcus_row(detection: ERC4262VaultDetection) -> dict:
         "Protocol": "Arcus",
         "features": set(detection.features),
         "_detection_data": detection,
-        "_manager_name": "Arcus",
+        "_manager_name": None,
         "_short_description": "Reviewed Arcus pToken.",
         "_description": "Reviewed Arcus pToken metadata.",
+        "_notes": "Reviewed Arcus pToken mechanics.",
     }
 
 
@@ -148,6 +150,8 @@ def test_migrate_arcus_metadata_reclassifies_only_reviewed_rows(monkeypatch: pyt
     assert vault_db.rows[btc_spec]["_detection_data"].deposit_count == BTC_DEPOSIT_COUNT
     assert vault_db.rows[hood_spec]["_detection_data"].redeem_count == HOOD_REDEEM_COUNT
     assert vault_db.rows[btc_spec]["_detection_data"].updated_at == UPDATED_AT
+    assert vault_db.rows[btc_spec]["_manager_name"] is None
+    assert vault_db.rows[btc_spec]["_notes"] == "Reviewed Arcus pToken mechanics."
     assert vault_db.leads[btc_spec].deposit_count == BTC_DEPOSIT_COUNT
     assert vault_db.leads[hood_spec].withdrawal_count == HOOD_REDEEM_COUNT
     assert vault_db.rows[other_spec] is unrelated_row

--- a/tests/erc_4626/test_migrate_arcus_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_arcus_vault_metadata.py
@@ -102,15 +102,15 @@ def create_refreshed_arcus_row(detection: ERC4262VaultDetection) -> dict:
         "Protocol": "Arcus",
         "features": set(detection.features),
         "_detection_data": detection,
-        "_manager_name": None,
+        "_manager_name": "Arcus",
         "_short_description": "Reviewed Arcus pToken.",
         "_description": "Reviewed Arcus pToken metadata.",
         "_notes": "Reviewed Arcus pToken mechanics.",
     }
 
 
-def test_needs_metadata_refresh_matches_only_stale_arcus_fields() -> None:
-    """Refresh legacy Arcus attribution and missing copy without rejecting a future named operator."""
+def test_needs_metadata_refresh_requires_arcus_manager_attribution() -> None:
+    """Refresh rows that lack the Arcus protocol-level manager attribution."""
 
     module = load_migration_module()
     detection = create_detection(ARCUS_BTC_3X_LONG_VAULT, deposit_count=BTC_DEPOSIT_COUNT, redeem_count=BTC_REDEEM_COUNT)
@@ -118,9 +118,9 @@ def test_needs_metadata_refresh_matches_only_stale_arcus_fields() -> None:
     current_row = create_refreshed_arcus_row(detection)
 
     assert not module.needs_metadata_refresh(current_row, detection)
-    assert module.needs_metadata_refresh(current_row | {"_manager_name": "Arcus"}, detection)
+    assert module.needs_metadata_refresh(current_row | {"_manager_name": None}, detection)
     assert module.needs_metadata_refresh(current_row | {"_notes": None}, detection)
-    assert not module.needs_metadata_refresh(current_row | {"_manager_name": "Published operator"}, detection)
+    assert module.needs_metadata_refresh(current_row | {"_manager_name": "Published operator"}, detection)
 
 
 def test_migrate_arcus_metadata_reclassifies_only_reviewed_rows(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
@@ -164,7 +164,7 @@ def test_migrate_arcus_metadata_reclassifies_only_reviewed_rows(monkeypatch: pyt
     assert vault_db.rows[btc_spec]["_detection_data"].deposit_count == BTC_DEPOSIT_COUNT
     assert vault_db.rows[hood_spec]["_detection_data"].redeem_count == HOOD_REDEEM_COUNT
     assert vault_db.rows[btc_spec]["_detection_data"].updated_at == UPDATED_AT
-    assert vault_db.rows[btc_spec]["_manager_name"] is None
+    assert vault_db.rows[btc_spec]["_manager_name"] == "Arcus"
     assert vault_db.rows[btc_spec]["_notes"] == "Reviewed Arcus pToken mechanics."
     assert vault_db.leads[btc_spec].deposit_count == BTC_DEPOSIT_COUNT
     assert vault_db.leads[hood_spec].withdrawal_count == HOOD_REDEEM_COUNT

--- a/tests/erc_4626/vault_protocol/test_arcus.py
+++ b/tests/erc_4626/vault_protocol/test_arcus.py
@@ -60,10 +60,14 @@ def test_arcus_hood_3x_long_vault(web3: Web3) -> None:
     assert vault.get_fee_mode() is None
     assert vault.get_link() == "https://app.arcus.xyz/"
 
-    assert vault.manager_name == "Arcus"
-    assert vault.short_description == "Arcus pToken labelled HOOD (3x Long)."
+    assert vault.manager_name is None
+    assert vault.short_description == "Arcus pToken targeting 3x long HOOD perpetual exposure."
     assert vault.description is not None
-    assert "does not independently verify" in vault.description
+    assert "pro-rata claim" in vault.description
+    notes = vault.get_notes()
+    assert notes is not None
+    assert "HOOD perpetual position" in notes
+    assert "not simply 3 times" in notes
 
     bridge_vault_raw = web3.eth.call({"to": Web3.to_checksum_address(ARCUS_HOOD_3X_LONG_VAULT), "data": Web3.keccak(text="bridgeVault()")[:4]})
     bridge_vault = eth_abi.decode(["address"], bridge_vault_raw)[0]
@@ -79,8 +83,11 @@ def test_arcus_btc_3x_long_vault(web3: Web3) -> None:
     assert vault.vault_contract.functions.name().call() == "BTC (3x Long)"
     assert vault.vault_contract.functions.symbol().call() == "pBTC3x"
     assert vault.vault_contract.functions.asset().call().lower() == "0x5fc5360d0400a0fd4f2af552add042d716f1d168"
-    assert vault.manager_name == "Arcus"
-    assert vault.short_description == "Arcus pToken labelled BTC (3x Long)."
+    assert vault.manager_name is None
+    assert vault.short_description == "Arcus pToken targeting 3x long BTC perpetual exposure."
+    notes = vault.get_notes()
+    assert notes is not None
+    assert "BTC perpetual position" in notes
 
     bridge_vault_raw = web3.eth.call({"to": Web3.to_checksum_address(ARCUS_BTC_3X_LONG_VAULT), "data": Web3.keccak(text="bridgeVault()")[:4]})
     bridge_vault = eth_abi.decode(["address"], bridge_vault_raw)[0]

--- a/tests/erc_4626/vault_protocol/test_arcus.py
+++ b/tests/erc_4626/vault_protocol/test_arcus.py
@@ -62,7 +62,7 @@ def test_arcus_hood_3x_long_vault(web3: Web3) -> None:
     assert vault.get_fee_mode() is VaultFeeMode.externalised
     assert vault.get_link() == "https://app.arcus.xyz/"
 
-    assert vault.manager_name is None
+    assert vault.manager_name == "Arcus"
     assert vault.short_description == "Arcus pToken targeting 3x long HOOD perpetual exposure."
     assert vault.description is not None
     assert "pro-rata claim" in vault.description
@@ -85,7 +85,7 @@ def test_arcus_btc_3x_long_vault(web3: Web3) -> None:
     assert vault.vault_contract.functions.name().call() == "BTC (3x Long)"
     assert vault.vault_contract.functions.symbol().call() == "pBTC3x"
     assert vault.vault_contract.functions.asset().call().lower() == "0x5fc5360d0400a0fd4f2af552add042d716f1d168"
-    assert vault.manager_name is None
+    assert vault.manager_name == "Arcus"
     assert vault.short_description == "Arcus pToken targeting 3x long BTC perpetual exposure."
     assert vault.get_performance_fee("latest") == pytest.approx(0.0)
     assert vault.get_deposit_fee("latest") == pytest.approx(0.0025)

--- a/tests/erc_4626/vault_protocol/test_arcus.py
+++ b/tests/erc_4626/vault_protocol/test_arcus.py
@@ -12,6 +12,7 @@ from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_BRIDGE_VAULT,
 from eth_defi.erc_4626.vault_protocol.arcus.vault import ArcusVault
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.fork_blocks import ROBINHOOD_MIDNIGHT_BLOCK
+from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 JSON_RPC_ROBINHOOD = os.environ.get("JSON_RPC_ROBINHOOD")
@@ -54,10 +55,11 @@ def test_arcus_hood_3x_long_vault(web3: Web3) -> None:
     assert vault.vault_contract.functions.asset().call().lower() == "0x5fc5360d0400a0fd4f2af552add042d716f1d168"
     assert vault.vault_contract.functions.totalAssets().call() == ARCUS_HOOD_3X_LONG_TOTAL_ASSETS
     assert vault.get_management_fee("latest") is None
-    assert vault.get_performance_fee("latest") is None
+    assert vault.get_performance_fee("latest") == pytest.approx(0.0)
+    assert vault.get_deposit_fee("latest") == pytest.approx(0.0025)
     assert vault.get_deposit_manager_capability() is None
     assert vault.get_risk() == VaultTechnicalRisk.dangerous
-    assert vault.get_fee_mode() is None
+    assert vault.get_fee_mode() is VaultFeeMode.externalised
     assert vault.get_link() == "https://app.arcus.xyz/"
 
     assert vault.manager_name is None
@@ -85,6 +87,8 @@ def test_arcus_btc_3x_long_vault(web3: Web3) -> None:
     assert vault.vault_contract.functions.asset().call().lower() == "0x5fc5360d0400a0fd4f2af552add042d716f1d168"
     assert vault.manager_name is None
     assert vault.short_description == "Arcus pToken targeting 3x long BTC perpetual exposure."
+    assert vault.get_performance_fee("latest") == pytest.approx(0.0)
+    assert vault.get_deposit_fee("latest") == pytest.approx(0.0025)
     notes = vault.get_notes()
     assert notes is not None
     assert "BTC perpetual position" in notes

--- a/tests/erc_4626/vault_protocol/test_arcus_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_arcus_metadata.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_HOOD_3X_LONG_VAULT
-from eth_defi.vault.fee import get_vault_fee_mode
+from eth_defi.vault.fee import VaultFeeMode, get_vault_fee_mode
 from eth_defi.vault.protocol_metadata import build_metadata_json
 
 
@@ -21,4 +21,4 @@ def test_arcus_protocol_metadata() -> None:
     assert metadata["links"]["homepage"] == "https://arcus.xyz/"
     assert metadata["logos"]["generic"] == "https://example.invalid/vault-protocol-metadata/arcus/generic.png"
     assert metadata["logos"]["light"] == "https://example.invalid/vault-protocol-metadata/arcus/light.png"
-    assert get_vault_fee_mode("Arcus", ARCUS_HOOD_3X_LONG_VAULT) is None
+    assert get_vault_fee_mode("Arcus", ARCUS_HOOD_3X_LONG_VAULT) is VaultFeeMode.externalised

--- a/tests/erc_4626/vault_protocol/test_arcus_offchain_data.py
+++ b/tests/erc_4626/vault_protocol/test_arcus_offchain_data.py
@@ -8,30 +8,32 @@ from eth_defi.erc_4626.vault_protocol.arcus.offchain_data import get_arcus_vault
 
 
 @pytest.mark.parametrize(
-    ("vault_address", "expected_name"),
+    ("vault_address", "market"),
     (
-        (ARCUS_BTC_3X_LONG_VAULT, "BTC (3x Long)"),
-        (ARCUS_HOOD_3X_LONG_VAULT, "HOOD (3x Long)"),
+        (ARCUS_BTC_3X_LONG_VAULT, "BTC"),
+        (ARCUS_HOOD_3X_LONG_VAULT, "HOOD"),
     ),
 )
-def test_arcus_offchain_data_is_address_scoped(vault_address: HexAddress, expected_name: str) -> None:
-    """Return conservative copy only for individually reviewed pTokens.
+def test_arcus_offchain_data_is_address_scoped(vault_address: HexAddress, market: str) -> None:
+    """Return announcement-backed copy only for reviewed pTokens.
 
-    The overlay is intentionally local: Arcus's exchange-market API does not
-    provide pToken accounting or product terms.
+    The overlay is intentionally local so scans do not depend on Arcus's live
+    vault API.
 
     :param vault_address:
         Reviewed Arcus production pToken address.
-    :param expected_name:
-        Expected onchain product label represented in the overlay.
+    :param market:
+        Expected perpetual market represented in the overlay.
     """
 
     metadata = get_arcus_vault_offchain_data(vault_address)
 
     assert metadata is not None
-    assert metadata["curator_name"] == "Arcus"
-    assert metadata["short_description"] == f"Arcus pToken labelled {expected_name}."
-    assert "does not independently verify" in metadata["description"]
+    assert metadata["short_description"] == f"Arcus pToken targeting 3x long {market} perpetual exposure."
+    assert f"targets 3x long {market} exposure" in metadata["description"]
+    assert "automatic threshold-based rebalancing" in metadata["notes"]
+    assert "Read the [announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus) for more details." in metadata["notes"]
+    assert f"{market} perpetual position" in metadata["notes"]
 
 
 def test_arcus_offchain_data_excludes_unreviewed_p_tokens() -> None:

--- a/tests/erc_4626/vault_protocol/test_arcus_offchain_data.py
+++ b/tests/erc_4626/vault_protocol/test_arcus_offchain_data.py
@@ -34,6 +34,8 @@ def test_arcus_offchain_data_is_address_scoped(vault_address: HexAddress, market
     assert "automatic threshold-based rebalancing" in metadata["notes"]
     assert "Read the [announcement](https://arcus.xyz/blog/ptokens-a-new-primitive-on-arcus) for more details." in metadata["notes"]
     assert f"{market} perpetual position" in metadata["notes"]
+    assert metadata["deposit_fee"] == pytest.approx(0.0025)
+    assert metadata["performance_fee"] == pytest.approx(0.0)
 
 
 def test_arcus_offchain_data_excludes_unreviewed_p_tokens() -> None:

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -1234,6 +1234,7 @@ def test_identify_arcus_protocol_curator() -> None:
     assert metadata["canonical_feeder_id"] == "arcus"
     assert metadata["website"] == "https://arcus.xyz/"
     assert metadata["twitter"] == "https://x.com/arcus_xyz"
+    assert metadata["short_description"] == "Arcus is the protocol curator of its pToken strategies on Robinhood Chain."
     assert "third-party curator has been publicly named" in metadata["long_description"]
 
 


### PR DESCRIPTION
## Why

Arcus pToken vault pages need to explain how holder returns, target-leverage rebalancing and pooled collateral differ from opening a personal perpetual position. Existing Arcus metadata also referenced stale product information and did not consistently expose Arcus as the protocol curator and manager display name.

## Lessons learnt

Arcus describes pToken rebalancing as automatic and threshold-driven. The `manager_name` value is a protocol-level display attribution: it can identify Arcus as the product manager without claiming that the unlabelled onchain manager address has been independently identified. Published product fees must also flow through the adapter so exported net-return calculations match the explanatory copy.

## Summary

- Add announcement-backed `get_notes()` copy for the reviewed BTC and HOOD pTokens.
- Simplify the address-scoped metadata and replace stale product descriptions and links.
- Report the reviewed 0.25% deposit fee, zero profit share and externalised fee mode.
- Expose Arcus as the manager name for reviewed pTokens and as their protocol curator.
- Refresh the Arcus curator entry with the official pToken announcement as evidence.
- Refresh persisted Arcus rows when notes or manager attribution are missing, with a convergence guard.
- Update focused unit and Robinhood fork coverage.

## Related issues and PRs

Continues #1527.

## Unrelated CI and test fixes

None.