### PR TITLE
notes: mark Morpho Moonwell Flagship USDC Compounder as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -772,6 +772,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "lighter-pool-robinhood-281474976710654": (None, LIGHTER_ROBINHOOD_LLP_INSURANCE),
     # Morpho Yearn Morpho Vault 1 Compounder (Base)
     "0xf115c134c23c7a05fbd489a8be3116ebf54b0d9f": (VaultFlag.subvault, SUBVAULT),
+    # Morpho Moonwell Flagship USDC Compounder (Base)
+    "0xd5428b889621eee8060fc105aa0ab0fa2e344468": (VaultFlag.subvault, SUBVAULT),
     # Morpho Zircuit Finance USDC on Base Compounder
     "0x049e8aab2d3ca187e47d74cf8171ad266f18643e": (VaultFlag.subvault, SUBVAULT),
     # Tulipa Capital USDT0

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -220,6 +220,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
         ("0x6abbda8243f4bf130a97beae759a6e91522520b9", "Yearn", VaultFlag.subvault, "not intended"),
+        ("0xd5428b889621eee8060fc105aa0ab0fa2e344468", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x049e8aab2d3ca187e47d74cf8171ad266f18643e", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x93fec6639717b6215a48e5a72a162c50dcc40d68", "Yearn", VaultFlag.subvault, "not intended"),


### PR DESCRIPTION
## Why

This Yearn compounder is an internal strategy component and should not be exposed as an investable vault.

## Lessons learnt

Manual vault flags use lower-cased share-token addresses and require metadata rescanning before publication.

## Summary

- Marked the Base Morpho Moonwell Flagship USDC Compounder as a subvault.
- Added focused regression coverage for its manual flag.

## Related issues and PRs

None.