### PR TITLE
fix: export Enzyme Blue protocol fees

### DIFF
--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -188,14 +188,14 @@ can change over a vault's lifetime; that backfill needs component-change,
 ``RateSet``, ``EntranceFeeSet`` and ``ExitFeeSet`` event handling.
 
 Blue has a different fee model. Its fund-level FeeManager configuration can be
-combined with an additional protocol fee. The `protocol-access mechanism
-<https://specs.enzyme.finance/topics/protocol-fee>`__ can settle that charge
-either by minting shares to the ProtocolFeeReserve or by paying MLN. The
-current export's management fee is the user-facing sum of the manager and
-ProtocolFeeTracker rates. It also publishes the protocol rate separately as a
-breakdown; consumers must not add it to management a second time. Blue
-management, performance, entrance, exit and protocol rates are current reads
-only.
+combined with an additional protocol fee. Enzyme's `Protocol Fees
+<https://docs.enzyme.finance/user-documentation/blue-general-info/protocol-fees>`__
+documentation defines this as a fee on Assets Under Technology, settled by
+share inflation or MLN payment, rather than a high-water-mark performance fee.
+The current export therefore includes the ProtocolFeeTracker rate in the
+user-facing management fee. It also retains the protocol rate separately, so
+consumers can calculate the manager-only rate as ``Mgmt fee - Protocol fee``.
+Blue management, performance, entrance and exit rates are current reads only.
 Historical Blue fee configuration remains TODO because releases, FeeManager
 plugins and protocol-fee trackers can change at migration boundaries.
 

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -111,6 +111,19 @@ MAX_WORKERS=8 poetry run python scripts/enzyme/migrate-current-metadata.py
 This migration uses configured RPC and Hypersync credentials, preserves price
 history, and stores a resumable checkpoint alongside the local vault database.
 
+To refresh every Blue vault's current FeeManager and ProtocolFeeTracker values
+after a fee-reader update, run the dedicated current-fee migration instead. It
+does not change historical fee series or price history:
+
+```shell
+DRY_RUN=true poetry run python scripts/enzyme/migrate-blue-fees.py
+MAX_WORKERS=8 poetry run python scripts/enzyme/migrate-blue-fees.py
+```
+
+Blue's ``Mgmt fee`` includes protocol access. ``Protocol fee`` is exported
+separately, so consumers can calculate the manager-only rate as ``Mgmt fee -
+Protocol fee``.
+
 ## Running migrations in the scanner container
 
 ``docker-compose.yml`` passes ``ENZYME_BLUE_API_TOKEN`` only to

--- a/eth_defi/enzyme/blue_vault.py
+++ b/eth_defi/enzyme/blue_vault.py
@@ -26,6 +26,7 @@ from eth_defi.enzyme.offchain_metadata import create_enzyme_vault_link, load_enz
 from eth_defi.enzyme.onyx_flow import EnzymeVaultFlowManager
 from eth_defi.enzyme.tags import get_strategy_tags as lookup_strategy_tags
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
@@ -349,6 +350,9 @@ class EnzymeBlueVault(VaultBase):
 
         try:
             return getattr(contract.functions, function_name)(*args).call(block_identifier=block_identifier)
+        except ExtraValueError:
+            # A provider response is not proof that a reviewed fee is absent.
+            raise
         except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError):
             return None
 
@@ -361,7 +365,17 @@ class EnzymeBlueVault(VaultBase):
         return [get_deployed_contract(self.web3, "enzyme/EnzymeBlueFee.json", address) for address in addresses]
 
     def _fetch_protocol_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
-        """Read the configured current Blue protocol-access rate, if enabled."""
+        """Read the configured current Blue protocol-access rate.
+
+        A reviewed Blue deployment with no ProtocolFeeTracker has explicitly
+        disabled this optional charge, so it is a confirmed zero rather than
+        unavailable fee information.
+
+        :param block_identifier: Block number or tag for the current-state
+            configuration read.
+        :return: Current protocol-access rate, zero when disabled, or
+            ``None`` for an unsupported deployment.
+        """
 
         deployment = ENZYME_BLUE_DEPLOYMENTS.get(self.chain_id)
         if deployment is None:
@@ -369,30 +383,46 @@ class EnzymeBlueVault(VaultBase):
         dispatcher = get_deployed_contract(self.web3, "enzyme/Dispatcher.json", deployment.dispatcher)
         fund_deployer_address = dispatcher.functions.getFundDeployerForVaultProxy(self.address).call(block_identifier=block_identifier)
         fund_deployer = get_deployed_contract(self.web3, "enzyme/FundDeployer.json", fund_deployer_address)
-        tracker_address = fund_deployer.functions.getProtocolFeeTracker().call(block_identifier=block_identifier)
+        try:
+            tracker_address = fund_deployer.functions.getProtocolFeeTracker().call(block_identifier=block_identifier)
+        except ExtraValueError:
+            # Do not publish a zero protocol fee when the provider failed.
+            raise
+        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError):
+            # Pre-ProtocolFeeTracker Blue releases have no protocol access fee.
+            return Percent(0)
         if tracker_address.lower() == ZERO_ADDRESS.lower():
-            return None
+            return Percent(0)
         tracker = get_deployed_contract(self.web3, "enzyme/ProtocolFeeTracker.json", tracker_address)
         fee_bps = tracker.functions.getFeeBpsForVault(self.address).call(block_identifier=block_identifier)
         return Percent(float(Decimal(fee_bps) / FEE_BPS_DENOMINATOR))
 
     def get_fee_data(self) -> FeeData:
-        """Read current Blue manager, investor, and protocol fee rates.
+        """Read current Blue investor fee rates.
 
         Blue's protocol fee is distinct from a fund's optional ManagementFee
-        plugin. The exported management fee is their user-facing combined rate,
-        while the protocol component is retained separately for transparency.
+        plugin, but it is included in the exported management fee rather than
+        exposed as a separate fee category. Enzyme's canonical `Protocol Fees
+        documentation <https://docs.enzyme.finance/user-documentation/blue-general-info/protocol-fees>`__
+        defines it as a charge on Assets Under Technology applied through share
+        inflation; unlike the PerformanceFee it is not conditional on growth
+        above a high-water mark. It is therefore a management fee for the
+        public vault export.
+
         Performance, entrance, and exit contracts store their rates in basis
-        points, as documented by Enzyme's canonical `PerformanceFee contract
-        <https://github.com/enzymefinance/protocol/blob/current/contracts/release/extensions/fee-manager/fees/PerformanceFee.sol>`__
-        and fee base contracts. ManagementFee instead stores a Ray-scaled
-        per-second compounding factor.
+        points. Enzyme's canonical `ManagementFee
+        <https://docs.enzyme.finance/enzyme-blue-protocol/fee-formulas/managementfee>`__
+        and `Performance Fee
+        <https://docs.enzyme.finance/enzyme-blue-protocol/fee-formulas/performance-fee>`__
+        documentation describes ManagementFee's Ray-scaled per-second
+        compounding factor and PerformanceFee's high-water-mark calculation.
         Historical fee configuration is TODO because Blue fee plugins,
         releases, and protocol-fee trackers can be replaced.
 
         :return:
-            Current fee settings, with the additional protocol charge in
-            :attr:`~eth_defi.vault.fee.FeeData.protocol`.
+            Current investor-facing fee settings. ``management`` includes
+            protocol access. ``protocol`` is retained as a breakdown, so the
+            manager-only rate is ``management - protocol``.
         """
 
         block_identifier = self._get_block_identifier()
@@ -408,6 +438,8 @@ class EnzymeBlueVault(VaultBase):
                 continue
             fee_info = self._try_fee_call(fee, "getFeeInfoForFund", self.comptroller_contract.address, block_identifier=block_identifier)
             if fee_info is None:
+                # The reviewed Blue plugins expose the canonical getters above.
+                # Do not turn a missing optional component into ``unknown``.
                 continue
             rate = Decimal(fee_info[0])
             # ManagementFee stores a 1e27-scaled per-second compounding factor,
@@ -421,7 +453,13 @@ class EnzymeBlueVault(VaultBase):
                 performance = Percent(float(rate / FEE_BPS_DENOMINATOR))
 
         protocol_fee = self._fetch_protocol_fee(block_identifier)
-        management = combine_user_facing_management_fee(management, protocol_fee)
+        # Missing reviewed fee plugins are zero, not unavailable metadata.
+        management = management if management is not None else Percent(0)
+        performance = performance if performance is not None else Percent(0)
+        deposit = deposit if deposit is not None else Percent(0)
+        withdraw = withdraw if withdraw is not None else Percent(0)
+        # Protocol access is included in management; see this method's docstring.
+        management = combine_user_facing_management_fee(management, protocol_fee) if protocol_fee is not None else None
         return FeeData(fee_mode=self.get_fee_mode(), management=management, performance=performance, deposit=deposit, withdraw=withdraw, protocol=protocol_fee)
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/enzyme/fee.py
+++ b/eth_defi/enzyme/fee.py
@@ -16,18 +16,18 @@ def combine_user_facing_management_fee(manager_fee: Percent | None, protocol_fee
     charge through minting, asset transfers, or internal debt accounting.
 
     :param manager_fee:
-        Current vault-manager annual fee, or ``None`` when unconfigured.
+        Current vault-manager rate, or ``None`` when unconfigured.
     :param protocol_fee:
-        Current additional protocol annual fee, or ``None`` when the reviewed
+        Current additional protocol rate, or ``None`` when the reviewed
         protocol surface has no separately configured rate.
     :return:
-        The user-facing combined annual management fee, or ``None`` when both
-        components are unavailable.
+        The combined management rate, or ``None`` when both components are
+        unavailable.
     """
 
     if manager_fee is None and protocol_fee is None:
         return None
 
-    # Export what the investor pays, not what Enzyme does internally to settle
-    # or distribute either fee. A protocol fee is charged on top of manager fee.
+    # Export the combined investor-facing rate. The separate protocol field is
+    # a breakdown, not a second charge to add to this result.
     return Percent(float((manager_fee or 0) + (protocol_fee or 0)))

--- a/eth_defi/enzyme/migration.py
+++ b/eth_defi/enzyme/migration.py
@@ -1,0 +1,68 @@
+"""Shared launch helpers for Enzyme metadata migrations.
+
+The scripts in :mod:`scripts.enzyme` remain separate operator entry points,
+but both delegate to the same resumable historical-migration engine. This
+module centralises their temporary environment handling so new migration flags
+cannot leak between entry points.
+"""
+
+import os
+import runpy
+from collections.abc import Mapping, MutableMapping
+from pathlib import Path
+
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE
+
+#: Environment values temporarily overridden while the delegated script runs.
+MIGRATION_ENVIRONMENT_VARIABLES = (
+    "ENZYME_SCAN_PRICES",
+    "ENZYME_CLEAN_PRICES",
+    "ENZYME_REFRESH_EXISTING_METADATA",
+    "ENZYME_REFRESH_BLUE_FEES",
+    "ENZYME_CHECKPOINT_PATH",
+)
+
+
+def configure_enzyme_migration_environment(environment: MutableMapping[str, str], overrides: Mapping[str, str], checkpoint_filename: str) -> None:
+    """Apply a metadata-only Enzyme migration configuration in place.
+
+    The caller supplies the explicit refresh flags for its operation. A caller
+    may still set a custom checkpoint path, but price scanning and cleaning are
+    always disabled by the entry points using this helper.
+
+    :param environment: Process environment mapping to update.
+    :param overrides: Explicit migration mode flags to force.
+    :param checkpoint_filename: Default checkpoint basename beside the vault
+        metadata database.
+    :return: None.
+    """
+
+    environment.update(overrides)
+    vault_db_path = Path(environment.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    environment.setdefault("ENZYME_CHECKPOINT_PATH", str(vault_db_path.with_name(checkpoint_filename)))
+
+
+def run_enzyme_backfill_with_environment(overrides: Mapping[str, str], checkpoint_filename: str, script_path: Path) -> None:
+    """Run the shared backfill entry point with temporary migration settings.
+
+    The previous process environment is restored even when the delegated
+    migration fails. This makes the helper safe for unit tests and for callers
+    that invoke more than one migration in the same Python process.
+
+    :param overrides: Explicit migration mode flags to force.
+    :param checkpoint_filename: Default checkpoint basename beside the vault
+        metadata database.
+    :param script_path: Path to the delegated ``backfill-history.py`` script.
+    :return: None after the delegated migration exits.
+    """
+
+    previous_values = {name: os.environ.get(name) for name in MIGRATION_ENVIRONMENT_VARIABLES}
+    try:
+        configure_enzyme_migration_environment(os.environ, overrides, checkpoint_filename)
+        runpy.run_path(str(script_path), run_name="__main__")
+    finally:
+        for name, value in previous_values.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -338,11 +338,11 @@ class FeeData:
     #: Fee for this class
     withdraw: float | None
 
-    #: Protocol-level fee charged in addition to vault-manager fees.
+    #: Protocol-level component of the exported fee schedule.
     #:
     #: Most protocols do not expose a separate protocol charge, so this is
-    #: optional. Adapters can retain it alongside a user-facing aggregate
-    #: management fee when their protocol charges it on top of manager fees.
+    #: optional. An adapter can retain it alongside an aggregate management
+    #: fee, allowing consumers to calculate a manager-only breakdown.
     protocol: float | None = None
 
     def __post_init__(self) -> None:

--- a/scripts/enzyme/backfill-history.py
+++ b/scripts/enzyme/backfill-history.py
@@ -21,6 +21,10 @@ Environment variables:
 - ``DRY_RUN``: print the discovered migration plan without writing, default ``false``.
 - ``ENZYME_SCAN_PRICES``: scan historical prices and TVL, default ``true``.
 - ``ENZYME_CLEAN_PRICES``: replace selected cleaned histories, default ``true``.
+- ``ENZYME_REFRESH_EXISTING_METADATA``: refresh every Enzyme row's current
+  metadata, default ``false``.
+- ``ENZYME_REFRESH_BLUE_FEES``: refresh every Enzyme Blue row's current fee
+  metadata, default ``false``. Used by ``migrate-blue-fees.py``.
 - ``ENZYME_REWRITE_TARGETED``: rewrite every selected vault from deployment,
   default ``false``. Vaults without price rows always start from their factory
   creation block.
@@ -699,9 +703,9 @@ def should_refresh_metadata(vault_db: VaultDatabase, candidate: EnzymeFactoryCan
     :return: ``True`` for missing, broken, or explicitly refreshed rows.
     """
 
+    row = vault_db.rows.get(VaultSpec(candidate.chain, candidate.address))
     if parse_bool_env("ENZYME_REFRESH_EXISTING_METADATA", default=False):
         return True
-    row = vault_db.rows.get(VaultSpec(candidate.chain, candidate.address))
     if row is not None and row.get("_enzyme_metadata_version") != ENZYME_CURRENT_METADATA_VERSION:
         return True
     if isinstance(candidate, EnzymeVaultFactoryCandidate) and row is not None and row.get("_enzyme_onyx_permission_version") != ENZYME_ONYX_PERMISSION_VERSION:
@@ -710,6 +714,8 @@ def should_refresh_metadata(vault_db: VaultDatabase, candidate: EnzymeFactoryCan
         return True
     if row is not None and int(row.get("_enzyme_metadata_checked_block") or 0) >= end_block:
         return False
+    if isinstance(candidate, EnzymeBlueVaultFactoryCandidate) and parse_bool_env("ENZYME_REFRESH_BLUE_FEES", default=False):
+        return True
     return not has_complete_current_metadata(vault_db, candidate)
 
 

--- a/scripts/enzyme/export-vaults.py
+++ b/scripts/enzyme/export-vaults.py
@@ -193,7 +193,9 @@ def main() -> None:
                 "Share price": format_metric(share_price),
                 "Performance fee": format_metric(row.get("Perf fee")),
                 "Management fee (user-facing)": format_metric(row.get("Mgmt fee")),
-                "Protocol fee": format_metric(row.get("Protocol fee")),
+                # Reference only: subtract this from management only to show a
+                # manager-only rate. It is already included in investor fees.
+                "Protocol fee (included in management)": format_metric(row.get("Protocol fee")),
             }
         )
     print(tabulate(table, headers="keys", tablefmt="github"))

--- a/scripts/enzyme/migrate-blue-fees.py
+++ b/scripts/enzyme/migrate-blue-fees.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Refresh current Enzyme Blue fees without rewriting price history.
+
+This migration discovers every factory-confirmed Enzyme Blue VaultProxy on
+Ethereum, Polygon, Base and Arbitrum, then rereads its current FeeManager and
+ProtocolFeeTracker configuration at one fixed head block per chain. It writes
+the resulting management, performance, entrance, exit and protocol-reference
+fees to the shared vault metadata database. Enzyme's protocol-access charge is
+included in management; subtract the separately exported protocol value to
+calculate the manager-only rate. No historical fee configuration, raw-price
+Parquet, cleaned-price Parquet or reader state is modified.
+
+Run this once after a Blue fee-reader change. Ordinary all-chain vault scans
+subsequently refresh the same current metadata whenever their lead-discovery
+cache expires (seven days by default), so JSON exports track later fee changes.
+
+Usage::
+
+    # Review the factory-discovered scope without writes
+    source .local-test.env && DRY_RUN=true poetry run python scripts/enzyme/migrate-blue-fees.py
+
+    # Apply the resumable current-fee refresh
+    source .local-test.env && MAX_WORKERS=8 poetry run python scripts/enzyme/migrate-blue-fees.py
+
+Environment variables:
+
+- ``DRY_RUN``: print the discovery plan without writing, default ``false``.
+- ``JSON_RPC_ETHEREUM``, ``JSON_RPC_POLYGON``, ``JSON_RPC_BASE`` and
+  ``JSON_RPC_ARBITRUM``: required multi-provider RPC configurations.
+- ``HYPERSYNC_API_KEY``: required for factory event discovery.
+- ``MAX_WORKERS``: current-metadata worker count, default ``8``.
+- ``ENZYME_METADATA_BATCH_SIZE``: durable batch size, default ``128``.
+- ``ENZYME_CHECKPOINT_PATH``: optional resumable checkpoint path.
+- ``VAULT_DB_PATH``: optional vault metadata database path.
+- ``PIPELINE_LOCK_TIMEOUT``: seconds to wait for the shared writer lock,
+  default ``60``.
+"""
+
+from collections.abc import MutableMapping
+from pathlib import Path
+
+from eth_defi.enzyme import migration
+
+MIGRATION_OVERRIDES = {
+    "ENZYME_SCAN_PRICES": "false",
+    "ENZYME_CLEAN_PRICES": "false",
+    "ENZYME_REFRESH_EXISTING_METADATA": "false",
+    "ENZYME_REFRESH_BLUE_FEES": "true",
+}
+
+CHECKPOINT_FILENAME = "enzyme-blue-fees-state.json"
+
+
+def configure_blue_fee_migration_environment(environment: MutableMapping[str, str]) -> None:
+    """Force the Blue current-fee migration mode.
+
+    This preserves every historical database and price file. The dedicated
+    refresh flag selects every factory-confirmed Blue row. The shared engine
+    still performs its normal incremental repairs for other Enzyme rows.
+
+    :param environment: Process environment mapping to update in place.
+    :return: None.
+    """
+
+    migration.configure_enzyme_migration_environment(environment, MIGRATION_OVERRIDES, CHECKPOINT_FILENAME)
+
+
+def main() -> None:
+    """Run the shared Enzyme engine in Blue current-fee refresh mode.
+
+    :return: None after the delegated migration exits.
+    """
+
+    migration.run_enzyme_backfill_with_environment(MIGRATION_OVERRIDES, CHECKPOINT_FILENAME, Path(__file__).with_name("backfill-history.py"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enzyme/migrate-current-metadata.py
+++ b/scripts/enzyme/migrate-current-metadata.py
@@ -52,26 +52,25 @@ Environment variables:
 - ``PIPELINE_LOCK_TIMEOUT``: seconds to wait for the shared writer lock,
   default ``60``.
 
-``ENZYME_SCAN_PRICES``, ``ENZYME_CLEAN_PRICES`` and
-``ENZYME_REFRESH_EXISTING_METADATA`` are deliberately overridden by this
-entry point. Use ``backfill-history.py`` for historical price work or an
-intentional unconditional metadata refresh.
+``ENZYME_SCAN_PRICES``, ``ENZYME_CLEAN_PRICES`` and refresh flags are
+deliberately overridden by this entry point. Use ``migrate-blue-fees.py`` for
+an intentional Blue-fee refresh, or ``backfill-history.py`` for historical
+price work.
 """
 
-import os
-import runpy
 from collections.abc import MutableMapping
 from pathlib import Path
 
-from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE
+from eth_defi.enzyme import migration
 
-#: Environment values temporarily forced while the delegated script runs.
-MIGRATION_ENVIRONMENT_VARIABLES = (
-    "ENZYME_SCAN_PRICES",
-    "ENZYME_CLEAN_PRICES",
-    "ENZYME_REFRESH_EXISTING_METADATA",
-    "ENZYME_CHECKPOINT_PATH",
-)
+MIGRATION_OVERRIDES = {
+    "ENZYME_SCAN_PRICES": "false",
+    "ENZYME_CLEAN_PRICES": "false",
+    "ENZYME_REFRESH_EXISTING_METADATA": "false",
+    "ENZYME_REFRESH_BLUE_FEES": "false",
+}
+
+CHECKPOINT_FILENAME = "enzyme-current-metadata-state.json"
 
 
 def configure_metadata_migration_environment(environment: MutableMapping[str, str]) -> None:
@@ -87,11 +86,7 @@ def configure_metadata_migration_environment(environment: MutableMapping[str, st
     :return: None.
     """
 
-    environment["ENZYME_SCAN_PRICES"] = "false"
-    environment["ENZYME_CLEAN_PRICES"] = "false"
-    environment["ENZYME_REFRESH_EXISTING_METADATA"] = "false"
-    vault_db_path = Path(environment.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
-    environment.setdefault("ENZYME_CHECKPOINT_PATH", str(vault_db_path.with_name("enzyme-current-metadata-state.json")))
+    migration.configure_enzyme_migration_environment(environment, MIGRATION_OVERRIDES, CHECKPOINT_FILENAME)
 
 
 def main() -> None:
@@ -100,17 +95,7 @@ def main() -> None:
     :return: None after the delegated migration exits.
     """
 
-    previous_values = {name: os.environ.get(name) for name in MIGRATION_ENVIRONMENT_VARIABLES}
-    try:
-        configure_metadata_migration_environment(os.environ)
-        migration_path = Path(__file__).with_name("backfill-history.py")
-        runpy.run_path(str(migration_path), run_name="__main__")
-    finally:
-        for name, value in previous_values.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
+    migration.run_enzyme_backfill_with_environment(MIGRATION_OVERRIDES, CHECKPOINT_FILENAME, Path(__file__).with_name("backfill-history.py"))
 
 
 if __name__ == "__main__":

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -399,10 +399,11 @@ state or price parquet before a rerun. `ENZYME_END_BLOCK_<chain-id>` can bound
 one chain for diagnosis; use `ENZYME_SCAN_PRICES=false` for a metadata-only
 repair. Historical fees are intentionally TODO. Current Blue metadata exports
 the user-facing management fee as the manager rate plus the additional
-ProtocolFeeTracker rate. The latter is also exported separately as ``Protocol
-fee`` for a transparent breakdown; internal
-[protocol-access settlement](https://specs.enzyme.finance/topics/protocol-fee)
-does not change the investor-facing aggregate.
+ProtocolFeeTracker rate. Enzyme defines protocol access as a fee on Assets
+Under Technology, rather than a high-water-mark performance fee, so it is
+included in management. ``Protocol fee`` is exported separately so consumers
+can calculate ``manager fee = Mgmt fee - Protocol fee``.
+See Enzyme's [canonical Protocol Fees documentation](https://docs.enzyme.finance/user-documentation/blue-general-info/protocol-fees).
 
 Historical Enzyme price rows intentionally do not populate ``deposits_open``
 or ``redemption_open``. Enzyme Blue policies and Onyx handler configurations
@@ -1294,8 +1295,10 @@ The current standard Onyx FeeHandler exposes management, performance, entrance
 and exit settings, but no separately configured protocol fee. Its ``Mgmt fee``
 is therefore its full user-facing recurring management charge. Blue's ``Mgmt
 fee`` is the corresponding investor-facing sum of the fund manager fee and
-ProtocolFeeTracker rate. ``Protocol fee`` retains the latter as a transparent
-breakdown, not as an extra charge to add again.
+ProtocolFeeTracker rate. Enzyme's protocol fee applies to Assets Under
+Technology rather than gains above a high-water mark, so it is included in
+``Mgmt fee``. ``Protocol fee`` is exported separately for the calculation
+``manager fee = Mgmt fee - Protocol fee``.
 
 Run a read-only discovery plan first:
 
@@ -1325,6 +1328,7 @@ poetry run python scripts/enzyme/backfill-history.py
 | `ENZYME_REWRITE_TARGETED` | Rewrite every selected Enzyme history from its factory creation block. Otherwise resumes after each vault's latest raw row; a new vault starts at its factory creation block. Default: false. |
 | `ENZYME_DISCOVERY_START_BLOCK` | Optional lower block for factory-event discovery. Default: the reviewed Enzyme deployment block for each chain. |
 | `ENZYME_REFRESH_EXISTING_METADATA` | Refresh good metadata rows as well as missing or broken rows. Default: false. |
+| `ENZYME_REFRESH_BLUE_FEES` | Refresh every Blue row's current fees without refreshing healthy Onyx rows. Used by `migrate-blue-fees.py`. Default: false. |
 | `FREQUENCY` | Historical frequency, `1h` or `1d`. Default: `1d`. |
 | `START_BLOCK` / `END_BLOCK` | Optional inclusive historical price bounds. `START_BLOCK` overrides the normal per-vault resume point, so use it only for a scoped repair. |
 | `ENZYME_END_BLOCK_<chain-id>` | Optional per-chain inclusive end block, useful for diagnosis without changing other chains. |
@@ -1337,7 +1341,7 @@ poetry run python scripts/enzyme/backfill-history.py
 `scripts/enzyme/export-vaults.py` prints the latest collected Enzyme rows as
 a Markdown table. It is read-only and includes the chain, name, curated short
 description, accounting unit, total value, share price, performance fee,
-user-facing management fee and a separate Blue protocol-fee breakdown. It calculates share price
+user-facing management fee, and the protocol-fee breakdown. It calculates share price
 from the latest onchain `NAV` and `Shares` stored in the metadata database.
 An Onyx value asset can be a named accounting unit instead of an ERC-20
 stablecoin, so the reported total value must not be treated as USD TVL without
@@ -1454,10 +1458,41 @@ checkpoint or metadata database. This checkpoint is intentionally separate
 from `enzyme-backfill-history-state.json`, so a metadata repair cannot discard
 an unfinished historical-price backfill.
 
+### Enzyme migrate-blue-fees.py
+
+`scripts/enzyme/migrate-blue-fees.py` refreshes only current Enzyme Blue fee
+metadata. It re-enumerates each Blue vault's configured FeeManager contracts
+and ProtocolFeeTracker, and writes management, performance, deposit,
+withdrawal and reference protocol-fee fields to the metadata database. Protocol
+access is included in management, and ``Protocol fee`` allows the manager-only
+rate to be calculated by subtraction. It never changes historical fee data,
+price Parquet files or reader state.
+
+The reader exports a zero when the authoritative FeeManager enumeration proves
+that a standard fee plugin is absent. The reader covers Enzyme Blue's complete
+canonical plugin set. The ordinary all-chain scanner refreshes the same current
+metadata on its next
+lead-discovery cache expiry (seven days by default), so later configuration
+changes reach the vault JSON export without rerunning this migration.
+
+```shell
+source .local-test.env && \
+DRY_RUN=true \
+poetry run python scripts/enzyme/migrate-blue-fees.py
+
+source .local-test.env && \
+MAX_WORKERS=8 \
+poetry run python scripts/enzyme/migrate-blue-fees.py
+```
+
+The script needs the four Enzyme RPC configurations and `HYPERSYNC_API_KEY`.
+It uses `enzyme-blue-fees-state.json` beside the vault database by default and
+forces historical-price work off.
+
 | Variable | Description |
 |----------|-------------|
 | `VAULT_DB_PATH` | Optional metadata database path. Default: production path. |
-| `ENZYME_CHECKPOINT_PATH` | Optional metadata-only checkpoint path. Default: `enzyme-current-metadata-state.json` beside the vault database. |
+| `ENZYME_CHECKPOINT_PATH` | Optional Blue-fee checkpoint path. Default: `enzyme-blue-fees-state.json` beside the vault database. |
 | `PIPELINE_LOCK_TIMEOUT` | Seconds to wait for the shared scanner writer lock. Default: `60`. |
 
 ### fix-t3tris-vaults.py

--- a/tests/enzyme/conftest.py
+++ b/tests/enzyme/conftest.py
@@ -34,7 +34,17 @@ logger = logging.getLogger(__name__)
 ENZYME_SKIP_REASON = "Legacy Enzyme Blue V4 deployment suite is no longer maintained"
 
 _ENZYME_TEST_DIR = Path(__file__).parent
-_ACTIVE_ENZYME_TEST_FILES = {"test_backfill_history.py", "test_blue_vault.py", "test_enzyme_lifetime_metrics.py", "test_migrate_current_metadata.py", "test_onyx_vault.py", "test_enzyme_offchain_metadata.py", "test_repair_zero_gav_history.py", "test_report_whitelist.py"}
+_ACTIVE_ENZYME_TEST_FILES = {
+    "test_backfill_history.py",
+    "test_blue_vault.py",
+    "test_enzyme_lifetime_metrics.py",
+    "test_enzyme_offchain_metadata.py",
+    "test_migrate_blue_fees.py",
+    "test_migrate_current_metadata.py",
+    "test_onyx_vault.py",
+    "test_repair_zero_gav_history.py",
+    "test_report_whitelist.py",
+}
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/enzyme/test_backfill_history.py
+++ b/tests/enzyme/test_backfill_history.py
@@ -292,6 +292,57 @@ def test_enzyme_backfill_repairs_unknown_permissions_for_both_architectures(monk
     assert module.should_refresh_metadata(database, onyx, METADATA_END_BLOCK) is False
 
 
+def test_enzyme_backfill_blue_fee_refresh_resumes_complete_blue_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refresh Blue once per fixed head while retaining normal Onyx selection."""
+
+    module = load_backfill_module()
+    monkeypatch.delenv("ENZYME_REFRESH_EXISTING_METADATA", raising=False)
+    monkeypatch.setenv("ENZYME_REFRESH_BLUE_FEES", "true")
+    onyx = create_candidate("0x000000000000000000000000000000000000bEEF", 35_306_010)
+    blue = EnzymeBlueVaultFactoryCandidate(
+        chain=8453,
+        address=HexAddress("0x000000000000000000000000000000000000cafE"),
+        dispatcher_address=ENZYME_BLUE_DEPLOYMENTS[8453].dispatcher,
+        fund_deployer=HexAddress("0x000000000000000000000000000000000000a11c"),
+        vault_accessor=HexAddress("0x000000000000000000000000000000000000acce"),
+        fund_name="Fee repair",
+        created_block=23_200_000,
+        created_at=onyx.created_at,
+        transaction_hash="0xbead",
+        log_index=3,
+    )
+    database = module.VaultDatabase(
+        rows={
+            VaultSpec(blue.chain, blue.address): {
+                "Name": "Blue",
+                "Symbol": "BLUE",
+                "_denomination_token": {"symbol": "USDC"},
+                "_deposit_permission": "permissionless",
+                "_enzyme_metadata_version": module.ENZYME_CURRENT_METADATA_VERSION,
+                "_enzyme_metadata_checked_block": METADATA_END_BLOCK,
+            },
+            VaultSpec(onyx.chain, onyx.address): {
+                "Name": "Onyx",
+                "Symbol": "ONYX",
+                "_denomination_token": {"symbol": "USDC"},
+                "_deposit_permission": "permissionless",
+                "_short_description": None,
+                "_description": module.ONYX_PUBLIC_DESCRIPTION_UNAVAILABLE,
+                "_enzyme_metadata_version": module.ENZYME_CURRENT_METADATA_VERSION,
+                "_enzyme_onyx_permission_version": module.ENZYME_ONYX_PERMISSION_VERSION,
+                "_enzyme_onyx_description_version": module.ENZYME_ONYX_DESCRIPTION_VERSION,
+                "_enzyme_metadata_checked_block": METADATA_END_BLOCK,
+            },
+        }
+    )
+
+    assert module.should_refresh_metadata(database, blue, METADATA_END_BLOCK) is False
+    assert module.should_refresh_metadata(database, onyx, METADATA_END_BLOCK) is False
+
+    database.rows[VaultSpec(blue.chain, blue.address)]["_enzyme_metadata_checked_block"] = METADATA_END_BLOCK - 1
+    assert module.should_refresh_metadata(database, blue, METADATA_END_BLOCK) is True
+
+
 def test_enzyme_backfill_repairs_missing_onyx_description_marker(monkeypatch) -> None:
     """Use the explicit Onyx description marker as resumable metadata state."""
 

--- a/tests/enzyme/test_blue_vault.py
+++ b/tests/enzyme/test_blue_vault.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 from eth_abi import encode
 from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput
 
 from eth_defi.enzyme import blue_vault
 from eth_defi.enzyme.blue_discovery import ENZYME_BLUE_DEPLOYMENTS, EnzymeBlueVaultFactoryCandidate, decode_enzyme_blue_vault_deployed_event, fetch_enzyme_blue_dispatchers_for_chain
@@ -16,6 +17,8 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.discovery_base import _prepare_probe_leads, create_enzyme_blue_factory_detection, create_enzyme_blue_potential_vault_match  # noqa: PLC2701
 from eth_defi.erc_4626.scan import fetch_deposit_permission
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.provider.fallback import ExtraValueError
+from eth_defi.types import Percent
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.deposit_redeem import VaultDepositPermission
 
@@ -240,7 +243,7 @@ def test_blue_legacy_policy_manager_fallback(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_blue_current_fees_include_protocol_fee_in_user_facing_management_rate(monkeypatch) -> None:
-    """Show the combined Blue fee paid by an investor and its breakdown."""
+    """Fold Blue's AUM protocol fee into management and retain its reference."""
 
     vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
     vault.default_block_identifier = None
@@ -269,3 +272,111 @@ def test_blue_current_fees_include_protocol_fee_in_user_facing_management_rate(m
     assert fee_data.performance == EXPECTED_PERFORMANCE_FEE
     assert fee_data.deposit == EXPECTED_ENTRANCE_FEE
     assert fee_data.withdraw == EXPECTED_EXIT_FEE
+
+
+def test_blue_current_fees_mark_absent_standard_plugins_as_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Export confirmed zeroes when FeeManager enables no fee plugins.
+
+    FeeManager is the authoritative enumeration of every configured Blue fund
+    fee. An empty result therefore proves that the manager, performance,
+    entrance and exit components are all disabled.
+    """
+
+    vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
+    vault.default_block_identifier = None
+    vault.comptroller_contract = SimpleNamespace(address=ACCESSOR)
+    monkeypatch.setattr(vault, "_fetch_enabled_fee_contracts", lambda _block: [])
+    monkeypatch.setattr(vault, "_fetch_protocol_fee", lambda _block: Percent(0))
+
+    fee_data = vault.get_fee_data()
+
+    assert fee_data.management == 0
+    assert fee_data.performance == 0
+    assert fee_data.deposit == 0
+    assert fee_data.withdraw == 0
+    assert fee_data.protocol == 0
+
+
+def test_blue_current_fees_fill_absent_plugins_around_enabled_exit_fee(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep an explicit exit fee while filling absent performance and entrance fees."""
+
+    vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
+    vault.default_block_identifier = None
+    vault.comptroller_contract = SimpleNamespace(address=ACCESSOR)
+    monkeypatch.setattr(vault, "_fetch_enabled_fee_contracts", lambda _block: ["exit"])
+    monkeypatch.setattr(vault, "_fetch_protocol_fee", lambda _block: Percent(EXPECTED_PROTOCOL_FEE))
+    monkeypatch.setattr(
+        vault,
+        "_try_fee_call",
+        lambda fee, function_name, *_args, **_kwargs: 0 if (fee, function_name) == ("exit", "getInKindRateForFund") else None,
+    )
+
+    fee_data = vault.get_fee_data()
+
+    assert fee_data.management == EXPECTED_PROTOCOL_FEE
+    assert fee_data.performance == 0
+    assert fee_data.deposit == 0
+    assert fee_data.withdraw == 0
+    assert fee_data.protocol == EXPECTED_PROTOCOL_FEE
+
+
+def test_blue_current_fees_keep_management_unknown_without_protocol_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not claim a management fee when the protocol component is unavailable."""
+
+    vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
+    vault.default_block_identifier = None
+    vault.comptroller_contract = SimpleNamespace(address=ACCESSOR)
+    monkeypatch.setattr(vault, "_fetch_enabled_fee_contracts", lambda _block: [])
+    monkeypatch.setattr(vault, "_fetch_protocol_fee", lambda _block: None)
+
+    fee_data = vault.get_fee_data()
+
+    assert fee_data.management is None
+    assert fee_data.protocol is None
+
+
+def test_blue_fee_call_propagates_provider_failure() -> None:
+    """Do not convert an RPC failure to a fee plugin that is absent."""
+
+    def raise_provider_error(**_kwargs: object) -> None:
+        """Simulate the fallback provider's final JSON-RPC failure."""
+
+        error_message = "rate limited"
+        raise ExtraValueError(error_message)
+
+    vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
+    fee = SimpleNamespace(functions=SimpleNamespace(getFeeInfoForFund=lambda *_args: SimpleNamespace(call=raise_provider_error)))
+
+    with pytest.raises(ExtraValueError, match="rate limited"):
+        vault._try_fee_call(fee, "getFeeInfoForFund", ACCESSOR, block_identifier="latest")
+
+
+def test_blue_legacy_fund_deployer_has_no_protocol_fee(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat the missing ProtocolFeeTracker on older Blue releases as zero."""
+
+    def raise_missing_tracker(**_kwargs: object) -> None:
+        """Simulate an old FundDeployer that predates the tracker getter."""
+
+        error_message = "ProtocolFeeTracker is unavailable"
+        raise BadFunctionCallOutput(error_message)
+
+    vault = EnzymeBlueVault.__new__(EnzymeBlueVault)
+    vault.spec = VaultSpec(CHAIN_ID, VAULT)
+    vault.web3 = object()
+    deployment = ENZYME_BLUE_DEPLOYMENTS[CHAIN_ID]
+    dispatcher = SimpleNamespace(functions=SimpleNamespace(getFundDeployerForVaultProxy=lambda *_args: SimpleNamespace(call=lambda **_kwargs: FUND_DEPLOYER)))
+    fund_deployer = SimpleNamespace(functions=SimpleNamespace(getProtocolFeeTracker=lambda: SimpleNamespace(call=raise_missing_tracker)))
+
+    def fake_get_deployed_contract(_web3: object, abi_name: str, address: str) -> SimpleNamespace:
+        """Return the minimal contracts needed for the legacy release read."""
+
+        if abi_name.endswith("Dispatcher.json"):
+            assert address == deployment.dispatcher
+            return dispatcher
+        assert abi_name.endswith("FundDeployer.json")
+        assert address == FUND_DEPLOYER
+        return fund_deployer
+
+    monkeypatch.setattr(blue_vault, "get_deployed_contract", fake_get_deployed_contract)
+
+    assert vault._fetch_protocol_fee("latest") == 0

--- a/tests/enzyme/test_migrate_blue_fees.py
+++ b/tests/enzyme/test_migrate_blue_fees.py
@@ -1,0 +1,68 @@
+"""Test the Enzyme Blue current-fee migration entry point."""
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "enzyme" / "migrate-blue-fees.py"
+
+
+def load_migration_module() -> ModuleType:
+    """Load the hyphenated Blue-fee migration as a Python module.
+
+    :return: Imported migration module.
+    """
+
+    spec = importlib.util.spec_from_file_location("enzyme_migrate_blue_fees", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_blue_fee_migration_forces_current_blue_only_mode() -> None:
+    """Prevent an operator environment from widening the migration scope."""
+
+    module = load_migration_module()
+    environment = {
+        "ENZYME_SCAN_PRICES": "true",
+        "ENZYME_CLEAN_PRICES": "true",
+        "ENZYME_REFRESH_EXISTING_METADATA": "true",
+        "ENZYME_REFRESH_BLUE_FEES": "false",
+    }
+
+    module.configure_blue_fee_migration_environment(environment)
+
+    assert environment == {
+        "ENZYME_SCAN_PRICES": "false",
+        "ENZYME_CLEAN_PRICES": "false",
+        "ENZYME_REFRESH_EXISTING_METADATA": "false",
+        "ENZYME_REFRESH_BLUE_FEES": "true",
+        "ENZYME_CHECKPOINT_PATH": str(module.migration.DEFAULT_VAULT_DATABASE.with_name("enzyme-blue-fees-state.json")),
+    }
+
+
+def test_blue_fee_migration_delegates_to_shared_resumable_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use the reviewed Enzyme backfill implementation without price writes."""
+
+    module = load_migration_module()
+    calls = []
+    monkeypatch.setattr(module.migration.runpy, "run_path", lambda path, run_name: calls.append((Path(path), run_name)))
+    monkeypatch.setenv("ENZYME_SCAN_PRICES", "true")
+    monkeypatch.setenv("ENZYME_CLEAN_PRICES", "true")
+    monkeypatch.setenv("ENZYME_REFRESH_EXISTING_METADATA", "true")
+    monkeypatch.setenv("ENZYME_REFRESH_BLUE_FEES", "false")
+    monkeypatch.delenv("ENZYME_CHECKPOINT_PATH", raising=False)
+
+    module.main()
+
+    assert calls == [(SCRIPT_PATH.with_name("backfill-history.py"), "__main__")]
+    assert os.environ["ENZYME_SCAN_PRICES"] == "true"
+    assert os.environ["ENZYME_CLEAN_PRICES"] == "true"
+    assert os.environ["ENZYME_REFRESH_EXISTING_METADATA"] == "true"
+    assert os.environ["ENZYME_REFRESH_BLUE_FEES"] == "false"
+    assert "ENZYME_CHECKPOINT_PATH" not in os.environ

--- a/tests/enzyme/test_migrate_current_metadata.py
+++ b/tests/enzyme/test_migrate_current_metadata.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "enzyme" / "migrate-current-metadata.py"
 
 
@@ -30,6 +32,7 @@ def test_metadata_migration_forces_incremental_non_price_mode() -> None:
         "ENZYME_SCAN_PRICES": "true",
         "ENZYME_CLEAN_PRICES": "true",
         "ENZYME_REFRESH_EXISTING_METADATA": "true",
+        "ENZYME_REFRESH_BLUE_FEES": "true",
     }
 
     module.configure_metadata_migration_environment(environment)
@@ -38,19 +41,21 @@ def test_metadata_migration_forces_incremental_non_price_mode() -> None:
         "ENZYME_SCAN_PRICES": "false",
         "ENZYME_CLEAN_PRICES": "false",
         "ENZYME_REFRESH_EXISTING_METADATA": "false",
-        "ENZYME_CHECKPOINT_PATH": str(module.DEFAULT_VAULT_DATABASE.with_name("enzyme-current-metadata-state.json")),
+        "ENZYME_REFRESH_BLUE_FEES": "false",
+        "ENZYME_CHECKPOINT_PATH": str(module.migration.DEFAULT_VAULT_DATABASE.with_name("enzyme-current-metadata-state.json")),
     }
 
 
-def test_metadata_migration_delegates_to_shared_resumable_engine(monkeypatch) -> None:
+def test_metadata_migration_delegates_to_shared_resumable_engine(monkeypatch: pytest.MonkeyPatch) -> None:
     """Use the reviewed Enzyme backfill implementation instead of duplicating it."""
 
     module = load_migration_module()
     calls = []
-    monkeypatch.setattr(module.runpy, "run_path", lambda path, run_name: calls.append((Path(path), run_name)))
+    monkeypatch.setattr(module.migration.runpy, "run_path", lambda path, run_name: calls.append((Path(path), run_name)))
     monkeypatch.setenv("ENZYME_SCAN_PRICES", "true")
     monkeypatch.setenv("ENZYME_CLEAN_PRICES", "true")
     monkeypatch.setenv("ENZYME_REFRESH_EXISTING_METADATA", "true")
+    monkeypatch.setenv("ENZYME_REFRESH_BLUE_FEES", "true")
     monkeypatch.delenv("ENZYME_CHECKPOINT_PATH", raising=False)
 
     module.main()
@@ -59,6 +64,7 @@ def test_metadata_migration_delegates_to_shared_resumable_engine(monkeypatch) ->
     assert os.environ["ENZYME_SCAN_PRICES"] == "true"
     assert os.environ["ENZYME_CLEAN_PRICES"] == "true"
     assert os.environ["ENZYME_REFRESH_EXISTING_METADATA"] == "true"
+    assert os.environ["ENZYME_REFRESH_BLUE_FEES"] == "true"
     assert "ENZYME_CHECKPOINT_PATH" not in os.environ
 
 


### PR DESCRIPTION
## Why

The vault export reported Enzyme Blue fees as unavailable or misleadingly separated the protocol access charge from the investor-facing management fee. Existing vault metadata needs a safe current-fee repair without changing historical price or fee series.

## Lessons learnt

A missing reviewed fee plugin is a confirmed zero only after its getter read succeeds; provider failures must remain failures rather than becoming zero fees. Blue protocol access is included in the exported management fee, while the separately exported protocol field enables the manager-only calculation.

## Summary

- Read and export current Blue management, performance, entrance, exit, and protocol fee components.
- Include protocol access in `Mgmt fee` and retain `Protocol fee` as the included breakdown.
- Add a resumable, metadata-only `migrate-blue-fees.py` migration and shared migration launcher.
- Update operator and protocol documentation, including canonical Enzyme references.
- Add focused regression coverage; `44 passed` for the Enzyme fee and migration test set.

## Related issues and PRs

Continues the Enzyme Blue metadata and direct vault-reader work.

## Unrelated CI and test fixes

None.