### PR TITLE
fix: refresh singleton RPC session for receipt reads

### DIFF
--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -30,7 +30,7 @@ from eth_defi.provider.anvil import is_anvil, mine
 from eth_defi.provider.fallback import FallbackProvider, get_fallback_provider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
 from eth_defi.provider.named import get_provider_name
-from eth_defi.provider.receipt import TransactionVisibilityTimedOut, wait_for_transaction_visibility
+from eth_defi.provider.receipt import ReceiptVisibilityMismatch, TransactionVisibilityTimedOut, wait_for_transaction_visibility
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.timestamp import get_latest_block_timestamp
 from eth_defi.tx import DecodeFailure, decode_signed_transaction, get_tx_broadcast_data
@@ -81,10 +81,17 @@ def is_invalid_sender(eth_rpc_error_messag: str) -> bool:
 
 
 def fetch_fresh_singleton_receipt(provider: BaseProvider, tx_hash: HexBytes) -> dict | None:
-    """Fetch a receipt after replacing a singleton RPC connection.
+    """Fetch a receipt after resetting a singleton RPC connection.
 
-    Reset the shared session used by the patched provider before retrying the
-    receipt read. This retains fallback-provider instrumentation and routing.
+    Derive exposes only one public RPC URL, but that URL may load balance requests
+    across backend nodes. During the 2026-09-08 Vega incident, the transaction was
+    mined one second after broadcast while one persistent HTTP connection returned
+    ``TransactionNotFound`` for ten minutes. Resetting the cached session gives the
+    same configured URL a chance to select a backend that can see the receipt.
+
+    The retry still goes through the original :py:class:`FallbackProvider`. This
+    keeps its request/error accounting and does not turn the singleton URL into a
+    second provider or change MEV transaction routing.
 
     :param provider:
         A singleton fallback provider.
@@ -96,15 +103,33 @@ def fetch_fresh_singleton_receipt(provider: BaseProvider, tx_hash: HexBytes) -> 
     if not isinstance(provider, FallbackProvider) or len(provider.providers) != 1:
         return None
 
+    # The workaround is deliberately restricted to the Derive-shaped topology:
+    # one FallbackProvider containing one HTTP endpoint. Multi-provider setups
+    # already have a genuinely independent read provider and must retain their
+    # existing failover and MEV routing behaviour.
     active_provider = provider.get_active_provider()
     if not isinstance(active_provider, HTTPProvider):
         return None
 
+    # Drop only this thread's pooled connection. The configured provider object,
+    # request headers, timeouts and authentication remain untouched.
     reset_http_session(active_provider)
     try:
-        return Web3(active_provider).eth.get_transaction_receipt(tx_hash)
+        # Route the retry through FallbackProvider, not its child, so the fresh
+        # request is visible in the existing RPC diagnostics and counters.
+        receipt = Web3(provider).eth.get_transaction_receipt(tx_hash)
     except TransactionNotFound:
         return None
+
+    # A fresh connection is only a transport recovery mechanism. Never let a
+    # faulty or misrouted backend make us confirm a different transaction under
+    # the hash we originally broadcast. Failed receipts (status == 0) still pass
+    # this identity check and are returned for the caller's normal revert handling.
+    receipt_tx_hash = receipt.get("transactionHash")
+    if receipt_tx_hash is None or HexBytes(receipt_tx_hash) != HexBytes(tx_hash):
+        raise ReceiptVisibilityMismatch(f"Fresh singleton RPC receipt hash {receipt_tx_hash!r} does not match requested transaction {HexBytes(tx_hash).hex()}")
+
+    return receipt
 
 
 def wait_transactions_to_complete(
@@ -1555,9 +1580,17 @@ def wait_and_broadcast_multiple_nodes_mev_blocker(
                     try:
                         backup_provider_receipt = backup_web3.eth.get_transaction_receipt(tx_hash)
                     except TransactionNotFound:
+                        # With a singleton Derive FallbackProvider, "backup" and
+                        # transaction provider are the same object. Retrying it on
+                        # the same pooled HTTP connection reproduced the 2026-09-08
+                        # ten-minute false timeout, so refresh that connection once
+                        # the normal backup delay has elapsed.
                         if backup_provider is transaction_provider:
                             backup_provider_receipt = fetch_fresh_singleton_receipt(backup_provider, tx_hash)
                         else:
+                            # A separate call provider is part of the established
+                            # MEV path. Preserve its exception and rebroadcast
+                            # behaviour instead of applying the singleton workaround.
                             raise
 
                     if backup_provider_receipt:

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -19,12 +19,12 @@ from typing import Collection, Dict, List, Set, Union, cast
 
 from eth_account.datastructures import SignedTransaction
 from hexbytes import HexBytes
-from web3 import Web3
+from web3 import HTTPProvider, Web3
 from web3.exceptions import TransactionNotFound
 from web3.providers import BaseProvider
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.event_reader.fast_json_rpc import get_last_headers
+from eth_defi.event_reader.fast_json_rpc import get_last_headers, reset_http_session
 from eth_defi.hotwallet import SignedTransactionWithNonce
 from eth_defi.provider.anvil import is_anvil, mine
 from eth_defi.provider.fallback import FallbackProvider, get_fallback_provider
@@ -78,6 +78,33 @@ def is_out_of_gas(eth_rpc_error_messag: str) -> bool:
 def is_invalid_sender(eth_rpc_error_messag: str) -> bool:
     """from address missing in the tx payload"""
     return "invalid sender" in eth_rpc_error_messag
+
+
+def fetch_fresh_singleton_receipt(provider: BaseProvider, tx_hash: HexBytes) -> dict | None:
+    """Fetch a receipt after replacing a singleton RPC connection.
+
+    Reset the shared session used by the patched provider before retrying the
+    receipt read. This retains fallback-provider instrumentation and routing.
+
+    :param provider:
+        A singleton fallback provider.
+    :param tx_hash:
+        Transaction whose receipt to fetch.
+    :return:
+        The receipt from the new connection, or ``None`` if it is not visible.
+    """
+    if not isinstance(provider, FallbackProvider) or len(provider.providers) != 1:
+        return None
+
+    active_provider = provider.get_active_provider()
+    if not isinstance(active_provider, HTTPProvider):
+        return None
+
+    reset_http_session(active_provider)
+    try:
+        return Web3(active_provider).eth.get_transaction_receipt(tx_hash)
+    except TransactionNotFound:
+        return None
 
 
 def wait_transactions_to_complete(
@@ -1476,7 +1503,7 @@ def wait_and_broadcast_multiple_nodes_mev_blocker(
         transaction_provider = provider.transact_provider
         backup_provider = provider.call_provider
     else:
-        # Test path
+        # A regular provider sends transactions and serves reads.
         transaction_provider = provider
         backup_provider = provider
 
@@ -1524,14 +1551,18 @@ def wait_and_broadcast_multiple_nodes_mev_blocker(
                         time.sleep(broadcast_and_read_delay.total_seconds())
 
                 if time.time() > try_other_provider_timeout:
-                    # Also try backup provider if sequencer is blocking us for some reason
-                    logger.info("Attempting backup provider %s", backup_provider)
+                    logger.info("Checking receipt through fallback provider %s", backup_provider)
+                    try:
+                        backup_provider_receipt = backup_web3.eth.get_transaction_receipt(tx_hash)
+                    except TransactionNotFound:
+                        if backup_provider is transaction_provider:
+                            backup_provider_receipt = fetch_fresh_singleton_receipt(backup_provider, tx_hash)
+                        else:
+                            raise
 
-                    # If we do not check for this we may get "nonce too low" error when
-                    # broadcasting the same transaction, which is a bug in JSON-RPC
-                    backup_provider_receipt = backup_web3.eth.get_transaction_receipt(tx_hash)
-
-                    if not backup_provider_receipt:
+                    if backup_provider_receipt:
+                        logger.info("Received receipt through fallback provider for tx hash: %s", tx.hash.hex())
+                    elif backup_provider is not transaction_provider:
                         logger.info(
                             "No receipt, attempting to broadcast with hash: %s with backup provider %s",
                             tx.hash.hex(),
@@ -1549,9 +1580,6 @@ def wait_and_broadcast_multiple_nodes_mev_blocker(
                                 logger.info("Already known race condition: %s", str(e))
                             else:
                                 raise e
-                    else:
-                        logger.info("Received backup receipt with has tx_hash: %s", tx.hash)
-
                 logger.debug("Starting MEV Blocker confirmation cycle, unconfirmed tx is: %s, sleeping poll delay %s", tx_hash.hex(), poll_delay)
 
                 # Read receipt using read node,

--- a/eth_defi/event_reader/fast_json_rpc.py
+++ b/eth_defi/event_reader/fast_json_rpc.py
@@ -10,11 +10,12 @@ from typing import Any, cast
 
 import orjson
 from web3 import Web3
+from web3._utils.caching.caching_utils import generate_cache_key
 from web3.providers import JSONBaseProvider
 from web3.providers.rpc import HTTPProvider
 from web3.types import RPCEndpoint, RPCResponse
 
-from eth_defi.compat import get_response_from_post_request
+from eth_defi.compat import get_response_from_post_request, sessions
 from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,24 @@ def patch_provider(provider: JSONBaseProvider):
     if isinstance(provider, HTTPProvider):
         provider.make_request = _make_request.__get__(provider)
     provider.decode_rpc_response = _fast_decode_rpc_response
+
+
+def reset_http_session(provider: HTTPProvider) -> None:
+    """Drop the current thread's cached HTTP connection for an endpoint.
+
+    The next patched request creates a new :class:`requests.Session` while
+    retaining the provider's middleware, accounting and diagnostics.
+
+    :param provider:
+        HTTP provider whose cached connection is reset.
+    :return:
+        Always ``None``.
+    """
+    cache_key = generate_cache_key(f"{threading.get_ident()}:{provider.endpoint_uri}")
+    with sessions._lock:
+        session = sessions.session_cache.pop(cache_key)
+    if session is not None:
+        session.close()
 
 
 def patch_web3(web3: Web3):

--- a/eth_defi/event_reader/fast_json_rpc.py
+++ b/eth_defi/event_reader/fast_json_rpc.py
@@ -121,10 +121,19 @@ def reset_http_session(provider: HTTPProvider) -> None:
     :return:
         Always ``None``.
     """
+    # get_response_from_post_request() uses Web3.py's HTTPSessionManager, whose
+    # cache key is exactly the current thread id plus endpoint URI. Reusing this
+    # key lets us evict the stale connection without replacing or reconstructing
+    # the configured HTTPProvider and its potentially sensitive request settings.
     cache_key = generate_cache_key(f"{threading.get_ident()}:{provider.endpoint_uri}")
     with sessions._lock:
+        # Remove the session while holding the manager's own lock so the next
+        # request in this thread cannot retrieve the connection being retired.
         session = sessions.session_cache.pop(cache_key)
     if session is not None:
+        # Closing after removal releases the old keep-alive socket. The next RPC
+        # call will create a new session and may reach a different load-balancer
+        # backend, which is the recovery needed by the Derive incident.
         session.close()
 
 

--- a/tests/derive/test_open_interest_history.py
+++ b/tests/derive/test_open_interest_history.py
@@ -165,7 +165,7 @@ def test_open_interest_db_backfill_and_resume(session, w3: Web3, tmp_path):
     2. Assert rows were inserted.
     3. Re-sync the same window — assert 0 new rows (idempotent).
     4. Assert DataFrame has correct columns including perp_price and index_price.
-    5. Assert all OI values are positive and all price values are present and positive.
+    5. Assert all OI values and the available price values are positive.
     6. Assert sync state records oldest/newest timestamps.
     """
     db = DeriveFundingRateDatabase(tmp_path / "funding-rates.duckdb")
@@ -208,18 +208,25 @@ def test_open_interest_db_backfill_and_resume(session, w3: Web3, tmp_path):
         assert "perp_price" in df.columns
         assert "index_price" in df.columns
 
-        # 5. All data points should be positive
+        # 5. All OI data points and the available price data points should be positive.
+        # Derive's price view methods are allowed to revert independently inside
+        # aggregate3(), and PerpSnapshotMulticallResult documents these fields as
+        # optional for that reason. On 2026-09-08, one historical getPerpPrice()
+        # subcall reverted while the same row's OI and index price were available;
+        # requiring every optional price to exist made this live test misleading.
         assert (df["open_interest"] > 0).all(), "All OI values should be positive"
-        assert df["perp_price"].notna().all(), "All perp_price values should be present"
-        assert (df["perp_price"] > 0).all(), "All perp_price values should be positive"
-        assert df["index_price"].notna().all(), "All index_price values should be present"
-        assert (df["index_price"] > 0).all(), "All index_price values should be positive"
+        perp_prices = df["perp_price"].dropna()
+        index_prices = df["index_price"].dropna()
+        assert len(perp_prices) >= 4, "Expected at least four available perp_price values"
+        assert len(index_prices) >= 4, "Expected at least four available index_price values"
+        assert (perp_prices > 0).all(), "All available perp_price values should be positive"
+        assert (index_prices > 0).all(), "All available index_price values should be positive"
 
-        # Sanity: prices should be in a reasonable range for ETH ($100–$100,000)
-        assert (df["perp_price"] > 100).all(), "perp_price below $100"
-        assert (df["perp_price"] < 100_000).all(), "perp_price above $100,000"
-        assert (df["index_price"] > 100).all(), "index_price below $100"
-        assert (df["index_price"] < 100_000).all(), "index_price above $100,000"
+        # Sanity-check every available price against a reasonable ETH range.
+        assert (perp_prices > 100).all(), "perp_price below $100"
+        assert (perp_prices < 100_000).all(), "perp_price above $100,000"
+        assert (index_prices > 100).all(), "index_price below $100"
+        assert (index_prices < 100_000).all(), "index_price above $100,000"
 
         # 6. Sync state
         state = db.get_open_interest_sync_state("ETH-PERP")

--- a/tests/rpc/test_mev_blocker.py
+++ b/tests/rpc/test_mev_blocker.py
@@ -1,17 +1,26 @@
 """Test MEV blocker provider switching."""
 
 import datetime
+import threading
 
 import pytest
 from web3 import HTTPProvider, Web3
+from web3._utils.caching.caching_utils import generate_cache_key
 
-from eth_defi.confirmation import wait_and_broadcast_multiple_nodes_mev_blocker, ConfirmationTimedOut
+from eth_defi.confirmation import (
+    ConfirmationTimedOut,
+    fetch_fresh_singleton_receipt,
+    wait_and_broadcast_multiple_nodes_mev_blocker,
+)
 from eth_defi.provider.anvil import launch_anvil, AnvilLaunch
 from eth_defi.provider.mev_blocker import MEVBlockerProvider, get_mev_blocker_provider
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 
 from eth_defi.hotwallet import HotWallet
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.abi import ZERO_ADDRESS
+from eth_defi.compat import sessions
 from eth_defi.tx import get_tx_broadcast_data
 
 
@@ -159,3 +168,40 @@ def test_mev_blocker_broadcast_timeout(mev_blocker_provider: MEVBlockerProvider)
 
     with pytest.raises(ConfirmationTimedOut):
         wait_and_broadcast_multiple_nodes_mev_blocker(web3.provider, [signed_tx], max_timeout=datetime.timedelta(seconds=-1))
+
+
+def test_fresh_singleton_receipt_fetch_keeps_provider_instrumentation(anvil: AnvilLaunch) -> None:
+    """Recover a transaction receipt without replacing the singleton provider.
+
+    1. Broadcast a transaction through a singleton fallback provider.
+    2. Probe its receipt using a fresh HTTP connection.
+    3. Verify the receipt is returned through a new session without replacing the provider.
+    """
+    # 1. Broadcast a transaction through a singleton fallback provider.
+    web3 = create_multi_provider_web3(anvil.json_rpc_url, retries=0)
+    fallback_provider = web3.get_fallback_provider()
+    wallet = HotWallet.create_for_testing(web3)
+    signed_tx = wallet.sign_transaction_with_new_nonce(
+        {
+            "from": wallet.address,
+            "to": ZERO_ADDRESS,
+            "value": 1,
+            "gas": 100_000,
+            "gasPrice": web3.eth.gas_price,
+        }
+    )
+    tx_hash = web3.eth.send_raw_transaction(get_tx_broadcast_data(signed_tx))
+    wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=0)
+    original_provider = fallback_provider.get_active_provider()
+    cache_key = generate_cache_key(f"{threading.get_ident()}:{original_provider.endpoint_uri}")
+    original_session = sessions.session_cache.get_cache_entry(cache_key)
+    assert original_session is not None
+
+    # 2. Fetch its receipt using a fresh HTTP connection.
+    receipt = fetch_fresh_singleton_receipt(fallback_provider, tx_hash)
+
+    # 3. Verify the receipt is returned through a new session without replacing the provider.
+    assert receipt["transactionHash"] == tx_hash
+    assert fallback_provider.get_active_provider() is original_provider
+    assert sessions.session_cache.get_cache_entry(cache_key) is not original_session
+    assert web3.eth.get_transaction_receipt(tx_hash)["transactionHash"] == tx_hash

--- a/tests/rpc/test_mev_blocker.py
+++ b/tests/rpc/test_mev_blocker.py
@@ -4,23 +4,23 @@ import datetime
 import threading
 
 import pytest
+from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3._utils.caching.caching_utils import generate_cache_key
 
+from eth_defi.abi import ZERO_ADDRESS
+from eth_defi.compat import sessions
 from eth_defi.confirmation import (
     ConfirmationTimedOut,
     fetch_fresh_singleton_receipt,
     wait_and_broadcast_multiple_nodes_mev_blocker,
 )
-from eth_defi.provider.anvil import launch_anvil, AnvilLaunch
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.provider.mev_blocker import MEVBlockerProvider, get_mev_blocker_provider
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
-
-from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.receipt import ReceiptVisibilityMismatch, wait_for_transaction_receipt_robust
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.abi import ZERO_ADDRESS
-from eth_defi.compat import sessions
 from eth_defi.tx import get_tx_broadcast_data
 
 
@@ -170,14 +170,84 @@ def test_mev_blocker_broadcast_timeout(mev_blocker_provider: MEVBlockerProvider)
         wait_and_broadcast_multiple_nodes_mev_blocker(web3.provider, [signed_tx], max_timeout=datetime.timedelta(seconds=-1))
 
 
-def test_fresh_singleton_receipt_fetch_keeps_provider_instrumentation(anvil: AnvilLaunch) -> None:
-    """Recover a transaction receipt without replacing the singleton provider.
+def test_fresh_singleton_receipt_recovers_broadcast_loop(anvil: AnvilLaunch, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recover the broadcast loop from stale singleton receipt visibility.
 
-    1. Broadcast a transaction through a singleton fallback provider.
-    2. Probe its receipt using a fresh HTTP connection.
-    3. Verify the receipt is returned through a new session without replacing the provider.
+    This reproduces the relevant shape of the 2026-09-08 Derive incident without
+    depending on an external flaky RPC: the first receipt read on the persistent
+    connection reports the transaction missing, while the read after session reset
+    reaches the real Anvil receipt.
+
+    1. Configure a singleton fallback provider whose first receipt read is stale.
+    2. Broadcast through the production confirmation loop and trigger recovery.
+    3. Verify the matching receipt used a new session and fallback instrumentation.
     """
-    # 1. Broadcast a transaction through a singleton fallback provider.
+    # 1. Configure a singleton fallback provider whose first receipt read is stale.
+    web3 = create_multi_provider_web3(anvil.json_rpc_url, retries=0)
+    fallback_provider = web3.get_fallback_provider()
+    wallet = HotWallet.create_for_testing(web3)
+    signed_tx = wallet.sign_transaction_with_new_nonce(
+        {
+            "from": wallet.address,
+            "to": ZERO_ADDRESS,
+            "value": 1,
+            "gas": 100_000,
+            "gasPrice": web3.eth.gas_price,
+        }
+    )
+    original_provider = fallback_provider.get_active_provider()
+    original_make_request = original_provider.make_request
+    cache_key = generate_cache_key(f"{threading.get_ident()}:{original_provider.endpoint_uri}")
+    original_session = sessions.session_cache.get_cache_entry(cache_key)
+    assert original_session is not None
+    receipt_reads = 0
+    receipt_sessions = []
+
+    def return_one_stale_receipt(method: str, params: list) -> dict:
+        """Simulate one load-balancer backend that has not indexed the receipt."""
+        nonlocal receipt_reads
+        if method == "eth_getTransactionReceipt":
+            receipt_reads += 1
+            receipt_sessions.append(sessions.session_cache.get_cache_entry(cache_key))
+            if receipt_reads == 1:
+                return {"jsonrpc": "2.0", "id": 1, "result": None}
+        return original_make_request(method, params)
+
+    # Mock only the first receipt response; subsequent calls still reach Anvil.
+    # This gives the test deterministic stale-then-fresh behaviour while retaining
+    # the real HTTP session manager and FallbackProvider request path.
+    monkeypatch.setattr(original_provider, "make_request", return_one_stale_receipt)
+    receipt_call_count = fallback_provider.get_total_api_call_counts()["eth_getTransactionReceipt"]
+
+    # 2. Broadcast through the production confirmation loop and trigger recovery.
+    receipts = wait_and_broadcast_multiple_nodes_mev_blocker(
+        web3.provider,
+        [signed_tx],
+        max_timeout=datetime.timedelta(seconds=2),
+        poll_delay=datetime.timedelta(milliseconds=10),
+        broadcast_and_read_delay=datetime.timedelta(0),
+        try_other_provider_delay=datetime.timedelta(seconds=-1),
+    )
+
+    # 3. Verify the matching receipt used a new session and fallback instrumentation.
+    receipt = receipts[signed_tx.hash]
+    assert receipt["transactionHash"] == signed_tx.hash
+    assert receipt_reads == 2
+    assert receipt_sessions[0] is original_session
+    assert receipt_sessions[1] is None
+    assert fallback_provider.get_active_provider() is original_provider
+    assert fallback_provider.get_total_api_call_counts()["eth_getTransactionReceipt"] == receipt_call_count + receipt_reads
+
+
+def test_fresh_singleton_receipt_validates_transaction_identity(anvil: AnvilLaunch, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validate receipt identity without hiding a real transaction failure.
+
+    1. Broadcast and confirm a transaction through a singleton fallback provider.
+    2. Simulate a misrouted backend returning that receipt under another hash.
+    3. Verify the fresh-session helper refuses the mismatching receipt.
+    4. Verify a matching failed receipt is still returned for revert handling.
+    """
+    # 1. Broadcast and confirm a transaction through a singleton fallback provider.
     web3 = create_multi_provider_web3(anvil.json_rpc_url, retries=0)
     fallback_provider = web3.get_fallback_provider()
     wallet = HotWallet.create_for_testing(web3)
@@ -192,16 +262,33 @@ def test_fresh_singleton_receipt_fetch_keeps_provider_instrumentation(anvil: Anv
     )
     tx_hash = web3.eth.send_raw_transaction(get_tx_broadcast_data(signed_tx))
     wait_for_transaction_receipt_robust(web3, tx_hash, confirmation_block_count=0)
+
+    # 2. Simulate a misrouted backend returning that receipt under another hash.
     original_provider = fallback_provider.get_active_provider()
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{original_provider.endpoint_uri}")
-    original_session = sessions.session_cache.get_cache_entry(cache_key)
-    assert original_session is not None
+    original_make_request = original_provider.make_request
+    raw_response = original_make_request("eth_getTransactionReceipt", [tx_hash.to_0x_hex()])
+    wrong_tx_hash = HexBytes("0x" + "ff" * 32)
+    wrong_response = {**raw_response, "result": {**raw_response["result"], "transactionHash": wrong_tx_hash.to_0x_hex()}}
+    response_to_return = wrong_response
 
-    # 2. Fetch its receipt using a fresh HTTP connection.
+    def return_wrong_receipt(method: str, params: list) -> dict:
+        """Return a validly shaped receipt for the wrong transaction hash."""
+        if method == "eth_getTransactionReceipt":
+            return response_to_return
+        return original_make_request(method, params)
+
+    # Mock a broken backend response because the safety property is that transport
+    # recovery must never weaken transaction identity validation.
+    monkeypatch.setattr(original_provider, "make_request", return_wrong_receipt)
+
+    # 3. Verify the fresh-session helper refuses the mismatching receipt.
+    with pytest.raises(ReceiptVisibilityMismatch, match="does not match requested transaction"):
+        fetch_fresh_singleton_receipt(fallback_provider, tx_hash)
+
+    # 4. Verify a matching failed receipt is still returned for revert handling.
+    # The recovery validates identity only: status == 0 is real chain data and the
+    # caller, not the flaky-RPC workaround, remains responsible for reporting it.
+    response_to_return = {**raw_response, "result": {**raw_response["result"], "status": "0x0"}}
     receipt = fetch_fresh_singleton_receipt(fallback_provider, tx_hash)
-
-    # 3. Verify the receipt is returned through a new session without replacing the provider.
     assert receipt["transactionHash"] == tx_hash
-    assert fallback_provider.get_active_provider() is original_provider
-    assert sessions.session_cache.get_cache_entry(cache_key) is not original_session
-    assert web3.eth.get_transaction_receipt(tx_hash)["transactionHash"] == tx_hash
+    assert receipt["status"] == 0


### PR DESCRIPTION
## Why

Derive exposes only one public JSON-RPC URL, but that URL may load balance persistent HTTP connections across backend nodes with different transaction visibility.

The Vega incident on 2026-09-08 demonstrates the failure mode. Transaction `0x440457616b1eebb44481067653d42731f303958527bbd57b64bbb34845782f8c` was broadcast at 14:38:06 UTC and succeeded in block 44,428,336 at approximately 14:38:07 UTC. The connection used by the executor nevertheless returned `TransactionNotFound` until the ten-minute confirmation timeout expired, crashing the live loop at 14:48:12 UTC.

The desired behaviour is narrowly scoped: when a singleton `FallbackProvider` cannot see a receipt after the existing backup delay, retire that thread's persistent HTTP session and retry the same configured endpoint through the same provider stack. Do not introduce another RPC, rebroadcast through a public read endpoint, change MEV routing, or conceal a real failed transaction.

## Lessons learnt

The earlier timeout increase changed `wait_for_transaction_receipt_robust()`, but this incident failed earlier inside `wait_and_broadcast_multiple_nodes_mev_blocker()`, so execution never reached the longer wait.

The fast JSON-RPC path caches HTTP sessions by thread and endpoint. Reconstructing providers is unnecessary and risks dropping request configuration or observability. Evicting only the cached session preserves headers, authentication, timeouts, middleware and provider identity while allowing Derive's load balancer to select a different backend.

A fresh connection is only transport recovery. Its receipt must still identify the exact transaction requested. A matching receipt with `status == 0` remains a real failed transaction and is returned unchanged for normal revert handling.

## Summary

- Reset the current thread's cached HTTP session only for a singleton `FallbackProvider` after the normal receipt lookup returns `TransactionNotFound`.
- Retry through the original `FallbackProvider` so RPC request/error accounting and diagnostics remain intact.
- Validate the refreshed receipt's `transactionHash` before accepting it.
- Preserve existing multi-provider failover, MEV routing, timeout and transaction-status semantics.
- Add an Anvil regression test that drives the broadcast loop through stale-then-fresh receipt visibility and verifies session eviction plus fallback accounting.
- Add safety coverage for a mismatching receipt and a matching failed receipt.
- Document the incident and recovery invariants beside the relevant code paths.

## Related issues and PRs

- Consumed by tradingstrategy-ai/trade-executor#1643.

## Unrelated CI and test fixes

- Correct the live Derive historical open-interest test to match the documented `PerpSnapshotMulticallResult` contract: `getPerpPrice()` and `getIndexPrice()` are independent `aggregate3(..., allowFailure=True)` subcalls and may be unavailable for an individual historical block.
- Continue requiring all stored open-interest values to be positive, at least four prices of each kind in the short sample, and every available price to be positive and within the ETH sanity range.
- This was observed both in two CI runs and locally on 2026-09-08: six of seven `perp_price` values were valid, while one historical price subcall was unavailable. Retrying reproduced the same data point, so the assertion was corrected instead of masking it as flaky.
