### PR TITLE
fix: use current Yearn vault links

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -14,6 +14,7 @@ import datetime
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.yearn.links import create_yearn_vault_link
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 #: Yearn TokenizedStrategy fee precision: 10_000 basis points is 100%.
@@ -107,4 +108,4 @@ class YearnCompounderVault(ERC4626Vault):
             Yearn vault URL for this chain and vault address.
         """
         del referral
-        return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"
+        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/eth_defi/erc_4626/vault_protocol/yearn/links.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/links.py
@@ -1,0 +1,39 @@
+"""Canonical links for Yearn vault and strategy pages."""
+
+from eth_typing import HexAddress
+
+
+#: Build every exported Yearn product link in one place, because Yearn has
+#: changed the public frontend route without changing the deployed contracts.
+#:
+#: The former ``/v3/{chain_id}/{address}`` route is served by a legacy
+#: frontend. It can return an HTTP success response for its application shell
+#: even when the retired client cannot resolve a vault, leaving users with a
+#: broken or permanently loading product page.
+#:
+#: Yearn's current frontend uses ``/vaults/{chain_id}/{address}`` for both V3
+#: allocator vaults and TokenizedStrategy-based products. The chain id keeps
+#: same-address deployments on different EVM chains distinct, and the vault
+#: address lets the frontend look up the exact product without relying on a
+#: mutable display name or a search-result ranking.
+#:
+#: Normalise the address to lowercase while building the path. EVM addresses
+#: are case-insensitive there, and this means records loaded from lowercase
+#: scanner metadata and checksum-form adapter properties publish one stable
+#: URL instead of duplicate links for the same product.
+#:
+#: Keep all Yearn adapters delegated to this function. A later Yearn frontend
+#: migration can then be updated once, rather than silently leaving one
+#: Yearn-derived vault family with stale links.
+def create_yearn_vault_link(chain_id: int, vault_address: HexAddress) -> str:
+    """Create the canonical current-Yearn frontend URL for a vault.
+
+    :param chain_id:
+        EVM chain id where the vault is deployed.
+    :param vault_address:
+        Canonical Yearn vault or TokenizedStrategy contract address.
+    :return:
+        Current Yearn frontend URL for this chain/address pair.
+    """
+
+    return f"https://yearn.fi/vaults/{chain_id}/{vault_address.lower()}"

--- a/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
@@ -13,6 +13,7 @@ from eth_typing import BlockIdentifier, HexAddress
 from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
+from eth_defi.erc_4626.vault_protocol.yearn.links import create_yearn_vault_link
 from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
     More information:
 
     - `Example Yearn Morpho Compounder vault <https://etherscan.io/address/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F>`__
-    - `Yearn website <https://yearn.fi/v3/1/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F>`__
+    - `Yearn website <https://yearn.fi/vaults/1/0x6D2981FF9b8d7edbb7604de7A65BAC8694ac849F>`__
     - `Morpho protocol <https://morpho.org/>`__
     """
 
@@ -87,8 +88,13 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
         return datetime.timedelta(0)
 
     def get_link(self, referral: str | None = None) -> str:
-        """Get the vault's web UI link.
+        """Return the canonical current-Yearn frontend link for this vault.
 
-        Links to the Yearn V3 vault page.
+        :param referral:
+            Optional referral identifier, unsupported by Yearn.
+        :return:
+            Yearn vault URL for this chain and vault address.
         """
-        return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"
+
+        del referral
+        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -12,6 +12,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
+from eth_defi.erc_4626.vault_protocol.yearn.links import create_yearn_vault_link
 from eth_defi.erc_4626.vault_protocol.yearn.notes import YEARN_VAULT_NOTES
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
@@ -215,4 +216,7 @@ class YearnV3Vault(ERC4626Vault):
         return YEARN_VAULT_NOTES.get(self.address.lower())
 
     def get_link(self, referral: str | None = None) -> str:
-        return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"
+        """Return the canonical current-Yearn frontend link for this vault."""
+
+        del referral
+        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -145,7 +145,7 @@ class WithdrawalDelayType(enum.StrEnum):
     ``instant`` applies when the protocol has no request, cooldown or epoch
     gate; a direct ERC-4626 redemption is possible subject to liquidity.
     Examples include `Aave <https://app.aave.com/markets/>`__ and
-    `Yearn V3 <https://yearn.fi/v3>`__.
+    `Yearn V3 <https://yearn.fi/vaults>`__.
 
     ``delay`` applies when a request follows a cooldown or asynchronous
     settlement lifecycle. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -219,6 +219,11 @@ Performance is shown in USD using the marginal amount returned by `preview_withd
 The entry and exit fee fields each model a 0.10% conversion between a generic USD stablecoin and the pool's BTC or ETH token. These endpoint costs sit outside the historical equity curve and exclude price impact, gas and MEV.
 """
 
+COINFLAKES_VAULT_V2_NOTE = """Coinflakes Vault v2.0 is a DAI-denominated Yearn V3 vault whose underlying strategy is published in the [Coinflakes sDAI strategy repository](https://github.com/0xNedAlbo/coinflakes-v2-sdai-strategy). Its README describes a Yearn V3 tokenized strategy that invests in the [Savings DAI Vault](https://spark.fi/).
+
+The [strategy implementation](https://github.com/0xNedAlbo/coinflakes-v2-sdai-strategy/blob/main/src/SDAIStrategy.sol) deposits DAI into sDAI, values its sDAI position with `convertToAssets`, and withdraws sDAI to service redemptions. Its recorded deployment at `0x430af232a837510b6f677d1e5ae3715c1e94d9d7` is the strategy named in the vault's [DebtUpdated event](https://routescan.io/tx/0x5ce59e71457ea98a8e0248981770fa778e896fd7cce9fd2d5669db4642ea9ce4/eventlog?chainid=1), confirming that the repository describes this vault's underlying strategy.
+"""
+
 #: Vault-specific notes and classifications that do not exclude a vault from
 #: research datasets.
 #:
@@ -231,6 +236,8 @@ VAULT_NOTES: dict[str, str] = {
     "0x1fecf3d9d4fee7f2c02917a66028a48c6706c179": WISDOMTREE_WTGXX_NOTE,
     "0x43415eb6ff9db7e26a15b704e7a3edce97d31c4e": SUPERSTATE_USTB_NOTE,
     "0x6a7c6aa2b8b8a6a891de552bdeffa87c3f53bd46": ODA_FACT_MONY_NOTE,
+    # Coinflakes Vault v2.0, Ethereum.
+    "0x254bd33e2f62713f893f0842c99e68f855cda315": COINFLAKES_VAULT_V2_NOTE,
     USTBL_TOKEN_ADDRESS: SPIKO_USTBL_NOTE,
     EUTBL_TOKEN_ADDRESS: SPIKO_EUTBL_NOTE,
 }

--- a/tests/erc_4626/vault_protocol/test_yearn_links.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_links.py
@@ -1,0 +1,28 @@
+"""Test canonical Yearn frontend links."""
+
+import pytest
+
+from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+from eth_defi.erc_4626.vault_protocol.yearn.links import create_yearn_vault_link
+from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
+from eth_defi.vault.base import VaultSpec
+
+VAULT_ADDRESS = "0x254bd33e2f62713f893f0842c99e68f855cda315"
+EXPECTED_LINK = f"https://yearn.fi/vaults/1/{VAULT_ADDRESS}"
+
+
+def test_create_yearn_vault_link_uses_current_frontend_route() -> None:
+    """Yearn links use the shared current chain-and-address route."""
+
+    assert create_yearn_vault_link(1, VAULT_ADDRESS) == EXPECTED_LINK
+
+
+@pytest.mark.parametrize("vault_class", (YearnV3Vault, YearnCompounderVault, YearnMorphoCompounderStrategy))
+def test_all_yearn_adapters_delegate_to_the_shared_link_builder(vault_class: type) -> None:
+    """Every supported Yearn vault family returns the same canonical link."""
+
+    vault = object.__new__(vault_class)
+    vault.spec = VaultSpec(1, VAULT_ADDRESS)
+
+    assert vault.get_link() == EXPECTED_LINK

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -62,6 +62,21 @@ def test_spxa_is_a_tokenised_fund() -> None:
     assert not is_flagged_vault("0x99e9092bae6d4394e54034ecb1e45441678323b9")
 
 
+def test_coinflakes_vault_note_describes_the_published_sdai_strategy() -> None:
+    """Coinflakes publishes its deployed Yearn V3 sDAI strategy source."""
+
+    address = "0x254bd33e2f62713f893f0842c99e68f855cda315"
+
+    note = get_notes(address)
+
+    assert note is not None
+    assert "Coinflakes sDAI strategy repository" in note
+    assert "deposits DAI into sDAI" in note
+    assert "0x430af232a837510b6f677d1e5ae3715c1e94d9d7" in note
+    assert get_vault_special_flags(address) == set()
+    assert not is_flagged_vault(address)
+
+
 @pytest.mark.parametrize("protocol", ("Lagoon Finance", "IPOR Fusion", "Yearn"))
 def test_minimal_risk_protocols_are_reclassified_as_low(protocol: str) -> None:
     """Former minimal protocol classifications use the unified low level."""


### PR DESCRIPTION
## Why

Yearn’s old `/v3/{chain}/{address}` frontend route can leave vault pages broken or permanently loading. Exported Yearn links must use its current canonical route.

## Lessons learnt

The legacy route may return an application shell with HTTP success while its retired client cannot resolve a vault. Yearn V3 allocator vaults, TokenizedStrategy compounders and Morpho compounder strategies all share the current chain-and-address URL structure.

## Summary

- Add one documented Yearn URL builder using `/vaults/{chain}/{address}` and stable lowercase address paths.
- Route all supported Yearn adapters through that builder and update stale documentation links.
- Add focused coverage for every Yearn adapter family.
- Add the Coinflakes sDAI strategy note and its source-link coverage.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- None.