### PR TITLE
feat: classify Enzyme vaults as discretionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Classify every Enzyme Blue and Onyx vault as discretionary trading by default and migrate cached tags (2026-09-08)
 - feat: Export documented vault strategy categories with quality-filtered TVL and one-month return aggregates, plus a local category-breakdown helper (2026-09-04)
 - feat: Add canonical signed per-period vault flow values, expose gross directional values and counts only from individually extracted events, estimate netted stablecoin ERC-4626 flows from daily vault states, and deprecate the legacy top-level netflow export (2026-08-31)
 - fix: Publish YieldBasis protocol metadata, description and listing logos under the canonical website slug (2026-08-31)

--- a/eth_defi/enzyme/blue_vault.py
+++ b/eth_defi/enzyme/blue_vault.py
@@ -171,16 +171,15 @@ class EnzymeBlueVault(VaultBase):
 
         return self.api_metadata.short_description if self.api_metadata else None
 
-    def get_strategy_tags(self) -> set[StrategyTag] | None:
-        """Return documented strategy tags for this Blue vault.
+    def get_strategy_tags(self) -> set[StrategyTag]:
+        """Return default and documented strategy tags for this Blue vault.
 
         The shared Enzyme mapping keys classifications by canonical share-token
-        address. Unmapped addresses intentionally return ``None`` because the
-        protocol's generic metadata does not establish an investment strategy.
+        address. Every Enzyme vault receives the default discretionary-trading
+        tag, while researched addresses receive additional strategy tags.
 
         :return:
-            A mutable tag set for a researched vault, or ``None`` when its
-            strategy remains undocumented.
+            A mutable set of default and address-specific strategy tags.
         """
 
         return lookup_strategy_tags(self.address)

--- a/eth_defi/enzyme/onyx_vault.py
+++ b/eth_defi/enzyme/onyx_vault.py
@@ -165,16 +165,15 @@ class EnzymeVault(VaultBase):
 
         return None
 
-    def get_strategy_tags(self) -> set[StrategyTag] | None:
-        """Return documented strategy tags for this Onyx Shares vault.
+    def get_strategy_tags(self) -> set[StrategyTag]:
+        """Return default and documented strategy tags for this Onyx Shares vault.
 
-        The shared Enzyme mapping uses the canonical Shares address. An
-        unmapped address remains ``None`` because the Onyx accounting and
-        subscription metadata cannot establish the manager's strategy alone.
+        The shared Enzyme mapping uses the canonical Shares address. Every
+        Enzyme vault receives the default discretionary-trading tag, while
+        researched addresses receive additional strategy tags.
 
         :return:
-            A mutable tag set for a researched vault, or ``None`` where no
-            sufficient strategy evidence is available.
+            A mutable set of default and address-specific strategy tags.
         """
 
         return lookup_strategy_tags(self.address)

--- a/eth_defi/enzyme/tags.py
+++ b/eth_defi/enzyme/tags.py
@@ -4,6 +4,11 @@ from eth_typing import HexAddress
 
 from eth_defi.vault.strategy_tag import StrategyTag, lookup_strategy_tags
 
+#: Enzyme is currently used as a manager-operated asset-management platform.
+#: There is no evidence that anyone currently uses Enzyme for non-discretionary
+#: trading, so every Enzyme share vault receives this default classification.
+DEFAULT_STRATEGY_TAGS = frozenset({StrategyTag.discretionary_trading})
+
 STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: Vault: OpalAccess - LiquidStone 2.
     #: Added: 2026-08-23.
@@ -281,19 +286,19 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
 }
 
 
-def get_strategy_tags(address: HexAddress) -> set[StrategyTag] | None:
+def get_strategy_tags(address: HexAddress) -> set[StrategyTag]:
     """Return the maintained strategy tags for an Enzyme shares address.
 
     Enzyme Blue VaultProxy and Onyx Shares deployments both use their share
-    token as the vault identity. The address mapping is therefore shared by
-    the two adapters, while retaining the ``None`` result that distinguishes
-    a vault with no researched strategy classification from an empty tag set.
+    token as the vault identity. Every Enzyme vault is classified as
+    discretionary trading by default; the shared address mapping adds any
+    further researched strategy tags.
 
     :param address:
         Canonical Enzyme Blue VaultProxy or Onyx Shares address.
     :return:
-        A mutable copy of the researched strategy tags, or ``None`` if the
-        address has no documented classification.
+        A mutable copy of the default and researched strategy tags.
     """
 
-    return lookup_strategy_tags(STRATEGY_TAGS, address)
+    address_specific_tags = lookup_strategy_tags(STRATEGY_TAGS, address)
+    return set(DEFAULT_STRATEGY_TAGS if address_specific_tags is None else DEFAULT_STRATEGY_TAGS | address_specific_tags)

--- a/scripts/erc-4626/migrate-vault-strategy-tags.py
+++ b/scripts/erc-4626/migrate-vault-strategy-tags.py
@@ -93,6 +93,7 @@ NATIVE_STRATEGY_TAG_RESOLVERS: dict[ERC4626Feature, NativeStrategyTagResolver] =
 # classifying the row differently from the scanner.
 EVM_ADAPTER_FEATURE_PRIORITY: tuple[ERC4626Feature, ...] = (
     ERC4626Feature.mellow_like,
+    ERC4626Feature.enzyme_onyx_like,
     ERC4626Feature.enzyme_blue_like,
     ERC4626Feature.symbiotic_like,
     ERC4626Feature.securitize_like,
@@ -236,6 +237,7 @@ EVM_STRATEGY_TAG_RESOLVERS: dict[ERC4626Feature, StrategyTagResolver] = {
     ERC4626Feature.ethena_like: partial(lookup_strategy_tags, ETHENA_STRATEGY_TAGS),
     ERC4626Feature.axis_like: partial(lookup_strategy_tags, AXIS_STRATEGY_TAGS),
     ERC4626Feature.yieldnest_like: partial(lookup_strategy_tags, YIELDNEST_STRATEGY_TAGS),
+    ERC4626Feature.enzyme_onyx_like: get_enzyme_strategy_tags,
     ERC4626Feature.enzyme_blue_like: get_enzyme_strategy_tags,
 }
 

--- a/tests/erc_4626/test_enzyme_strategy_tags.py
+++ b/tests/erc_4626/test_enzyme_strategy_tags.py
@@ -6,8 +6,8 @@ from eth_defi.enzyme.tags import get_strategy_tags
 from eth_defi.vault.strategy_tag import StrategyTag
 
 
-def test_enzyme_blue_documented_strategies_have_exact_tags() -> None:
-    """Resolve exact tags for representative Blue manager descriptions.
+def test_enzyme_blue_documented_strategies_include_default_and_exact_tags() -> None:
+    """Resolve default and exact tags for representative Blue manager descriptions.
 
     These addresses cover quantitative directional trading, automated
     market-maker liquidity provision, and the combined GMX/Uniswap strategy.
@@ -18,11 +18,13 @@ def test_enzyme_blue_documented_strategies_have_exact_tags() -> None:
 
     assert get_strategy_tags(HexAddress("0xd89551d350532d001ad3105968fecb24b1c3cec8")) == {
         StrategyTag.algorithmic_trading,
+        StrategyTag.discretionary_trading,
         StrategyTag.directional_trading,
     }
     assert get_strategy_tags(HexAddress("0x4134d87c87df974577c580561b4776c2ab70cb43")) == {
         StrategyTag.amm,
         StrategyTag.delta_neutral,
+        StrategyTag.discretionary_trading,
         StrategyTag.liquidity_provider,
         StrategyTag.mean_reversion,
     }
@@ -36,13 +38,12 @@ def test_enzyme_blue_documented_strategies_have_exact_tags() -> None:
     }
 
 
-def test_enzyme_blue_undocumented_strategy_remains_unmapped() -> None:
-    """Keep an eligible Blue listing without strategy detail unclassified.
+def test_enzyme_blue_undocumented_strategy_receives_default_tag() -> None:
+    """Apply the Enzyme default tag without address-specific strategy detail.
 
-    A meaningful description alone is not a classification: no manager
-    statement supports any available strategy tag for this vault.
+    A meaningful description alone does not warrant any additional tags.
 
-    :return: None after confirming no tag is inferred.
+    :return: None after confirming only the default tag is returned.
     """
 
-    assert get_strategy_tags(HexAddress("0xb8f69b26316818db0ea3b6d1639fedf744a2df41")) is None
+    assert get_strategy_tags(HexAddress("0xb8f69b26316818db0ea3b6d1639fedf744a2df41")) == {StrategyTag.discretionary_trading}

--- a/tests/erc_4626/test_migrate_vault_strategy_tags.py
+++ b/tests/erc_4626/test_migrate_vault_strategy_tags.py
@@ -287,7 +287,7 @@ def test_migrate_vault_strategy_tags_resolves_liquid_royalty_rows() -> None:
 
 
 def test_migrate_vault_strategy_tags_resolves_enzyme_blue_rows() -> None:
-    """Enzyme Blue rows use the shared documented share-token mapping."""
+    """Enzyme Blue rows use the shared default and documented tag mapping."""
 
     migration = load_migration_module()
     spec = VaultSpec(1, "0xd89551d350532d001ad3105968fecb24b1c3cec8")
@@ -300,10 +300,25 @@ def test_migrate_vault_strategy_tags_resolves_enzyme_blue_rows() -> None:
     assert result == (
         {
             StrategyTag.algorithmic_trading,
+            StrategyTag.discretionary_trading,
             StrategyTag.directional_trading,
         },
         "Enzyme tag resolver",
     )
+
+
+def test_migrate_vault_strategy_tags_resolves_enzyme_onyx_rows() -> None:
+    """Enzyme Onyx rows receive the shared default Enzyme tag."""
+
+    migration = load_migration_module()
+    spec = VaultSpec(8453, "0x0000000000000000000000000000000000000001")
+    row = {
+        "_detection_data": create_detection(spec, {ERC4626Feature.enzyme_onyx_like}),
+    }
+
+    result = migration.resolve_strategy_tags(spec, row)
+
+    assert result == ({StrategyTag.discretionary_trading}, "Enzyme tag resolver")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Enzyme currently operates as a manager-led asset-management platform, with no evidence of any non-discretionary trading deployment. Its vault exports should therefore carry the discretionary-trading category by default.

## Lessons learnt

Enzyme Blue and Onyx share an address-based tag resolver, but the cached-tag migration previously handled only Blue rows. Both feature flags must be registered for scanner and migration output to remain aligned.

## Summary

- Add the discretionary-trading tag to every Enzyme Blue and Onyx vault, retaining researched address-specific tags.
- Register Enzyme Onyx in the strategy-tag migration and add Blue/Onyx coverage.
- Add the feature changelog entry.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- None.