### PR TITLE
notes: mark Morpho Moonwell Flagship USDC Compounder as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -811,6 +811,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xf115c134c23c7a05fbd489a8be3116ebf54b0d9f": (VaultFlag.subvault, SUBVAULT),
     # Morpho Zircuit Finance USDC on Base Compounder
     "0x049e8aab2d3ca187e47d74cf8171ad266f18643e": (VaultFlag.subvault, SUBVAULT),
+    # Morpho Moonwell Flagship USDC Compounder (Yearn on Base)
+    "0xd5428b889621eee8060fc105aa0ab0fa2e344468": (VaultFlag.subvault, SUBVAULT),
     # Tulipa Capital USDT0
     "0xaf293898269ac7f366d0e05052b5fdfee8c8052c": (VaultFlag.irregular_reporting, IRREGULAR_REPORTING),
     # Hashfire launch fund.

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -267,6 +267,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
         ("0x6abbda8243f4bf130a97beae759a6e91522520b9", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x049e8aab2d3ca187e47d74cf8171ad266f18643e", "Yearn", VaultFlag.subvault, "not intended"),
+        ("0xd5428b889621eee8060fc105aa0ab0fa2e344468", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x93fec6639717b6215a48e5a72a162c50dcc40d68", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xad755c6c31515aef8d2f830767d846774f7e9ea9", "Morpho", VaultFlag.malicious, "malicious"),


### PR DESCRIPTION
## Why

Morpho Moonwell Flagship USDC Compounder is a Yearn-managed strategy component rather than a vault intended for direct end-user exposure.

## Lessons learnt

Yearn compounder detection can surface strategy components alongside directly investable vaults; manual `subvault` classification prevents those components being presented as standalone investment options.

## Summary

- Marked Base vault `0xd5428b889621eee8060fc105aa0ab0fa2e344468` as `VaultFlag.subvault`.
- Added focused flag coverage for the vault.

## Related issues and PRs

None.