### PR TITLE
notes: mark DAI to USDS Depositor as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -822,6 +822,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x0e297de4005883c757c9f09fdf7cf1363c20e626": (VaultFlag.subvault, SUBVAULT),
     # USDC To sUSDS Depositor (Yearn on Ethereum)
     "0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d": (VaultFlag.subvault, SUBVAULT),
+    # DAI to USDS Depositor
+    "0xaedf7d5f3112552e110e5f9d08c9997adce0b78d": (VaultFlag.subvault, SUBVAULT),
     # Morpho Gauntlet USDT Prime Compounder
     "0x6d2981ff9b8d7edbb7604de7a65bac8694ac849f": (VaultFlag.subvault, SUBVAULT),
     # Morpho Gauntlet AUSD Vault Compounder

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -263,6 +263,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0xd80c3e98c9093b41645c07c2b6d956136f89559b", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
+        ("0xaedf7d5f3112552e110e5f9d08c9997adce0b78d", "<protocol not yet identified>", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
         ("0x6abbda8243f4bf130a97beae759a6e91522520b9", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x049e8aab2d3ca187e47d74cf8171ad266f18643e", "Yearn", VaultFlag.subvault, "not intended"),


### PR DESCRIPTION
## Why

DAI to USDS Depositor is a subvault and should not appear as an investable main listing vault.

## Lessons learnt

Address-specific subvault classifications belong in the central manual vault flag table and are blacklisted downstream.

## Summary

- Marked DAI to USDS Depositor (`0xaedf7d5f3112552e110e5f9d08c9997adce0b78d`) as a subvault.
- Added coverage for its blacklist classification and standard note.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.