### PR TITLE
feat: export vault strategy categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Export documented vault strategy categories with quality-filtered TVL and one-month return aggregates, plus a local category-breakdown helper (2026-09-04)
 - feat: Add canonical signed per-period vault flow values, expose gross directional values and counts only from individually extracted events, estimate netted stablecoin ERC-4626 flows from daily vault states, and deprecate the legacy top-level netflow export (2026-08-31)
 - fix: Publish YieldBasis protocol metadata, description and listing logos under the canonical website slug (2026-08-31)
 - feat: Classify Axis's Ethereum V2 StakedUSDx vault, correct Plasma V1 redemption metadata, and migrate existing cached records (2026-08-30)

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -593,7 +593,8 @@ class StrategyCategoryExportRecord(TypedDict):
     description: str
 
     #: Number of eligible exported vaults carrying this category tag. Excludes
-    #: blacklisted rows and rows with missing, invalid, or broken current TVL.
+    #: blacklisted or stale rows and rows with missing, invalid, or broken
+    #: current TVL.
     vault_count: int
 
     #: Sum of current USD TVL across eligible exported vaults carrying this
@@ -602,7 +603,8 @@ class StrategyCategoryExportRecord(TypedDict):
 
     #: Current-TVL-weighted annualised one-month return, or ``None`` when no
     #: eligible tagged vault has both valid current USD TVL and a complete,
-    #: bounded 1M return observation. Net return is preferred when known.
+    #: bounded 1M return observation covering at least 28 days. Net return is
+    #: preferred when known.
     one_month_apy: float | None
 
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass, is_dataclass
 from decimal import Decimal
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Literal, NotRequired, TypeAlias, TypedDict
 
 import numpy as np
 import pandas as pd
@@ -573,8 +573,37 @@ class VaultMetricsExport(TypedDict):
     #: Only curators present in the exported vaults are included.
     curators: dict[str, "CuratorExportRecord"]
 
+    #: Strategy category labels, rules, and aggregates keyed by strategy tag.
+    #:
+    #: Omitted only when best-effort category aggregation fails. The rest of
+    #: the public vault export remains valid and publishable in that case.
+    categories: NotRequired[dict[str, "StrategyCategoryExportRecord"]]
+
     #: List of per-vault metric records
     vaults: list[VaultMetricsRecord]
+
+
+class StrategyCategoryExportRecord(TypedDict):
+    """One public strategy category and its aggregate vault metrics."""
+
+    #: Human-readable category label without Markdown links.
+    label: str
+
+    #: Exactly two sentences describing the evidence-based category rule.
+    description: str
+
+    #: Number of eligible exported vaults carrying this category tag. Excludes
+    #: blacklisted rows and rows with missing, invalid, or broken current TVL.
+    vault_count: int
+
+    #: Sum of current USD TVL across eligible exported vaults carrying this
+    #: category tag.
+    tvl_usd: float
+
+    #: Current-TVL-weighted annualised one-month return, or ``None`` when no
+    #: eligible tagged vault has both valid current USD TVL and a complete,
+    #: bounded 1M return observation. Net return is preferred when known.
+    one_month_apy: float | None
 
 
 def make_vault_display_flags(

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -1261,8 +1261,9 @@ def run_post_processing(
         exchange_rate_parquet_error = exc
         steps["materialise-exchange-rate-parquet"] = False
 
-    # Export top vaults JSON. This depends on cleaned Parquet and must run before
-    # the public data-file upload.
+    # Export top vaults JSON, including its best-effort strategy-category
+    # aggregate. This depends on cleaned Parquet and must run before the public
+    # data-file upload.
     if skip_top_vaults:
         logger.info("Skipping top vaults export (SKIP_TOP_VAULTS=true)")
     elif not cleaning_ok:

--- a/eth_defi/vault/sample_export.py
+++ b/eth_defi/vault/sample_export.py
@@ -26,6 +26,30 @@ logger = logging.getLogger(__name__)
 ETHEREUM_CHAIN_ID = 1
 
 
+def append_sample_strategy_categories(output_data: dict, vaults: list[dict]) -> bool:
+    """Best-effort add categories without requiring scanner extras on import.
+
+    The sample exporter is usable with a minimal data-file installation. Delay
+    the scanner-only import until category aggregation is actually needed;
+    the shared helper preserves the same all-or-nothing category behaviour as
+    the full export.
+
+    :param output_data:
+        Sample JSON mapping to enrich in place.
+    :param vaults:
+        Ethereum-only JSON-safe vault records.
+    :return:
+        ``True`` when categories were attached, otherwise ``False``.
+    """
+    try:
+        from eth_defi.vault.top_vaults_json import append_strategy_categories_to_export
+    except ImportError:
+        logger.exception("Sample strategy category export unavailable; publishing sample JSON without categories")
+        output_data.pop("categories", None)
+        return False
+    return append_strategy_categories_to_export(output_data, vaults)
+
+
 def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
     """Filter the cleaned vault prices parquet to Ethereum only.
 
@@ -121,6 +145,9 @@ def generate_sample_json(json_path: Path, output_path: Path) -> int:
     }
     if "xerberus_stats" in data:
         sample_data["xerberus_stats"] = data["xerberus_stats"]
+    # Category aggregates must match the Ethereum-only vault rows. The helper
+    # is best effort, matching the full vault export's failure behaviour.
+    append_sample_strategy_categories(sample_data, filtered_vaults)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:

--- a/eth_defi/vault/strategy_tag.py
+++ b/eth_defi/vault/strategy_tag.py
@@ -9,6 +9,7 @@ helper normalises adapter-supplied addresses before consulting these tables.
 
 import enum
 from collections.abc import Collection, Mapping
+from typing import TypedDict
 
 
 class StrategyTag(str, enum.Enum):
@@ -152,6 +153,152 @@ class StrategyTag(str, enum.Enum):
     #: Seeks return from the carry of an asset or position.
     #: Example vault: Staked USDe (Ethena).
     carry_trade = "carry_trade"
+
+
+class StrategyTagMetadata(TypedDict):
+    """Human-readable presentation metadata for one strategy category."""
+
+    #: Human-readable category label without Markdown links.
+    label: str
+
+    #: Exactly two sentences explaining the evidence-based tagging rule.
+    description: str
+
+
+#: Public presentation labels and category rules for every strategy tag.
+#:
+#: Descriptions deliberately contain exactly two sentences so API consumers can
+#: display them consistently without having to truncate prose.
+STRATEGY_TAG_METADATA: dict[StrategyTag, StrategyTagMetadata] = {
+    StrategyTag.unknown: {
+        "label": "Unknown strategy",
+        "description": "We use this tag only when research has explicitly established that the vault's strategy is unknown. It does not mean that an unresearched vault has been classified.",
+    },
+    StrategyTag.directional_trading: {
+        "label": "Directional trading",
+        "description": "The vault takes [directional exposure](https://tradingstrategy.ai/glossary/directional-strategy) to one or more markets and can benefit or lose from their direction. We apply this tag when the documented strategy intentionally expresses such a market view.",
+    },
+    StrategyTag.directional_leverage: {
+        "label": "Directional leverage",
+        "description": "The vault maintains a fixed leveraged long or short position in an underlying asset. We apply this tag when documented leverage creates direct directional exposure rather than reflecting a trading signal or execution method.",
+    },
+    StrategyTag.trend_following: {
+        "label": "Trend following",
+        "description": "The vault takes positions designed to follow sustained [market trends](https://tradingstrategy.ai/glossary/trend-following). We apply this tag when trend-following is documented as part of the investment process.",
+    },
+    StrategyTag.discretionary_trading: {
+        "label": "Discretionary trading",
+        "description": "The vault uses a manager's [judgement](https://tradingstrategy.ai/glossary/discretionary-investment-management) to select or manage positions. We apply this tag when the strategy documentation identifies discretionary decision-making.",
+    },
+    StrategyTag.algorithmic_trading: {
+        "label": "Algorithmic trading",
+        "description": "The vault uses [programmed rules](https://tradingstrategy.ai/glossary/algorithmic-trading) to select, execute, or manage positions. We apply this tag when automation is a documented part of the strategy rather than an implementation detail alone.",
+    },
+    StrategyTag.arbitrage: {
+        "label": "Arbitrage",
+        "description": "The vault seeks to capture price differences between markets or related instruments. We apply this tag when the manager or protocol documents arbitrage as a return source.",
+    },
+    StrategyTag.delta_neutral: {
+        "label": "Delta neutral",
+        "description": "The vault seeks to offset [directional market exposure](https://tradingstrategy.ai/glossary/delta-neutral) while earning non-directional returns. We apply this tag when the strategy documents a delta-neutral or market-neutral construction.",
+    },
+    StrategyTag.statistical_arbitrage: {
+        "label": "Statistical arbitrage",
+        "description": "The vault trades quantitatively identified [pricing patterns](https://tradingstrategy.ai/glossary/statistical-arbitrage) or statistical relationships. We apply this tag when statistical arbitrage is documented rather than inferred from quantitative branding.",
+    },
+    StrategyTag.mean_reversion: {
+        "label": "Mean reversion",
+        "description": "The vault trades [price moves](https://tradingstrategy.ai/glossary/mean-reversion) expected to return towards an average or equilibrium. We apply this tag when mean reversion is explicitly described by the strategy.",
+    },
+    StrategyTag.grid_trading: {
+        "label": "Grid trading",
+        "description": "The vault places orders at predefined price intervals to trade a market range. We apply this tag when the manager documents a grid-based execution strategy.",
+    },
+    StrategyTag.pair_trading: {
+        "label": "Pair trading",
+        "description": "The vault trades the relative price of two related assets rather than a single asset's direction. We apply this tag when the strategy documents paired long and short exposure.",
+    },
+    StrategyTag.funding_rate_arbitrage: {
+        "label": "Funding-rate arbitrage",
+        "description": "The vault seeks to capture [funding-rate differences](https://tradingstrategy.ai/glossary/funding-rate), commonly across perpetual futures markets. We apply this tag when funding payments are a documented return source.",
+    },
+    StrategyTag.lending: {
+        "label": "Lending",
+        "description": "The vault supplies assets to a [lending market](https://tradingstrategy.ai/glossary/lending-protocol) to earn interest. We apply this tag to documented lending strategies, including protocol-wide defaults where every supported vault is a lender.",
+    },
+    StrategyTag.lending_optimisation: {
+        "label": "Lending optimisation",
+        "description": "The vault allocates supplied assets between lending opportunities to improve yield. We apply this tag when active lending allocation or optimisation is documented.",
+    },
+    StrategyTag.lending_looping: {
+        "label": "Lending looping",
+        "description": "The vault borrows against supplied collateral to [recursively increase lending exposure](https://tradingstrategy.ai/glossary/recursive-looping). We apply this tag when the documented strategy uses a lending loop rather than simple lending.",
+    },
+    StrategyTag.market_making: {
+        "label": "Market making",
+        "description": "The vault provides [executable liquidity](https://tradingstrategy.ai/glossary/market-making) to buyers and sellers. We apply this tag when the vault's documented strategy is to make markets rather than merely invest in a liquidity pool.",
+    },
+    StrategyTag.liquidity_provider: {
+        "label": "Liquidity provider",
+        "description": "The vault supplies capital to a venue or protocol as a [liquidity provider](https://tradingstrategy.ai/glossary/liquidity-provider). We apply this tag when the documented role is liquidity provision, including passive provision without active quoting.",
+    },
+    StrategyTag.market_maker: {
+        "label": "Market maker",
+        "description": "The vault operates a strategy that quotes or supplies both sides of a market. We apply this tag when the documented activity is active market making.",
+    },
+    StrategyTag.market_making_amm: {
+        "label": "AMM market making",
+        "description": "The vault actively makes markets by supplying liquidity through an automated market maker. We apply this tag when the strategy itself performs market making on an AMM.",
+    },
+    StrategyTag.market_making_clob: {
+        "label": "CLOB market making",
+        "description": "The vault provides liquidity through a central limit order book. We apply this tag when the strategy documents order-book market making.",
+    },
+    StrategyTag.multistrategy: {
+        "label": "Multi-strategy",
+        "description": "The vault combines multiple distinct investment strategies. We apply this tag only when the manager documents more than one strategy as part of the mandate.",
+    },
+    StrategyTag.index: {
+        "label": "Index",
+        "description": "The vault tracks a predefined market or asset index in an index-fund style. We apply this tag when the documented objective is index exposure or replication.",
+    },
+    StrategyTag.perpetual_futures: {
+        "label": "Perpetual futures",
+        "description": "The vault trades [perpetual futures contracts](https://tradingstrategy.ai/glossary/perpetual-future). We apply this tag to documented perpetual-futures strategies and native perpetual-DEX defaults unless an explicit exception is maintained.",
+    },
+    StrategyTag.amm: {
+        "label": "Automated market maker",
+        "description": "The vault uses an [automated market maker](https://tradingstrategy.ai/glossary/amm) as its liquidity venue. We apply this tag for AMM venue exposure even when the vault is not itself an active market-making strategy.",
+    },
+    StrategyTag.rwa: {
+        "label": "Real-world assets",
+        "description": "The vault invests in [real-world assets](https://tradingstrategy.ai/glossary/rwa) or their tokenised representations. We apply this tag when the underlying exposure is documented as real-world assets.",
+    },
+    StrategyTag.rwa_credit: {
+        "label": "RWA credit",
+        "description": "The vault provides credit backed by real-world assets. We apply this tag when the strategy documents real-world asset collateral or credit exposure.",
+    },
+    StrategyTag.rwa_lending: {
+        "label": "RWA lending",
+        "description": "The vault lends against real-world assets. We apply this tag when the documented lending strategy has real-world asset exposure.",
+    },
+    StrategyTag.rwa_royalties: {
+        "label": "RWA royalties",
+        "description": "The vault invests in real-world royalty streams. We apply this tag when the documented assets are contractual royalty payments.",
+    },
+    StrategyTag.money_market_fund: {
+        "label": "Money-market fund",
+        "description": "The vault invests in money-market instruments. We apply this tag when the documented mandate is a money-market fund or equivalent cash-management product.",
+    },
+    StrategyTag.venture_funding: {
+        "label": "Venture funding",
+        "description": "The vault invests in early-stage companies or projects in a venture-capital style. We apply this tag when the documented mandate is venture funding rather than public-market exposure.",
+    },
+    StrategyTag.carry_trade: {
+        "label": "Carry trade",
+        "description": "The vault seeks return from the [carry](https://tradingstrategy.ai/glossary/carry-trade) of an asset or position. We apply this tag when carry is a documented return source, including cash-and-carry structures.",
+    },
+}
 
 
 def lookup_strategy_tags(

--- a/eth_defi/vault/top_vaults_json.py
+++ b/eth_defi/vault/top_vaults_json.py
@@ -32,6 +32,7 @@ To test out Pandas warning issues in calculate_lifetime_metrics(), enable strict
 
 import datetime
 import json
+import logging
 import math
 import os
 from dataclasses import dataclass
@@ -46,6 +47,8 @@ from eth_defi.core3.database import Core3Database
 from eth_defi.core3.vault_protocol import build_core3_protocols_for_export
 from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE, VaultPostDatabase
 from eth_defi.research.vault_metrics import (
+    MAX_VALID_NAV,
+    StrategyCategoryExportRecord,
     VaultMetricsExport,
     calculate_hourly_returns_for_all_vaults,
     calculate_lifetime_metrics,
@@ -59,6 +62,7 @@ from eth_defi.token import is_stablecoin_like
 from eth_defi.vault.base import VaultSpec  # noqa: F401
 from eth_defi.vault.curator_export import build_curators_for_export
 from eth_defi.vault.risk import VaultTechnicalRisk
+from eth_defi.vault.strategy_tag import STRATEGY_TAG_METADATA, StrategyTag
 from eth_defi.vault.vaultdb import VaultDatabase, get_pipeline_data_dir
 from eth_defi.version_info import VersionInfo
 from eth_defi.xerberus.constants import resolve_xerberus_database_path
@@ -69,12 +73,17 @@ from eth_defi.xerberus.vault_export import (
     compute_xerberus_export_stats,
 )
 
+logger = logging.getLogger(__name__)
+
 # --------------------------------------------------------------------
 # Configuration via environment variables (scalar tunables)
 # --------------------------------------------------------------------
 MONTHS = int(os.getenv("MONTHS", "3"))  # Time window in months
 EVENT_THRESHOLD = int(os.getenv("EVENT_THRESHOLD", "5"))  # Min event count
-MAX_ANNUALISED_RETURN = float(os.getenv("MAX_ANNUALISED_RETURN", "4.0"))  # Cap annualized return at 400%
+#: Reject one-month return outliers above this absolute annualised value from
+#: category-return weighting. This is deliberately not configurable: category
+#: aggregates must not change because a sibling reporting script sets an env var.
+MAX_CATEGORY_ANNUALISED_RETURN = 4.0
 THRESHOLD_TVL = float(os.getenv("MIN_TVL", "5000"))  # Minimum TVL filter
 TOP_PER_CHAIN = int(os.getenv("TOP_PER_CHAIN", "99999"))  # Top N vaults per chain
 
@@ -925,6 +934,134 @@ def validate_strict_json_serialisable(obj: dict) -> None:
     json.dumps(obj, ensure_ascii=False, allow_nan=False)
 
 
+def build_strategy_categories_for_export(vaults: list[dict]) -> dict[str, StrategyCategoryExportRecord]:
+    """Build public strategy-category labels and aggregates for exported vaults.
+
+    Every :class:`~eth_defi.vault.strategy_tag.StrategyTag` is included, even
+    if no current exported vault uses it, so consumers have a stable category
+    catalogue. A vault contributes its full current USD TVL to each of its
+    additive tags. Category aggregates exclude blacklisted vaults and broken
+    TVL values; the annualised one-month return is weighted only by eligible
+    vaults with a complete, bounded one-month observation. Net annualised
+    return is used when known, with gross return as the documented fallback.
+
+    :param vaults:
+        JSON-safe exported vault records, each optionally carrying strategy
+        tags and one-month metrics.
+    :return:
+        Category records keyed by stable strategy-tag values.
+    """
+    categories: dict[str, StrategyCategoryExportRecord] = {
+        tag.value: {
+            "label": metadata["label"],
+            "description": metadata["description"],
+            "vault_count": 0,
+            "tvl_usd": 0.0,
+            "one_month_apy": None,
+        }
+        for tag, metadata in STRATEGY_TAG_METADATA.items()
+    }
+    apy_weighted_totals = {tag.value: 0.0 for tag in StrategyTag}
+    apy_weights = {tag.value: 0.0 for tag in StrategyTag}
+
+    for vault in vaults:
+        if is_blacklisted_record(vault):
+            continue
+
+        raw_tags = vault.get("strategy_tags")
+        if not isinstance(raw_tags, list):
+            continue
+
+        tags = set()
+        for raw_tag in raw_tags:
+            try:
+                tags.add(StrategyTag(raw_tag))
+            except (TypeError, ValueError):
+                # A historical sticky row can contain an obsolete tag. It has
+                # no description in this version of the public catalogue.
+                continue
+
+        current_nav = vault.get("current_nav")
+        valid_current_nav = isinstance(current_nav, (int, float)) and not isinstance(current_nav, bool)
+        current_nav_float = float(current_nav) if valid_current_nav else None
+        if current_nav_float is not None and (not math.isfinite(current_nav_float) or current_nav_float < 0):
+            current_nav_float = None
+        if current_nav_float is None or current_nav_float > MAX_VALID_NAV:
+            continue
+
+        one_month_cagr_net = vault.get("one_month_cagr_net")
+        one_month_cagr = one_month_cagr_net if one_month_cagr_net is not None else vault.get("one_month_cagr")
+        valid_one_month_cagr = isinstance(one_month_cagr, (int, float)) and not isinstance(one_month_cagr, bool)
+        one_month_apy = float(one_month_cagr) if valid_one_month_cagr else None
+        has_complete_one_month_metric = _has_complete_bounded_one_month_metric(vault, one_month_apy)
+
+        for tag in tags:
+            category = categories.get(tag.value)
+            if category is None:
+                # Keep historic sticky rows exportable if a newer enum value
+                # reaches this code before its maintained public description.
+                # The catalogue-coverage test still requires the description
+                # to be added before this version can be released.
+                continue
+            category["vault_count"] += 1
+            category["tvl_usd"] += current_nav_float
+            if has_complete_one_month_metric:
+                apy_weighted_totals[tag.value] += current_nav_float * one_month_apy
+                apy_weights[tag.value] += current_nav_float
+
+    for tag_value, category in categories.items():
+        if apy_weights[tag_value] > 0:
+            category["one_month_apy"] = apy_weighted_totals[tag_value] / apy_weights[tag_value]
+
+    return categories
+
+
+def _has_complete_bounded_one_month_metric(vault: dict, annualised_return: float | None) -> bool:
+    """Check whether a vault has a usable one-month return for category weighting.
+
+    The public row uses zero as a backwards-compatible sentinel when a
+    one-month calculation was unavailable. Require the accompanying period
+    diagnostics so that sentinel does not become a genuine zero-return sample.
+
+    :param vault:
+        JSON-safe exported vault record.
+    :param annualised_return:
+        Net-or-gross annualised one-month return selected for the record.
+    :return:
+        ``True`` for a complete finite return within the export bound.
+    """
+    one_month_samples = vault.get("one_month_samples")
+    has_samples = isinstance(one_month_samples, (int, float)) and not isinstance(one_month_samples, bool) and one_month_samples > 0
+    return annualised_return is not None and math.isfinite(annualised_return) and abs(annualised_return) <= MAX_CATEGORY_ANNUALISED_RETURN and vault.get("one_month_start") is not None and has_samples
+
+
+def append_strategy_categories_to_export(output_data: dict, vaults: list[dict]) -> bool:
+    """Attach best-effort strategy categories without blocking the vault export.
+
+    The all-chains scanner publishes its top-vaults JSON through this module.
+    Category aggregation is useful supplementary data, but must never prevent
+    the established vault, curator, and risk exports from being written and
+    uploaded when a malformed historical row or a future category change is
+    encountered.
+
+    :param output_data:
+        JSON export mapping to enrich in place.
+    :param vaults:
+        JSON-safe exported vault records used to calculate category aggregates.
+    :return:
+        ``True`` when the ``categories`` key was attached, otherwise ``False``.
+    """
+    output_data.pop("categories", None)
+    try:
+        output_data["categories"] = build_strategy_categories_for_export(vaults)
+    except Exception:
+        # This is intentionally a fail-open boundary: category data is
+        # supplementary and must never stop established vault exports.
+        logger.exception("Strategy category export failed; publishing vault JSON without categories")
+        return False
+    return True
+
+
 def main(
     data_dir: Path | None = None,
     vault_db_path: Path | None = None,
@@ -1156,6 +1293,11 @@ def main(
         "curators": curators_export,
         "vaults": vaults,
     }
+    categories_attached = append_strategy_categories_to_export(output_data, vaults)
+    if categories_attached:
+        print(f"Built strategy category export for {len(output_data['categories']):,} tags")
+    else:
+        print("Skipped strategy category export; publishing vault JSON without categories")
     # Optional coverage stats: not on VaultMetricsExport TypedDict (extra key for consumers).
     output_data["xerberus_stats"] = xerberus_stats  # type: ignore[typeddict-unknown-key]
     print(f"Xerberus coverage: {xerberus_stats['pool_matches']} pool / {xerberus_stats['protocol_fallbacks']} protocol / {xerberus_stats['unmatched']} unmatched ({xerberus_stats['coverage_pct']}% of {xerberus_stats['total_vaults']})")

--- a/eth_defi/vault/top_vaults_json.py
+++ b/eth_defi/vault/top_vaults_json.py
@@ -84,6 +84,11 @@ EVENT_THRESHOLD = int(os.getenv("EVENT_THRESHOLD", "5"))  # Min event count
 #: category-return weighting. This is deliberately not configurable: category
 #: aggregates must not change because a sibling reporting script sets an env var.
 MAX_CATEGORY_ANNUALISED_RETURN = 4.0
+
+#: Minimum endpoint coverage accepted as a complete one-month category metric.
+#: The underlying period is a 30-day lookback; two days of endpoint tolerance
+#: accommodates sparse scans without treating young vault histories as 1M data.
+MIN_CATEGORY_ONE_MONTH_COVERAGE = datetime.timedelta(days=28)
 THRESHOLD_TVL = float(os.getenv("MIN_TVL", "5000"))  # Minimum TVL filter
 TOP_PER_CHAIN = int(os.getenv("TOP_PER_CHAIN", "99999"))  # Top N vaults per chain
 
@@ -940,10 +945,11 @@ def build_strategy_categories_for_export(vaults: list[dict]) -> dict[str, Strate
     Every :class:`~eth_defi.vault.strategy_tag.StrategyTag` is included, even
     if no current exported vault uses it, so consumers have a stable category
     catalogue. A vault contributes its full current USD TVL to each of its
-    additive tags. Category aggregates exclude blacklisted vaults and broken
-    TVL values; the annualised one-month return is weighted only by eligible
-    vaults with a complete, bounded one-month observation. Net annualised
-    return is used when known, with gross return as the documented fallback.
+    additive tags. Category aggregates exclude blacklisted and stale vaults as
+    well as broken TVL values; the annualised one-month return is weighted only
+    by eligible vaults with at least 28 days of bounded one-month observations.
+    Net annualised return is used when known, with gross return as the
+    documented fallback.
 
     :param vaults:
         JSON-safe exported vault records, each optionally carrying strategy
@@ -965,7 +971,8 @@ def build_strategy_categories_for_export(vaults: list[dict]) -> dict[str, Strate
     apy_weights = {tag.value: 0.0 for tag in StrategyTag}
 
     for vault in vaults:
-        if is_blacklisted_record(vault):
+        is_stale = vault.get("stale_export") is True or vault.get("stale_current_row") is True
+        if is_blacklisted_record(vault) or is_stale:
             continue
 
         raw_tags = vault.get("strategy_tags")
@@ -1022,6 +1029,8 @@ def _has_complete_bounded_one_month_metric(vault: dict, annualised_return: float
     The public row uses zero as a backwards-compatible sentinel when a
     one-month calculation was unavailable. Require the accompanying period
     diagnostics so that sentinel does not become a genuine zero-return sample.
+    A successful metric for a young vault may cover only three days, so require
+    month-scale endpoint coverage as well.
 
     :param vault:
         JSON-safe exported vault record.
@@ -1032,7 +1041,13 @@ def _has_complete_bounded_one_month_metric(vault: dict, annualised_return: float
     """
     one_month_samples = vault.get("one_month_samples")
     has_samples = isinstance(one_month_samples, (int, float)) and not isinstance(one_month_samples, bool) and one_month_samples > 0
-    return annualised_return is not None and math.isfinite(annualised_return) and abs(annualised_return) <= MAX_CATEGORY_ANNUALISED_RETURN and vault.get("one_month_start") is not None and has_samples
+    try:
+        one_month_start = normalise_datetime_to_naive_utc(vault.get("one_month_start"))
+        one_month_end = normalise_datetime_to_naive_utc(vault.get("one_month_end"))
+    except (TypeError, ValueError):
+        return False
+    has_full_coverage = one_month_start is not None and one_month_end is not None and one_month_end - one_month_start >= MIN_CATEGORY_ONE_MONTH_COVERAGE
+    return annualised_return is not None and math.isfinite(annualised_return) and abs(annualised_return) <= MAX_CATEGORY_ANNUALISED_RETURN and has_samples and has_full_coverage
 
 
 def append_strategy_categories_to_export(output_data: dict, vaults: list[dict]) -> bool:

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -2625,12 +2625,13 @@ by its stable identifier. Each record has a plain human-readable `label`, an
 exactly two-sentence `description` that may contain Markdown glossary links,
 `vault_count`, `tvl_usd`, and `one_month_apy`; the last field is a current-
 TVL-weighted annualised one-month return, not a quoted yield, and is `null`
-when no eligible tagged vault has a complete one-month observation. It uses a
-net return when fees are known and otherwise falls back to gross return.
-Blacklisted vaults and broken TVL values are excluded from every category
-aggregate, while annualised-return outliers are excluded from return weighting
-only. Because strategy tags are additive, a vault's current TVL contributes to
-every category it carries. Category aggregation is best effort:
+when no eligible tagged vault has at least 28 days of one-month observations.
+It uses a net return when fees are known and otherwise falls back to gross
+return. Blacklisted vaults, stale fallback/current rows, and broken TVL values
+are excluded from every category aggregate, while annualised-return outliers
+are excluded from return weighting only. Because strategy tags are additive,
+a vault's current TVL contributes to every category it carries. Category
+aggregation is best effort:
 if it fails, the vault JSON is still published without `categories` and the
 scanner logs the error. The Ethereum-only `vault-metadata.sample.json`
 recalculates categories from its Ethereum vaults, so its figures do not

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -2566,9 +2566,11 @@ poetry run python scripts/erc-4626/identify-curators.py
 
 ### vault-analysis-json.py
 
-Multi-chain vault analysis with JSON export and lifetime metric analysis.
-The implementation lives in `eth_defi.vault.top_vaults_json`; the script is a
-compatibility wrapper for manual operator runs.
+Multi-chain vault analysis with JSON export and lifetime metric analysis. The
+implementation lives in `eth_defi.vault.top_vaults_json`; the script is a
+compatibility wrapper for manual operator runs. The all-chains scanner writes
+and uploads `top_vaults_by_chain.json`, while a direct manual run defaults to
+`stablecoin-vault-metrics.json` unless `OUTPUT_JSON` is set.
 
 Generates `top_vaults_by_chain.json` with the following top-level structure:
 
@@ -2589,6 +2591,9 @@ Generates `top_vaults_by_chain.json` with the following top-level structure:
   "curators": {
     "gauntlet": { "slug": "gauntlet", "name": "Gauntlet", "twitter": "https://x.com/gauntlet_xyz", "recent_posts": [...], ... },
     "hyperliquid": { "slug": "hyperliquid", "name": "Hyperliquid", "protocol_curator": true, ... }
+  },
+  "categories": {
+    "lending": { "label": "Lending", "description": "...", "vault_count": 123, "tvl_usd": 456.0, "one_month_apy": 0.05 }
   },
   "vaults": [ ... ]
 }
@@ -2614,6 +2619,22 @@ curator slug. The `curators` dict is built from curator/protocol YAML files and
 the vault post feed database at export time, and only includes curators present
 in the exported vaults. Each curator record includes up to 10 recent posts from
 Twitter, LinkedIn, and RSS feeds.
+
+The top-level `categories` dict contains every maintained strategy tag, keyed
+by its stable identifier. Each record has a plain human-readable `label`, an
+exactly two-sentence `description` that may contain Markdown glossary links,
+`vault_count`, `tvl_usd`, and `one_month_apy`; the last field is a current-
+TVL-weighted annualised one-month return, not a quoted yield, and is `null`
+when no eligible tagged vault has a complete one-month observation. It uses a
+net return when fees are known and otherwise falls back to gross return.
+Blacklisted vaults and broken TVL values are excluded from every category
+aggregate, while annualised-return outliers are excluded from return weighting
+only. Because strategy tags are additive, a vault's current TVL contributes to
+every category it carries. Category aggregation is best effort:
+if it fails, the vault JSON is still published without `categories` and the
+scanner logs the error. The Ethereum-only `vault-metadata.sample.json`
+recalculates categories from its Ethereum vaults, so its figures do not
+describe the full multi-chain export.
 
 The export is append-biased. Once a vault passes the production `MIN_TVL` peak
 TVL filter, it is recorded in a sticky state file and remains in later exports
@@ -2685,6 +2706,22 @@ After generating, upload to R2 with rclone:
 ```shell
 rclone copy ~/.tradingstrategy/top_vaults_by_chain.json vaults-storage:top-defi-vaults/
 ```
+
+### list-vault-strategy-categories.py
+
+Print the exported strategy-category breakdown in descending USD TVL order.
+The script is local-only and deliberately requires a JSON export containing
+`categories`; it stops instead of incorrectly presenting an older untagged
+export as a zero-valued category table.
+
+```shell
+INPUT_JSON=~/.tradingstrategy/vaults/top_vaults_by_chain.json \
+  poetry run python scripts/erc-4626/list-vault-strategy-categories.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `INPUT_JSON` | Local vault JSON to tabulate. Default: `~/.tradingstrategy/vaults/top_vaults_by_chain.json`. |
 
 ### vault-analysis-gsheet.py
 

--- a/scripts/erc-4626/list-vault-strategy-categories.py
+++ b/scripts/erc-4626/list-vault-strategy-categories.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+"""Print a local vault strategy-category breakdown sorted by USD TVL.
+
+The script reads a locally exported vault JSON file and never uploads data. It
+requires the top-level ``categories`` mapping produced by the vault exporter,
+so it never presents an incomplete legacy export as a zero-valued breakdown.
+
+Usage:
+
+.. code-block:: shell
+
+    INPUT_JSON=/tmp/top-vaults-by-category.json poetry run python scripts/erc-4626/list-vault-strategy-categories.py
+
+Environment variables:
+
+- ``INPUT_JSON``: Local vault metrics JSON input. Defaults to
+  ``~/.tradingstrategy/vaults/top_vaults_by_chain.json``.
+"""
+
+import json
+import logging
+import math
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.research.vault_metrics import StrategyCategoryExportRecord
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.vaultdb import get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+def format_usd(value: float) -> str:
+    """Format one USD TVL value for the terminal table.
+
+    :param value:
+        Finite USD TVL value.
+    :return:
+        Whole-dollar formatted USD amount.
+    """
+    return f"${value:,.0f}"
+
+
+def format_percent(value: float | None) -> str:
+    """Format one annualised 1M APY value for the terminal table.
+
+    :param value:
+        Annualised decimal return, or ``None`` when unavailable.
+    :return:
+        Percentage text or a missing-value marker.
+    """
+    if value is None:
+        return "-"
+    return f"{value:.2%}"
+
+
+def resolve_input_path() -> Path:
+    """Resolve the local vault JSON input path from the environment.
+
+    :return:
+        Existing or expected local JSON path.
+    """
+    default_path = get_pipeline_data_dir() / "top_vaults_by_chain.json"
+    return Path(os.environ.get("INPUT_JSON", str(default_path))).expanduser()
+
+
+def create_table_rows(categories: Mapping[str, StrategyCategoryExportRecord]) -> list[dict[str, str | int]]:
+    """Create sorted terminal table rows from category aggregates.
+
+    :param categories:
+        Strategy-category records keyed by tag.
+    :return:
+        Rows ordered by descending USD TVL and then tag identifier.
+    """
+    sorted_categories = sorted(
+        categories.items(),
+        key=lambda item: (-float(item[1]["tvl_usd"]), item[0]),
+    )
+    return [
+        {
+            "Tag": tag,
+            "Label": category["label"],
+            "Vaults": category["vault_count"],
+            "TVL (USD)": format_usd(float(category["tvl_usd"])),
+            "1M annualised return": format_percent(category["one_month_apy"]),
+        }
+        for tag, category in sorted_categories
+    ]
+
+
+def main() -> None:
+    """Read the local JSON export and print its strategy-category breakdown."""
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "warning"))
+    input_path = resolve_input_path()
+    assert input_path.exists(), f"Vault JSON input not found: {input_path}"
+
+    logger.info("Reading local vault JSON from %s", input_path)
+    with input_path.open(encoding="utf-8") as input_file:
+        export_data = json.load(input_file)
+
+    categories = export_data.get("categories")
+    assert isinstance(categories, dict), "Vault JSON has no categories mapping: category aggregation either failed or this export predates category support"
+    assert all(math.isfinite(float(category["tvl_usd"])) for category in categories.values())
+    rows = create_table_rows(categories)
+    print(tabulate(rows, headers="keys", tablefmt="rounded_outline"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_list_vault_strategy_categories.py
+++ b/tests/erc_4626/test_list_vault_strategy_categories.py
@@ -1,0 +1,62 @@
+"""Tests for the local strategy-category breakdown script."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def load_category_script():
+    """Load the local category-breakdown script as an importable module.
+
+    :return:
+        Loaded script module.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "list-vault-strategy-categories.py"
+    spec = importlib.util.spec_from_file_location("list_vault_strategy_categories", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_category_breakdown_requires_exported_categories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not present an old export without tags as a zero-valued table."""
+    input_path = tmp_path / "vault-metrics.json"
+    input_path.write_text(json.dumps({"vaults": []}), encoding="utf-8")
+    monkeypatch.setenv("INPUT_JSON", str(input_path))
+
+    module = load_category_script()
+    monkeypatch.setattr(module, "setup_console_logging", lambda **_: None)
+
+    with pytest.raises(AssertionError, match="no categories mapping"):
+        module.main()
+
+
+def test_category_breakdown_rows_sort_by_tvl() -> None:
+    """Order category records in descending USD TVL without changing logging."""
+    module = load_category_script()
+    rows = module.create_table_rows(
+        {
+            "small": {
+                "label": "Small",
+                "description": "Rule one. Rule two.",
+                "vault_count": 1,
+                "tvl_usd": 100.0,
+                "one_month_apy": 0.10,
+            },
+            "large": {
+                "label": "Large",
+                "description": "Rule one. Rule two.",
+                "vault_count": 2,
+                "tvl_usd": 200.0,
+                "one_month_apy": None,
+            },
+        }
+    )
+
+    assert [row["Tag"] for row in rows] == ["large", "small"]
+    assert rows[1]["1M annualised return"] == "10.00%"

--- a/tests/erc_4626/test_list_vault_strategy_categories.py
+++ b/tests/erc_4626/test_list_vault_strategy_categories.py
@@ -2,12 +2,13 @@
 
 import importlib.util
 import json
+import types
 from pathlib import Path
 
 import pytest
 
 
-def load_category_script():
+def load_category_script() -> types.ModuleType:
     """Load the local category-breakdown script as an importable module.
 
     :return:

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 from decimal import Decimal
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import pandas as pd
 import pytest
 
 from eth_defi.vault import top_vaults_json
+from eth_defi.vault.strategy_tag import STRATEGY_TAG_METADATA, StrategyTag
 from eth_defi.version_info import VersionInfo
 
 
@@ -57,6 +59,168 @@ def make_lifetime_df(*rows: dict) -> pd.DataFrame:
 def make_export_record(module, **kwargs) -> dict:
     """Build a JSON-safe exported row for state seeding."""
     return module.export_lifetime_row(pd.Series(make_metrics_row(**kwargs)))
+
+
+def test_strategy_category_export_includes_labels_and_tvl_weighted_one_month_apy() -> None:
+    """Export every category with two-sentence rules and additive aggregates.
+
+    A vault with more than one maintained tag contributes to each category,
+    while an unrecognised historical tag is not exposed without catalogue
+    metadata. The one-month APY uses only finite current-TVL weights and finite
+    complete annualised one-month returns.
+    """
+    small_vault_tvl = 100.0
+    large_vault_tvl = 200.0
+    categories = top_vaults_json.build_strategy_categories_for_export(
+        [
+            {
+                "strategy_tags": ["lending", "algorithmic_trading", "lending"],
+                "current_nav": small_vault_tvl,
+                "one_month_cagr": 0.20,
+                "one_month_cagr_net": 0.10,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["lending", "not_a_category"],
+                "current_nav": large_vault_tvl,
+                "one_month_cagr": 0.20,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["unknown"],
+                "current_nav": None,
+                "one_month_cagr": 0.50,
+            },
+        ]
+    )
+
+    assert set(categories) == {tag.value for tag in StrategyTag}
+    assert categories["lending"] == {
+        "label": "Lending",
+        "description": STRATEGY_TAG_METADATA[StrategyTag.lending]["description"],
+        "vault_count": 2,
+        "tvl_usd": 300.0,
+        "one_month_apy": pytest.approx(1 / 6),
+    }
+    assert categories["algorithmic_trading"]["vault_count"] == 1
+    assert categories["algorithmic_trading"]["tvl_usd"] == small_vault_tvl
+    assert categories["unknown"]["vault_count"] == 0
+    assert categories["unknown"]["tvl_usd"] == 0.0
+    assert categories["unknown"]["one_month_apy"] is None
+
+
+def test_strategy_category_export_excludes_blacklisted_and_invalid_tvl() -> None:
+    """Do not let rejected records distort public category aggregates."""
+    valid_tvl = 100.0
+    valid_return = 0.10
+    categories = top_vaults_json.build_strategy_categories_for_export(
+        [
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": valid_tvl,
+                "one_month_cagr": valid_return,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 1_000_000_000_000.0,
+                "one_month_cagr": 100.0,
+                "risk": top_vaults_json.BLACKLISTED_RISK_LABEL,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 100_000_000_001.0,
+                "one_month_cagr": 100.0,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+        ]
+    )
+
+    assert categories["lending"]["vault_count"] == 1
+    assert categories["lending"]["tvl_usd"] == valid_tvl
+    assert categories["lending"]["one_month_apy"] == valid_return
+
+
+def test_strategy_category_export_requires_complete_bounded_one_month_metric() -> None:
+    """Ignore sentinels and outliers when weighting one-month returns."""
+    valid_return = 0.10
+    expected_tvl = 2_100.0
+    expected_vault_count = 3
+    categories = top_vaults_json.build_strategy_categories_for_export(
+        [
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 100.0,
+                "one_month_cagr_net": valid_return,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 1_000.0,
+                "one_month_cagr": 0.0,
+            },
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 1_000.0,
+                "one_month_cagr": 5.0,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
+        ]
+    )
+
+    assert categories["lending"]["vault_count"] == expected_vault_count
+    assert categories["lending"]["tvl_usd"] == expected_tvl
+    assert categories["lending"]["one_month_apy"] == valid_return
+
+
+def test_strategy_tag_metadata_covers_every_tag_with_two_sentences() -> None:
+    """Keep the public category catalogue complete and concise."""
+    assert set(STRATEGY_TAG_METADATA) == set(StrategyTag)
+    assert all(metadata["label"] and "[" not in metadata["label"] for metadata in STRATEGY_TAG_METADATA.values())
+    descriptions_without_markdown_links = (re.sub(r"\]\([^)]*\)", "]", metadata["description"]) for metadata in STRATEGY_TAG_METADATA.values())
+    assert all(description.count(".") == 2 for description in descriptions_without_markdown_links)
+
+
+def test_strategy_category_export_skips_a_tag_without_current_catalogue_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a local export readable during an enum-and-catalogue rollout.
+
+    The catalogue coverage test above still prevents releasing an incomplete
+    registry. This fallback only protects existing sticky rows while a newer
+    persisted enum value is being reconciled with its public description.
+    """
+    monkeypatch.delitem(STRATEGY_TAG_METADATA, StrategyTag.lending)
+
+    categories = top_vaults_json.build_strategy_categories_for_export([{"strategy_tags": [StrategyTag.lending.value], "current_nav": 100.0, "one_month_cagr": 0.10}])
+
+    assert StrategyTag.lending.value not in categories
+
+
+def test_strategy_category_failure_does_not_block_vault_export(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A category failure logs an error without adding a partial JSON key."""
+
+    def fail_category_build(_: list[dict]) -> dict:
+        raise RuntimeError("broken category input")
+
+    monkeypatch.setattr(top_vaults_json, "build_strategy_categories_for_export", fail_category_build)
+    output_data = {"vaults": []}
+
+    with caplog.at_level("ERROR"):
+        success = top_vaults_json.append_strategy_categories_to_export(output_data, [])
+
+    assert success is False
+    assert "categories" not in output_data
+    assert "Strategy category export failed" in caplog.text
 
 
 def test_sticky_export_first_qualification_creates_state():

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -79,6 +79,7 @@ def test_strategy_category_export_includes_labels_and_tvl_weighted_one_month_apy
                 "one_month_cagr": 0.20,
                 "one_month_cagr_net": 0.10,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {
@@ -86,6 +87,7 @@ def test_strategy_category_export_includes_labels_and_tvl_weighted_one_month_apy
                 "current_nav": large_vault_tvl,
                 "one_month_cagr": 0.20,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {
@@ -122,6 +124,7 @@ def test_strategy_category_export_excludes_blacklisted_and_invalid_tvl() -> None
                 "current_nav": valid_tvl,
                 "one_month_cagr": valid_return,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {
@@ -130,6 +133,7 @@ def test_strategy_category_export_excludes_blacklisted_and_invalid_tvl() -> None
                 "one_month_cagr": 100.0,
                 "risk": top_vaults_json.BLACKLISTED_RISK_LABEL,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {
@@ -137,6 +141,7 @@ def test_strategy_category_export_excludes_blacklisted_and_invalid_tvl() -> None
                 "current_nav": 100_000_000_001.0,
                 "one_month_cagr": 100.0,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
         ]
@@ -148,10 +153,10 @@ def test_strategy_category_export_excludes_blacklisted_and_invalid_tvl() -> None
 
 
 def test_strategy_category_export_requires_complete_bounded_one_month_metric() -> None:
-    """Ignore sentinels and outliers when weighting one-month returns."""
+    """Ignore sentinels, partial periods, and outliers in 1M weighting."""
     valid_return = 0.10
-    expected_tvl = 2_100.0
-    expected_vault_count = 3
+    expected_tvl = 3_100.0
+    expected_vault_count = 4
     categories = top_vaults_json.build_strategy_categories_for_export(
         [
             {
@@ -159,6 +164,7 @@ def test_strategy_category_export_requires_complete_bounded_one_month_metric() -
                 "current_nav": 100.0,
                 "one_month_cagr_net": valid_return,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {
@@ -171,7 +177,16 @@ def test_strategy_category_export_requires_complete_bounded_one_month_metric() -
                 "current_nav": 1_000.0,
                 "one_month_cagr": 5.0,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
+            },
+            {
+                "strategy_tags": ["lending"],
+                "current_nav": 1_000.0,
+                "one_month_cagr": 0.20,
+                "one_month_start": "2026-08-29T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
+                "one_month_samples": 4,
             },
         ]
     )
@@ -179,6 +194,45 @@ def test_strategy_category_export_requires_complete_bounded_one_month_metric() -
     assert categories["lending"]["vault_count"] == expected_vault_count
     assert categories["lending"]["tvl_usd"] == expected_tvl
     assert categories["lending"]["one_month_apy"] == valid_return
+
+
+def test_strategy_category_export_excludes_stale_records() -> None:
+    """Do not describe replayed or old metrics as current aggregates."""
+    current_tvl = 100.0
+    records = [
+        {
+            "strategy_tags": ["lending"],
+            "current_nav": current_tvl,
+            "one_month_cagr": 0.10,
+            "one_month_start": "2026-08-01T00:00:00Z",
+            "one_month_end": "2026-09-01T00:00:00Z",
+            "one_month_samples": 31,
+        },
+        {
+            "strategy_tags": ["lending"],
+            "current_nav": 1_000_000.0,
+            "one_month_cagr": 1.0,
+            "one_month_start": "2026-08-01T00:00:00Z",
+            "one_month_end": "2026-09-01T00:00:00Z",
+            "one_month_samples": 31,
+            "stale_export": True,
+        },
+        {
+            "strategy_tags": ["lending"],
+            "current_nav": 1_000_000.0,
+            "one_month_cagr": 1.0,
+            "one_month_start": "2026-08-01T00:00:00Z",
+            "one_month_end": "2026-09-01T00:00:00Z",
+            "one_month_samples": 31,
+            "stale_current_row": True,
+        },
+    ]
+
+    categories = top_vaults_json.build_strategy_categories_for_export(records)
+
+    assert categories["lending"]["vault_count"] == 1
+    assert categories["lending"]["tvl_usd"] == current_tvl
+    assert categories["lending"]["one_month_apy"] == 0.10
 
 
 def test_strategy_tag_metadata_covers_every_tag_with_two_sentences() -> None:

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -72,6 +72,7 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
                 "current_nav": 100.0,
                 "one_month_cagr": 0.10,
                 "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_end": "2026-09-01T00:00:00Z",
                 "one_month_samples": 31,
             },
             {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault B"},

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -63,7 +63,17 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
             },
         },
         "vaults": [
-            {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault A"},
+            {
+                "chain_id": 1,
+                "protocol_slug": "morpho",
+                "curator_slug": "gauntlet",
+                "name": "Morpho Vault A",
+                "strategy_tags": ["lending"],
+                "current_nav": 100.0,
+                "one_month_cagr": 0.10,
+                "one_month_start": "2026-08-01T00:00:00Z",
+                "one_month_samples": 31,
+            },
             {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault B"},
             {"chain_id": 1, "protocol_slug": "fluid", "curator_slug": "re7-labs", "name": "Fluid Vault"},
             {"chain_id": 42161, "protocol_slug": "gains-network", "curator_slug": "gains-network", "name": "Gains Vault on Arbitrum"},
@@ -117,6 +127,14 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
             "commit_hash": "4cea3aa3deadbeef",
         },
     }
+
+    # Categories are recomputed from Ethereum records, rather than copied
+    # from the all-chain source export.
+    expected_lending_tvl = 100.0
+    expected_lending_return = 0.10
+    assert result["categories"]["lending"]["vault_count"] == 1
+    assert result["categories"]["lending"]["tvl_usd"] == expected_lending_tvl
+    assert result["categories"]["lending"]["one_month_apy"] == expected_lending_return
 
 
 def test_sample_parquet_has_version_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Expose stable, human-readable strategy categories in the public vault export and make their TVL breakdown available locally.

## Lessons learnt

Sticky exports can retain blacklisted or malformed historical rows, so category aggregates must apply explicit data-quality eligibility rather than summing every exported record.

## Summary

- Add a complete two-sentence strategy-tag catalogue and best-effort category JSON export.
- Include quality-filtered category counts, USD TVL, and TVL-weighted one-month annualised returns.
- Recompute categories for the Ethereum sample, document the semantics, and add a local tabulate helper.
- Cover enum evolution, export isolation, data-quality filters, sample consistency, and helper ordering.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.