### PR TITLE
fix: reduce recurring ERC-4626 flow rejection logs

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1414,7 +1414,7 @@ def _derive_erc4626_estimated_daily_flows(
     valid = valid_state & valid_state.shift(1, fill_value=False) & observed_intervals
     rejected_interval_count = int((observed_intervals & ~valid).sum())
     if rejected_interval_count:
-        logger.info(
+        logger.debug(
             "ERC-4626 flow estimate rejected %d/%d observed intervals for %s because vault accounting states were invalid or inconsistent",
             rejected_interval_count,
             int(observed_intervals.sum()),

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+import logging
 import os.path
 import pickle
 from dataclasses import replace
@@ -312,7 +313,7 @@ def test_erc4626_state_deltas_reject_partial_scanner_states() -> None:
     assert result[vault_metrics.FLOW_VALUE_COLUMN].isna().all()
 
 
-def test_erc4626_state_deltas_reject_inconsistent_accounting_states() -> None:
+def test_erc4626_state_deltas_reject_inconsistent_accounting_states(caplog: pytest.LogCaptureFixture) -> None:
     """Do not treat a broken assets/supply/share-price identity as investor flow."""
     prices = pd.DataFrame(
         {
@@ -324,9 +325,17 @@ def test_erc4626_state_deltas_reject_inconsistent_accounting_states() -> None:
         index=pd.date_range("2026-01-01", periods=2, freq="D"),
     )
 
-    result = vault_metrics._derive_erc4626_estimated_daily_flows(prices)
+    with caplog.at_level(logging.DEBUG, logger=vault_metrics.__name__):
+        result = vault_metrics._derive_erc4626_estimated_daily_flows(prices)
 
     assert result[vault_metrics.FLOW_VALUE_COLUMN].isna().all()
+    assert caplog.record_tuples == [
+        (
+            vault_metrics.__name__,
+            logging.DEBUG,
+            "ERC-4626 flow estimate rejected 1/1 observed intervals for <unknown> because vault accounting states were invalid or inconsistent",
+        ),
+    ]
 
 
 def test_get_trading_strategy_links_use_canonical_vault_routes():


### PR DESCRIPTION
## Why

The periodic vault scanner logs expected ERC-4626 flow-estimator rejections at INFO for known vault accounting models where `total_assets` does not equal `total_supply × share_price`. This repeats every scan cycle and hides operational information.

## Lessons learnt

The estimator precondition is not universal across ERC-4626-shaped vaults: virtual accounting, fees, delayed valuations and protocol-specific conversion methods can make the identity unsuitable for inferred flows. The estimator must fail closed, but that normal outcome is diagnostic rather than operational.

## Summary

- Demote recurring per-vault flow-estimate rejection messages from INFO to DEBUG.
- Assert the rejection is still logged at DEBUG.

## Related issues and PRs

Continues the canonical period-flow metrics work in #1546.

## Unrelated CI and test fixes

None.