### PR TITLE
notes: explain Yearn yBOLD yield mechanics

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/yearn/notes.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/notes.py
@@ -1,0 +1,12 @@
+"""Handwritten notes for specific Yearn vaults."""
+
+#: Yearn BOLD receipt-token vault on Ethereum.
+YBOLD_VAULT = "0x9f4330700a36b29952869fac9b33f45eedd8a3d8"
+
+#: Yearn yBOLD Auto-Compounder vault on Ethereum.
+YSYBOLD_VAULT = "0x23346b04a7f55b8760e5860aa5a77383d63491cd"
+
+#: Address-keyed notes for Yearn vaults.
+YEARN_VAULT_NOTES: dict[str, str] = {
+    YBOLD_VAULT: (f"yBOLD is a 1:1 BOLD receipt token and does not accrue yield. Stake yBOLD in [ysyBOLD](https://yearn.fi/vaults/1/{YSYBOLD_VAULT}) to earn compounded yield."),
+}

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -12,6 +12,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
+from eth_defi.erc_4626.vault_protocol.yearn.notes import YEARN_VAULT_NOTES
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,23 @@ class YearnV3Vault(ERC4626Vault):
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
         return INSTANT_WITHDRAWAL_PERIOD
+
+    def get_notes(self) -> str | None:
+        """Return Yearn-specific notes for manually maintained vaults.
+
+        Shared manual notes retain precedence over Yearn-specific notes. This
+        allows an address to carry an operational warning without losing the
+        standard shared-vault override behaviour.
+
+        :return:
+            Markdown note for vault exports, when configured.
+        """
+
+        manual_notes = super().get_notes()
+        if manual_notes:
+            return manual_notes
+
+        return YEARN_VAULT_NOTES.get(self.address.lower())
 
     def get_link(self, referral: str | None = None) -> str:
         return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -6,7 +6,22 @@ import pytest
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
+from eth_defi.erc_4626.vault_protocol.yearn.notes import YBOLD_VAULT, YSYBOLD_VAULT
 from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
+from eth_defi.vault.base import VaultSpec
+
+
+def test_ybold_note_links_to_yield_bearing_staking_vault() -> None:
+    """yBOLD must explain that only the ysyBOLD staking vault earns yield."""
+    vault = object.__new__(YearnV3Vault)
+    vault.spec = VaultSpec(chain_id=1, vault_address=YBOLD_VAULT)
+    vault.features = None
+
+    note = vault.get_notes()
+
+    assert note is not None
+    assert "does not accrue yield" in note
+    assert f"[ysyBOLD](https://yearn.fi/vaults/1/{YSYBOLD_VAULT})" in note
 
 
 def test_yearn_without_deposit_limit_module_is_permissionless() -> None:


### PR DESCRIPTION
# Why

yBOLD is a 1:1 BOLD receipt token and does not earn yield itself. Its listing needs to direct users to the ysyBOLD staking vault, where the yield-bearing share price accrues.

# Lessons learnt

Yearn presents yBOLD and ysyBOLD closely together, but they have distinct return mechanics. Vault notes must distinguish the non-yield-bearing receipt token from the staking vault.

# Summary

- Added an address-keyed Yearn vault notes module.
- Added a yBOLD note with an inline link to the canonical ysyBOLD vault.
- Made the Yearn adapter export those per-vault notes.
- Added focused test coverage for the note.

# Related issues and PRs

None.

# Unrelated CI and test fixes

None.