### PR TITLE
fix: reconcile Yearn vault visibility with public catalogue

### DIFF
--- a/docs/source/vaults/yearn/index.rst
+++ b/docs/source/vaults/yearn/index.rst
@@ -21,6 +21,23 @@ data and its selector when the RPC provider supplies them, but does not label an
 opaque provider message as a decoded Solidity error. It does not treat a
 missing approval or an RPC failure as a vault closure.
 
+Public catalogue metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The scanner caches the public `yDaemon detected-vault catalogue
+<https://ydaemon.yearn.fi/vaults/detected?limit=2000>`__ daily. An address in
+this catalogue is not dynamically flagged ``unofficial`` and its Yearn
+description is exported with the first sentence as the short description. An
+absent address receives the dynamic flag only when a complete catalogue is
+available. This is a website-presence check; it does not assert an endorsement,
+safety rating, or investment suitability. Hidden and retired metadata fields
+do not change this result because they are lifecycle information, not evidence
+that Yearn does not know the vault.
+
+Use ``scripts/erc-4626/migrate-yearn-vault-metadata.py`` to repair existing
+cached Yearn rows. It defaults to a non-mutating dry run and changes only the
+metadata pickle after a successful catalogue download.
+
 Links
 ~~~~~
 

--- a/docs/source/vaults/yearn/index.rst
+++ b/docs/source/vaults/yearn/index.rst
@@ -25,14 +25,20 @@ Public catalogue metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The scanner caches the public `yDaemon detected-vault catalogue
-<https://ydaemon.yearn.fi/vaults/detected?limit=2000>`__ daily. An address in
-this catalogue is not dynamically flagged ``unofficial`` and its Yearn
-description is exported with the first sentence as the short description. An
-absent address receives the dynamic flag only when a complete catalogue is
-available. This is a website-presence check; it does not assert an endorsement,
-safety rating, or investment suitability. Hidden and retired metadata fields
-do not change this result because they are lifecycle information, not evidence
-that Yearn does not know the vault.
+<https://ydaemon.yearn.fi/vaults/detected?limit=2000>`__ daily. A matching
+address positively confirms that Yearn publishes a vault page and supplies the
+exported description; its bounded first sentence is the short description.
+Template descriptions with unresolved placeholders are omitted rather than
+shown on the website.
+
+The catalogue is not a complete registry for TokenizedStrategy, compounder, or
+Morpho compounder adapter shapes. Their absence is therefore always unknown,
+never ``unofficial``. For direct Yearn V3 vaults only, the versioned `yDaemon
+source metadata <https://github.com/yearn/ydaemon/tree/main/data/meta/vaults>`__
+can identify an explicit static non-endorsement. A public-page match overrides
+that static result, covering freshly launched vaults before the source files
+catch up. These are website membership signals, not safety ratings or
+investment recommendations.
 
 Use ``scripts/erc-4626/migrate-yearn-vault-metadata.py`` to repair existing
 cached Yearn rows. It defaults to a non-mutating dry run and changes only the

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -14,7 +14,7 @@ import datetime
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnDetectedVaultMetadataMixin, create_yearn_vault_link
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnDetectedVaultMetadataMixin
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 #: Yearn TokenizedStrategy fee precision: 10_000 basis points is 100%.
@@ -97,15 +97,3 @@ class YearnCompounderVault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:  # noqa: PLR6301
         return INSTANT_WITHDRAWAL_PERIOD
-
-    def get_link(self, referral: str | None = None) -> str:
-        """Return the direct Yearn vault page.
-
-        :param referral:
-            Optional referral identifier, unsupported by Yearn.
-
-        :return:
-            Yearn vault URL for this chain and vault address.
-        """
-        del referral
-        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -14,10 +14,8 @@ import datetime
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import fetch_yearn_vault_endorsement
-from eth_defi.erc_4626.vault_protocol.yearn.vault import create_yearn_vault_link
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnDetectedVaultMetadataMixin, create_yearn_vault_link
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
-from eth_defi.vault.flag import NOT_IN_YEARN_FRONTEND, VaultFlag
 
 #: Yearn TokenizedStrategy fee precision: 10_000 basis points is 100%.
 PERFORMANCE_FEE_DENOMINATOR = 10_000
@@ -34,7 +32,7 @@ _PERFORMANCE_FEE_ABI = [
 ]
 
 
-class YearnCompounderVault(ERC4626Vault):
+class YearnCompounderVault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
     """Read fee data from Yearn TokenizedStrategy compounder vaults.
 
     These vaults expose a performance-fee percentage but no annual management,
@@ -99,37 +97,6 @@ class YearnCompounderVault(ERC4626Vault):
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:  # noqa: PLR6301
         return INSTANT_WITHDRAWAL_PERIOD
-
-    def get_flags(self) -> set[VaultFlag]:
-        """Add an exclusion flag to unendorsed Yearn compounder contracts.
-
-        Compounder classification identifies a Yearn TokenizedStrategy vault,
-        so an explicit unendorsed yDaemon result safely marks it as unofficial.
-
-        :return:
-            Existing flags plus :attr:`VaultFlag.unofficial` only
-            when Yearn explicitly does not endorse the vault.
-        """
-
-        flags = super().get_flags()
-        if fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False:
-            flags = set(flags)
-            flags.add(VaultFlag.unofficial)
-        return flags
-
-    def get_notes(self) -> str | None:
-        """Return manual notes before the Yearn endorsement warning.
-
-        :return:
-            Existing shared note, the unendorsed-Yearn note, or ``None``.
-        """
-
-        notes = super().get_notes()
-        if notes:
-            return notes
-        if fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False:
-            return NOT_IN_YEARN_FRONTEND
-        return None
 
     def get_link(self, referral: str | None = None) -> str:
         """Return the direct Yearn vault page.

--- a/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
@@ -51,7 +51,7 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
             abi_fname="yearn/YearnV3Vault.json",
         )
 
-    def has_custom_fees(self) -> bool:
+    def has_custom_fees(self) -> bool:  # noqa: PLR6301
         """Deposit/withdrawal fees.
 
         Yearn Morpho Compounder strategies do not charge deposit/withdrawal fees.
@@ -59,7 +59,20 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
         """
         return False
 
-    def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
+    def supports_yearn_unofficial_classification(self) -> bool:  # noqa: PLR6301
+        """Keep static yDaemon registry misses unknown for strategy adapters.
+
+        The static per-chain metadata does not comprehensively include Yearn
+        Morpho compounder strategies, so an absent entry is not evidence that
+        the strategy is unofficial.
+
+        :return:
+            Always ``False``.
+        """
+
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float:  # noqa: PLR6301
         """Get the current management fee as a percent.
 
         Yearn strategies internalise fees into the share price.
@@ -67,9 +80,10 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
         :return:
             0.0 as fees are built into share price
         """
+        del block_identifier
         return 0.0
 
-    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:  # noqa: PLR6301
         """Get the current performance fee as a percent.
 
         Yearn strategies internalise fees into the share price.
@@ -77,9 +91,10 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
         :return:
             0.0 as fees are built into share price
         """
+        del block_identifier
         return 0.0
 
-    def get_estimated_lock_up(self) -> datetime.timedelta:
+    def get_estimated_lock_up(self) -> datetime.timedelta:  # noqa: PLR6301
         """Get estimated lock-up period.
 
         No lock-up period for Yearn Morpho Compounder strategies.

--- a/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/morpho_compounder.py
@@ -13,7 +13,7 @@ from eth_typing import BlockIdentifier
 from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
-from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault, create_yearn_vault_link
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
 
 logger = logging.getLogger(__name__)
 
@@ -100,15 +100,3 @@ class YearnMorphoCompounderStrategy(YearnV3Vault):
         No lock-up period for Yearn Morpho Compounder strategies.
         """
         return datetime.timedelta(0)
-
-    def get_link(self, referral: str | None = None) -> str:
-        """Return the canonical current-Yearn frontend link for this vault.
-
-        :param referral:
-            Optional referral identifier, unsupported by Yearn.
-        :return:
-            Yearn vault URL for this chain and vault address.
-        """
-
-        del referral
-        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/eth_defi/erc_4626/vault_protocol/yearn/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/offchain_metadata.py
@@ -36,12 +36,12 @@ DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "yearn"
 #: Raw GitHub directory containing Yearn's versioned yDaemon chain documents.
 YEARN_YDAEMON_METADATA_BASE_URL = "https://raw.githubusercontent.com/yearn/ydaemon/main/data/meta/vaults"
 
-#: Live catalogue that powers Yearn's public vault pages. Unlike the static
-#: source repository, it contains recently launched vaults such as Flex USDC.
-YEARN_DETECTED_VAULTS_URL = "https://ydaemon.yearn.fi/vaults/detected?limit=2000"
-
 #: Maximum record count requested from the public detected-vault endpoint.
 YEARN_DETECTED_VAULTS_LIMIT = 2000
+
+#: Live catalogue that powers Yearn's public vault pages. Unlike the static
+#: source repository, it contains recently launched vaults such as Flex USDC.
+YEARN_DETECTED_VAULTS_URL = f"https://ydaemon.yearn.fi/vaults/detected?limit={YEARN_DETECTED_VAULTS_LIMIT}"
 
 #: Static catalogue metadata changes much less frequently than scanner cycles.
 DEFAULT_CACHE_DURATION = datetime.timedelta(days=1)
@@ -113,18 +113,56 @@ class YearnDetectedVaultMetadata:
     description: str | None
 
 
+#: Public catalogue records keyed by EVM chain ID and lowercase vault address.
+YearnDetectedVaultRecords = dict[tuple[int, str], YearnDetectedVaultMetadata]
+
+
+@dataclass(slots=True, frozen=True)
+class YearnDetectedVaultCatalogue:
+    """One public Yearn vault-page catalogue response.
+
+    A page hit is always positive evidence. A miss can support a negative
+    direct-V3 decision only when the response did not reach the requested
+    endpoint limit.
+
+    :param vaults:
+        Chain ID and lowercase address keyed public vault metadata.
+    :param is_complete:
+        Whether a catalogue miss is safe to use as negative evidence.
+    """
+
+    #: Chain ID and lowercase address keyed public vault metadata.
+    vaults: YearnDetectedVaultRecords
+
+    #: Whether a catalogue miss is safe to use as negative evidence.
+    is_complete: bool
+
+    def get(self, chain_id: int, vault_address: HexAddress) -> YearnDetectedVaultMetadata | None:
+        """Look up one vault's public-page metadata.
+
+        :param chain_id:
+            EVM chain ID of the vault.
+        :param vault_address:
+            Vault contract address.
+        :return:
+            Public metadata when Yearn lists a vault page, otherwise ``None``.
+        """
+
+        return self.vaults.get((chain_id, vault_address.lower()))
+
+
 @dataclass(slots=True, frozen=True)
 class CachedYearnDetectedVaultIndex:
     """One worker's cached public Yearn vault-page index.
 
-    :param vaults:
-        Chain ID and lowercase address keyed public vault metadata.
+    :param catalogue:
+        Public vault-page records and their completeness state.
     :param fetched_at:
         Naive UTC time when this worker last fetched the endpoint.
     """
 
-    #: Chain ID and lowercase address keyed public vault metadata.
-    vaults: dict[tuple[int, str], YearnDetectedVaultMetadata]
+    #: Public vault-page records and their completeness state.
+    catalogue: YearnDetectedVaultCatalogue
 
     #: Naive UTC time when this worker last fetched the endpoint.
     fetched_at: datetime.datetime
@@ -189,17 +227,17 @@ def _normalise_yearn_detected_description(description: object) -> str | None:
     return description
 
 
-def _parse_yearn_detected_vault_index(payload: object) -> dict[tuple[int, str], YearnDetectedVaultMetadata]:
+def _parse_yearn_detected_vault_index(payload: object) -> YearnDetectedVaultCatalogue:
     """Normalise the live detected-vault response into a public-page index.
 
-    A result exactly at the endpoint limit is still useful for positive hits,
-    but may be incomplete. Callers never infer unofficial status from a miss,
-    so truncation cannot create a false negative classification.
+    A result exactly at the endpoint limit remains useful for positive hits,
+    but is explicitly marked incomplete so callers never infer unofficial
+    status from a miss.
 
     :param payload:
         JSON-decoded detected-vault endpoint response.
     :return:
-        Chain ID and lowercase address keyed public vault metadata.
+        Public-page records and whether a miss is complete negative evidence.
     :raise ValueError:
         If the response does not have the expected list-of-vaults shape.
     """
@@ -210,7 +248,7 @@ def _parse_yearn_detected_vault_index(payload: object) -> dict[tuple[int, str], 
     if len(payload) >= YEARN_DETECTED_VAULTS_LIMIT:
         logger.warning("Yearn detected-vault response reached its limit of %d records; using it for positive matches only", len(payload))
 
-    index: dict[tuple[int, str], YearnDetectedVaultMetadata] = {}
+    index: YearnDetectedVaultRecords = {}
     for record in payload:
         if not isinstance(record, dict):
             continue
@@ -224,7 +262,7 @@ def _parse_yearn_detected_vault_index(payload: object) -> dict[tuple[int, str], 
     if not index:
         message = "Yearn detected-vault response must contain vault records"
         raise ValueError(message)
-    return index
+    return YearnDetectedVaultCatalogue(vaults=index, is_complete=len(payload) < YEARN_DETECTED_VAULTS_LIMIT)
 
 
 def _normalise_yearn_vault_metadata(metadata: dict[str, object]) -> YearnVaultMetadata:
@@ -389,7 +427,7 @@ _yearn_metadata_retry_after: dict[int, datetime.datetime] = {}
 _yearn_detected_vaults_state = YearnDetectedVaultCache()
 
 
-def fetch_yearn_detected_vaults() -> dict[tuple[int, str], YearnDetectedVaultMetadata] | None:
+def fetch_yearn_detected_vaults() -> YearnDetectedVaultCatalogue | None:
     """Fetch Yearn's public vault-page catalogue once per scanner worker.
 
     This endpoint is intentionally a positive-only source. A matching entry
@@ -406,29 +444,67 @@ def fetch_yearn_detected_vaults() -> dict[tuple[int, str], YearnDetectedVaultMet
     cached_index = _yearn_detected_vaults_state.index
     cache_is_fresh = cached_index is not None and now_ - cached_index.fetched_at <= DEFAULT_CACHE_DURATION
     if cache_is_fresh:
-        return cached_index.vaults
+        return cached_index.catalogue
 
     retry_after = _yearn_detected_vaults_state.retry_after
     if retry_after is not None and now_ < retry_after:
-        return cached_index.vaults if cached_index is not None else None
+        return cached_index.catalogue if cached_index is not None else None
 
     try:
         logger.info("Fetching Yearn public vault catalogue from %s", YEARN_DETECTED_VAULTS_URL)
         response = requests.get(YEARN_DETECTED_VAULTS_URL, timeout=30)
         response.raise_for_status()
-        index = _parse_yearn_detected_vault_index(response.json())
+        catalogue = _parse_yearn_detected_vault_index(response.json())
     except (HTTPError, RequestException, JSONDecodeError, ValueError) as error:
         _yearn_detected_vaults_state.retry_after = now_ + UNAVAILABLE_RETRY_DELAY
         if cached_index is not None:
             logger.warning("Could not refresh Yearn public vault catalogue: %s; using the previous cache", error)
-            return cached_index.vaults
+            return cached_index.catalogue
         logger.warning("Yearn public vault catalogue is unavailable: %s", error)
         return None
 
-    _yearn_detected_vaults_state.index = CachedYearnDetectedVaultIndex(vaults=index, fetched_at=now_)
+    _yearn_detected_vaults_state.index = CachedYearnDetectedVaultIndex(catalogue=catalogue, fetched_at=now_)
     _yearn_detected_vaults_state.retry_after = None
-    logger.info("Fetched %d Yearn public vault-page records", len(index))
-    return index
+    logger.info("Fetched %d Yearn public vault-page records (complete=%s)", len(catalogue.vaults), catalogue.is_complete)
+    return catalogue
+
+
+def resolve_yearn_vault_endorsement(
+    chain_id: int,
+    vault_address: HexAddress,
+    *,
+    static_endorsement: bool | None,
+    detected_vaults: YearnDetectedVaultCatalogue | None,
+) -> bool | None:
+    """Combine the public website and static yDaemon endorsement evidence.
+
+    A live public-page entry always establishes that a vault is official, even
+    if Yearn's static repository has not caught up. Otherwise both sources
+    must be available before a static non-endorsement can classify a direct V3
+    vault as unofficial. This helper intentionally does not decide whether an
+    adapter family is eligible for negative classification.
+
+    :param chain_id:
+        EVM chain ID of the vault.
+    :param vault_address:
+        Vault contract address.
+    :param static_endorsement:
+        Static yDaemon endorsement result, or ``None`` when unavailable.
+    :param detected_vaults:
+        Public-page catalogue, or ``None`` when unavailable.
+    :return:
+        ``True`` for a website-listed or statically endorsed vault, ``False``
+        for a confirmed static non-endorsement, and ``None`` when either source
+        is unavailable.
+    """
+
+    if detected_vaults is None:
+        return None
+    if detected_vaults.get(chain_id, vault_address) is not None:
+        return True
+    if not detected_vaults.is_complete:
+        return None
+    return static_endorsement
 
 
 def fetch_yearn_vault_endorsement(chain_id: int, vault_address: HexAddress) -> bool | None:

--- a/eth_defi/erc_4626/vault_protocol/yearn/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/offchain_metadata.py
@@ -14,6 +14,7 @@ fetch as unknown and do not exclude any vault on that basis.
 import datetime
 import json
 import logging
+import re
 from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
@@ -35,11 +36,21 @@ DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "yearn"
 #: Raw GitHub directory containing Yearn's versioned yDaemon chain documents.
 YEARN_YDAEMON_METADATA_BASE_URL = "https://raw.githubusercontent.com/yearn/ydaemon/main/data/meta/vaults"
 
+#: Live catalogue that powers Yearn's public vault pages. Unlike the static
+#: source repository, it contains recently launched vaults such as Flex USDC.
+YEARN_DETECTED_VAULTS_URL = "https://ydaemon.yearn.fi/vaults/detected?limit=2000"
+
+#: Maximum record count requested from the public detected-vault endpoint.
+YEARN_DETECTED_VAULTS_LIMIT = 2000
+
 #: Static catalogue metadata changes much less frequently than scanner cycles.
 DEFAULT_CACHE_DURATION = datetime.timedelta(days=1)
 
 #: Retry unavailable source metadata without making every vault trigger an HTTP request.
 UNAVAILABLE_RETRY_DELAY = datetime.timedelta(minutes=5)
+
+#: A listing summary must remain suitable for a compact vault-table cell.
+MAX_SHORT_DESCRIPTION_LENGTH = 200
 
 
 @dataclass(slots=True, frozen=True)
@@ -83,6 +94,137 @@ class CachedYearnVaultIndex:
 
     #: Naive UTC time when this worker last refreshed the index.
     fetched_at: datetime.datetime
+
+
+@dataclass(slots=True, frozen=True)
+class YearnDetectedVaultMetadata:
+    """Public Yearn catalogue metadata for one vault.
+
+    The detected-vault endpoint is used only as positive evidence that Yearn
+    publishes a vault page. Its omission of a contract is deliberately not a
+    classification decision: TokenizedStrategy and compounder adapters are not
+    exhaustively represented by that endpoint.
+
+    :param description:
+        Optional Yearn-authored strategy description suitable for export.
+    """
+
+    #: Optional Yearn-authored strategy description.
+    description: str | None
+
+
+@dataclass(slots=True, frozen=True)
+class CachedYearnDetectedVaultIndex:
+    """One worker's cached public Yearn vault-page index.
+
+    :param vaults:
+        Chain ID and lowercase address keyed public vault metadata.
+    :param fetched_at:
+        Naive UTC time when this worker last fetched the endpoint.
+    """
+
+    #: Chain ID and lowercase address keyed public vault metadata.
+    vaults: dict[tuple[int, str], YearnDetectedVaultMetadata]
+
+    #: Naive UTC time when this worker last fetched the endpoint.
+    fetched_at: datetime.datetime
+
+
+@dataclass(slots=True)
+class YearnDetectedVaultCache:
+    """Hold the mutable per-process state for the public vault catalogue.
+
+    :param index:
+        Most recently successful catalogue index.
+    :param retry_after:
+        Naive UTC time before a failed request may be retried.
+    """
+
+    #: Most recently successful catalogue index.
+    index: CachedYearnDetectedVaultIndex | None = None
+
+    #: Naive UTC time before a failed request may be retried.
+    retry_after: datetime.datetime | None = None
+
+
+def extract_yearn_short_description(description: str | None) -> str | None:
+    """Extract a bounded first sentence from a Yearn description.
+
+    Yearn descriptions are free-form Markdown and do not consistently use a
+    full stop followed by a space. A punctuation-aware split handles links and
+    newline-separated sentences, while a length limit prevents a malformed or
+    sentence-less source value from filling the website listing.
+
+    :param description:
+        Full description from Yearn's detected-vault endpoint.
+    :return:
+        First sentence when it fits the compact listing field, otherwise
+        ``None``.
+    """
+
+    if not description:
+        return None
+    sentence = re.split(r"(?<=[.!?])\s+", description.strip(), maxsplit=1)[0]
+    return sentence if len(sentence) <= MAX_SHORT_DESCRIPTION_LENGTH else None
+
+
+def _normalise_yearn_detected_description(description: object) -> str | None:
+    """Validate one public Yearn description before website export.
+
+    yDaemon sometimes returns template placeholders such as ``{{token}}``.
+    Their substitution context is not part of this endpoint, so omit those
+    records instead of displaying a misleading unresolved template.
+
+    :param description:
+        Raw endpoint description.
+    :return:
+        Trimmed exportable description, or ``None``.
+    """
+
+    if not isinstance(description, str):
+        return None
+    description = description.strip()
+    if not description or "{{" in description or "}}" in description:
+        return None
+    return description
+
+
+def _parse_yearn_detected_vault_index(payload: object) -> dict[tuple[int, str], YearnDetectedVaultMetadata]:
+    """Normalise the live detected-vault response into a public-page index.
+
+    A result exactly at the endpoint limit is still useful for positive hits,
+    but may be incomplete. Callers never infer unofficial status from a miss,
+    so truncation cannot create a false negative classification.
+
+    :param payload:
+        JSON-decoded detected-vault endpoint response.
+    :return:
+        Chain ID and lowercase address keyed public vault metadata.
+    :raise ValueError:
+        If the response does not have the expected list-of-vaults shape.
+    """
+
+    if not isinstance(payload, list):
+        message = "Yearn detected-vault response must be a list"
+        raise ValueError(message)
+    if len(payload) >= YEARN_DETECTED_VAULTS_LIMIT:
+        logger.warning("Yearn detected-vault response reached its limit of %d records; using it for positive matches only", len(payload))
+
+    index: dict[tuple[int, str], YearnDetectedVaultMetadata] = {}
+    for record in payload:
+        if not isinstance(record, dict):
+            continue
+        chain_id = record.get("chainID")
+        address = record.get("address")
+        if type(chain_id) is not int or not isinstance(address, str):
+            continue
+        index[chain_id, address.lower()] = YearnDetectedVaultMetadata(
+            description=_normalise_yearn_detected_description(record.get("description")),
+        )
+    if not index:
+        message = "Yearn detected-vault response must contain vault records"
+        raise ValueError(message)
+    return index
 
 
 def _normalise_yearn_vault_metadata(metadata: dict[str, object]) -> YearnVaultMetadata:
@@ -242,6 +384,51 @@ _cached_yearn_vaults: dict[int, CachedYearnVaultIndex] = {}
 
 #: Per-chain retry deadlines after a transient source failure.
 _yearn_metadata_retry_after: dict[int, datetime.datetime] = {}
+
+#: Per-process positive public-page index shared by all Yearn adapters.
+_yearn_detected_vaults_state = YearnDetectedVaultCache()
+
+
+def fetch_yearn_detected_vaults() -> dict[tuple[int, str], YearnDetectedVaultMetadata] | None:
+    """Fetch Yearn's public vault-page catalogue once per scanner worker.
+
+    This endpoint is intentionally a positive-only source. A matching entry
+    confirms that the vault appears on Yearn's website and can provide a
+    description. A missing entry remains unknown, including when the response
+    is capped at its server-side limit.
+
+    :return:
+        Public-page metadata keyed by chain ID and lowercase address, or
+        ``None`` when the endpoint is temporarily unavailable.
+    """
+
+    now_ = native_datetime_utc_now()
+    cached_index = _yearn_detected_vaults_state.index
+    cache_is_fresh = cached_index is not None and now_ - cached_index.fetched_at <= DEFAULT_CACHE_DURATION
+    if cache_is_fresh:
+        return cached_index.vaults
+
+    retry_after = _yearn_detected_vaults_state.retry_after
+    if retry_after is not None and now_ < retry_after:
+        return cached_index.vaults if cached_index is not None else None
+
+    try:
+        logger.info("Fetching Yearn public vault catalogue from %s", YEARN_DETECTED_VAULTS_URL)
+        response = requests.get(YEARN_DETECTED_VAULTS_URL, timeout=30)
+        response.raise_for_status()
+        index = _parse_yearn_detected_vault_index(response.json())
+    except (HTTPError, RequestException, JSONDecodeError, ValueError) as error:
+        _yearn_detected_vaults_state.retry_after = now_ + UNAVAILABLE_RETRY_DELAY
+        if cached_index is not None:
+            logger.warning("Could not refresh Yearn public vault catalogue: %s; using the previous cache", error)
+            return cached_index.vaults
+        logger.warning("Yearn public vault catalogue is unavailable: %s", error)
+        return None
+
+    _yearn_detected_vaults_state.index = CachedYearnDetectedVaultIndex(vaults=index, fetched_at=now_)
+    _yearn_detected_vaults_state.retry_after = None
+    logger.info("Fetched %d Yearn public vault-page records", len(index))
+    return index
 
 
 def fetch_yearn_vault_endorsement(chain_id: int, vault_address: HexAddress) -> bool | None:

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -13,7 +13,12 @@ from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
 from eth_defi.erc_4626.vault_protocol.yearn.notes import YEARN_VAULT_NOTES
-from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import fetch_yearn_vault_endorsement
+from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
+    YearnDetectedVaultMetadata,
+    extract_yearn_short_description,
+    fetch_yearn_detected_vaults,
+    fetch_yearn_vault_endorsement,
+)
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 from eth_defi.vault.flag import NOT_IN_YEARN_FRONTEND, VaultFlag
 
@@ -34,7 +39,53 @@ def create_yearn_vault_link(chain_id: int, vault_address: HexAddress) -> str:
     return f"https://yearn.fi/vaults/{chain_id}/{vault_address.lower()}"
 
 
-class YearnV3Vault(ERC4626Vault):
+class YearnDetectedVaultMetadataMixin:
+    """Expose positive Yearn website metadata for supported Yearn adapters.
+
+    The public detected-vault endpoint is not an exhaustive adapter registry.
+    It may confirm a page and provide its description, but its absence must
+    never mark a vault as unofficial.
+    """
+
+    @cached_property
+    def yearn_detected_vaults(self) -> dict[tuple[int, str], YearnDetectedVaultMetadata] | None:
+        """Fetch the public Yearn catalogue while preserving outage state.
+
+        :return:
+            Complete fetched catalogue, or ``None`` when temporarily
+            unavailable.
+        """
+
+        return fetch_yearn_detected_vaults()
+
+    @cached_property
+    def yearn_detected_metadata(self) -> YearnDetectedVaultMetadata | None:
+        """Get positive public Yearn metadata for this vault when it is listed.
+
+        :return:
+            Public-page metadata, or ``None`` when the vault is absent or the
+            catalogue is temporarily unavailable.
+        """
+
+        if self.get_protocol_name() != "Yearn" or self.yearn_detected_vaults is None:
+            return None
+        return self.yearn_detected_vaults.get((self.chain_id, self.vault_address.lower()))
+
+    @property
+    def description(self) -> str | None:
+        """Return the Yearn website description when it is safely exportable."""
+
+        metadata = self.yearn_detected_metadata
+        return metadata.description if metadata else None
+
+    @property
+    def short_description(self) -> str | None:
+        """Return the first bounded sentence of the Yearn website description."""
+
+        return extract_yearn_short_description(self.description)
+
+
+class YearnV3Vault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
     """Yearn V3 vaults.
 
     - Yearn V3 vaults are ERC-4626-compliant vaults with multiple strategies, built with Vyper (not Solidity)
@@ -244,10 +295,38 @@ class YearnV3Vault(ERC4626Vault):
         """
 
         flags = super().get_flags()
-        if self.get_protocol_name() == "Yearn" and fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False:
+        if self._is_dynamically_unofficial():
             flags = set(flags)
             flags.add(VaultFlag.unofficial)
         return flags
+
+    def _is_dynamically_unofficial(self) -> bool:
+        """Check whether both Yearn sources support an unofficial decision.
+
+        The public catalogue is a positive override for a lagging static
+        record. A catalogue outage remains unknown rather than allowing the
+        static miss to flag a recently launched public vault.
+
+        :return:
+            ``True`` only for a direct Yearn V3 vault with a complete public
+            catalogue, no public-page entry, and static non-endorsement.
+        """
+
+        if not self.supports_yearn_unofficial_classification() or self.get_protocol_name() != "Yearn":
+            return False
+        if self.yearn_detected_vaults is None or self.yearn_detected_metadata is not None:
+            return False
+        return fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False
+
+    def supports_yearn_unofficial_classification(self) -> bool:  # noqa: PLR6301
+        """State whether the static V3 registry can safely classify this adapter.
+
+        :return:
+            ``True`` for direct Yearn V3 vaults; strategy-derived adapters
+            override this to retain an unknown result for a registry miss.
+        """
+
+        return True
 
     def get_notes(self) -> str | None:
         """Return Yearn-specific notes for manually maintained vaults.
@@ -268,7 +347,7 @@ class YearnV3Vault(ERC4626Vault):
         if yearn_note:
             return yearn_note
 
-        if self.get_protocol_name() == "Yearn" and fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False:
+        if self._is_dynamically_unofficial():
             return NOT_IN_YEARN_FRONTEND
         return None
 

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -14,10 +14,12 @@ from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
 from eth_defi.erc_4626.vault_protocol.yearn.notes import YEARN_VAULT_NOTES
 from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
+    YearnDetectedVaultCatalogue,
     YearnDetectedVaultMetadata,
     extract_yearn_short_description,
     fetch_yearn_detected_vaults,
     fetch_yearn_vault_endorsement,
+    resolve_yearn_vault_endorsement,
 )
 from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 from eth_defi.vault.flag import NOT_IN_YEARN_FRONTEND, VaultFlag
@@ -48,12 +50,11 @@ class YearnDetectedVaultMetadataMixin:
     """
 
     @cached_property
-    def yearn_detected_vaults(self) -> dict[tuple[int, str], YearnDetectedVaultMetadata] | None:
+    def yearn_detected_vaults(self) -> YearnDetectedVaultCatalogue | None:
         """Fetch the public Yearn catalogue while preserving outage state.
 
         :return:
-            Complete fetched catalogue, or ``None`` when temporarily
-            unavailable.
+            Fetched catalogue, or ``None`` when temporarily unavailable.
         """
 
         return fetch_yearn_detected_vaults()
@@ -69,20 +70,40 @@ class YearnDetectedVaultMetadataMixin:
 
         if self.get_protocol_name() != "Yearn" or self.yearn_detected_vaults is None:
             return None
-        return self.yearn_detected_vaults.get((self.chain_id, self.vault_address.lower()))
+        return self.yearn_detected_vaults.get(self.chain_id, self.vault_address)
 
     @property
     def description(self) -> str | None:
-        """Return the Yearn website description when it is safely exportable."""
+        """Return the Yearn website description when it is safely exportable.
+
+        :return:
+            Yearn-authored description, or ``None`` when unavailable or unusable.
+        """
 
         metadata = self.yearn_detected_metadata
         return metadata.description if metadata else None
 
     @property
     def short_description(self) -> str | None:
-        """Return the first bounded sentence of the Yearn website description."""
+        """Return the first bounded sentence of the Yearn website description.
+
+        :return:
+            Compact Yearn-authored description, or ``None`` when unavailable.
+        """
 
         return extract_yearn_short_description(self.description)
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Return the canonical current-Yearn frontend link for this vault.
+
+        :param referral:
+            Ignored legacy referral parameter retained for compatibility.
+        :return:
+            Canonical Yearn vault-page URL.
+        """
+
+        del referral
+        return create_yearn_vault_link(self.chain_id, self.vault_address)
 
 
 class YearnV3Vault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
@@ -314,9 +335,18 @@ class YearnV3Vault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
 
         if not self.supports_yearn_unofficial_classification() or self.get_protocol_name() != "Yearn":
             return False
-        if self.yearn_detected_vaults is None or self.yearn_detected_metadata is not None:
+        detected_vaults = self.yearn_detected_vaults
+        if detected_vaults is None or self.yearn_detected_metadata is not None:
             return False
-        return fetch_yearn_vault_endorsement(self.chain_id, self.vault_address) is False
+        return (
+            resolve_yearn_vault_endorsement(
+                self.chain_id,
+                self.vault_address,
+                static_endorsement=fetch_yearn_vault_endorsement(self.chain_id, self.vault_address),
+                detected_vaults=detected_vaults,
+            )
+            is False
+        )
 
     def supports_yearn_unofficial_classification(self) -> bool:  # noqa: PLR6301
         """State whether the static V3 registry can safely classify this adapter.
@@ -350,9 +380,3 @@ class YearnV3Vault(YearnDetectedVaultMetadataMixin, ERC4626Vault):
         if self._is_dynamically_unofficial():
             return NOT_IN_YEARN_FRONTEND
         return None
-
-    def get_link(self, referral: str | None = None) -> str:
-        """Return the canonical current-Yearn frontend link for this vault."""
-
-        del referral
-        return create_yearn_vault_link(self.chain_id, self.vault_address)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -452,13 +452,15 @@ database or network changes.
 
 #### Yearn catalogue metadata migration
 
-`migrate-yearn-vault-metadata.py` refreshes the cached flags, descriptions and
-Yearn links for existing Yearn V3-family rows. It uses the public [yDaemon
-detected-vault catalogue](https://ydaemon.yearn.fi/vaults/detected?limit=2000)
-as a website-presence check: a returned address is not dynamically marked
-`unofficial`; an absent address is marked only after a complete catalogue is
-available. The result is not an endorsement or safety assessment. Hidden and
-retired metadata fields do not make an address unofficial.
+`migrate-yearn-vault-metadata.py` refreshes cached descriptions and Yearn links
+for existing Yearn V3-family rows. A match in the public [yDaemon detected-vault
+catalogue](https://ydaemon.yearn.fi/vaults/detected?limit=2000) positively
+confirms a public Yearn vault page, supplies its description and overrides a
+lagging static record. It never treats an absence as `unofficial`: the catalogue
+does not fully cover TokenizedStrategy, compounder, or Morpho compounder adapter
+shapes. Only direct Yearn V3 rows use the versioned static yDaemon metadata for
+the negative `unofficial` decision. The result is not an endorsement or safety
+assessment.
 
 Always inspect the non-mutating default first:
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -450,6 +450,27 @@ The scanner does not support whole-chain lead resets. `RESET_LEADS` has been
 removed and setting it causes `scan-vaults.py` to fail before it makes any
 database or network changes.
 
+#### Yearn catalogue metadata migration
+
+`migrate-yearn-vault-metadata.py` refreshes the cached flags, descriptions and
+Yearn links for existing Yearn V3-family rows. It uses the public [yDaemon
+detected-vault catalogue](https://ydaemon.yearn.fi/vaults/detected?limit=2000)
+as a website-presence check: a returned address is not dynamically marked
+`unofficial`; an absent address is marked only after a complete catalogue is
+available. The result is not an endorsement or safety assessment. Hidden and
+retired metadata fields do not make an address unofficial.
+
+Always inspect the non-mutating default first:
+
+```shell
+DRY_RUN=true poetry run python scripts/erc-4626/migrate-yearn-vault-metadata.py
+```
+
+Set `DRY_RUN=false` only to create a sibling backup and atomically update
+`vault-metadata-db.pickle`. The migration does not alter leads, reader state,
+or price Parquet files. Use `VAULT_DB_PATH` to choose a non-default metadata
+database.
+
 ### update-vault-links.py
 
 Metadata-only repair for persisted native vault-app links. The script selects

--- a/scripts/erc-4626/migrate-yearn-vault-metadata.py
+++ b/scripts/erc-4626/migrate-yearn-vault-metadata.py
@@ -39,11 +39,12 @@ from tabulate import tabulate
 
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
-    YearnDetectedVaultMetadata,
+    YearnDetectedVaultCatalogue,
     YearnVaultMetadata,
     extract_yearn_short_description,
     fetch_yearn_detected_vaults,
     fetch_yearn_vaults_file_for_chain,
+    resolve_yearn_vault_endorsement,
 )
 from eth_defi.erc_4626.vault_protocol.yearn.vault import create_yearn_vault_link
 from eth_defi.utils import setup_console_logging, wait_other_writers
@@ -112,7 +113,7 @@ class YearnVaultMetadataMigrationResult:
     :param updated_rows:
         Number of rows changed or proposed for change.
     :param unavailable_metadata_rows:
-        Direct V3 rows missing either required classification source.
+        Rows with at least one unavailable source required for their repair.
     :param skipped_rows:
         Persisted Yearn rows outside the adapter scope.
     :param updates:
@@ -125,7 +126,7 @@ class YearnVaultMetadataMigrationResult:
     #: Number of rows changed or proposed for change.
     updated_rows: int
 
-    #: Direct V3 rows missing either required classification source.
+    #: Rows with at least one unavailable source required for their repair.
     unavailable_metadata_rows: int
 
     #: Persisted Yearn rows outside the adapter scope.
@@ -263,7 +264,7 @@ def _plan_yearn_vault_metadata_update(
     spec: VaultSpec,
     row: VaultRow,
     index: dict[str, YearnVaultMetadata] | None,
-    detected_vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None,
+    detected_vaults: YearnDetectedVaultCatalogue | None,
 ) -> _YearnVaultMetadataPlan:
     """Calculate one Yearn row's current adapter-owned metadata fields.
 
@@ -273,6 +274,8 @@ def _plan_yearn_vault_metadata_update(
         Persisted vault metadata row in the fixed migration scope.
     :param index:
         yDaemon chain index, or ``None`` when temporarily unavailable.
+    :param detected_vaults:
+        Public Yearn catalogue, or ``None`` when temporarily unavailable.
     :return:
         Complete non-mutating row-update plan.
     :raises ValueError:
@@ -287,22 +290,29 @@ def _plan_yearn_vault_metadata_update(
     old_notes = row.get("_notes")
     new_notes = old_notes
     new_link = create_yearn_vault_link(spec.chain_id, spec.vault_address)
-    detected_metadata = detected_vaults.get((spec.chain_id, spec.vault_address.lower())) if detected_vaults is not None else None
+    detected_metadata = detected_vaults.get(spec.chain_id, spec.vault_address) if detected_vaults is not None else None
     new_description = row.get("_description")
     new_short_description = row.get("_short_description")
     if detected_metadata is not None:
         new_description = detected_metadata.description
         new_short_description = extract_yearn_short_description(detected_metadata.description)
+    elif detected_vaults is not None and detected_vaults.is_complete:
+        new_description = None
+        new_short_description = None
     endorsed: bool | None = None
     manually_unofficial = VaultFlag.unofficial in get_vault_special_flags(spec.vault_address, protocol_name=YEARN_PROTOCOL_NAME)
 
-    if _is_direct_yearn_v3_row(row) and detected_vaults is not None:
-        # A public-page match overrules a lagging static yDaemon source file.
-        if detected_metadata is not None:
-            endorsed = True
-        elif index is not None:
+    if _is_direct_yearn_v3_row(row):
+        static_endorsement = None
+        if index is not None:
             metadata = index.get(spec.vault_address.lower())
-            endorsed = metadata.endorsed if metadata is not None else False
+            static_endorsement = metadata.endorsed if metadata is not None else False
+        endorsed = resolve_yearn_vault_endorsement(
+            spec.chain_id,
+            spec.vault_address,
+            static_endorsement=static_endorsement,
+            detected_vaults=detected_vaults,
+        )
 
         if endorsed is True and not manually_unofficial:
             new_flags.discard(VaultFlag.unofficial)
@@ -346,7 +356,7 @@ def migrate_yearn_vault_metadata(
     metadata_by_chain: dict[int, dict[str, YearnVaultMetadata] | None],
     *,
     dry_run: bool,
-    detected_vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None = None,
+    detected_vaults: YearnDetectedVaultCatalogue | None = None,
 ) -> YearnVaultMetadataMigrationResult:
     """Apply current Yearn metadata fields to persisted adapter rows.
 
@@ -364,8 +374,7 @@ def migrate_yearn_vault_metadata(
     :param dry_run:
         Report changes without mutating ``vault_db`` when ``True``.
     :param detected_vaults:
-        Positive-only public Yearn catalogue, or ``None`` when temporarily
-        unavailable.
+        Public Yearn catalogue, or ``None`` when temporarily unavailable.
     :return:
         Target, change, unavailable-source, and skipped-row counts.
     :raises ValueError:
@@ -386,7 +395,10 @@ def migrate_yearn_vault_metadata(
 
         inspected_rows += 1
         index = metadata_by_chain.get(spec.chain_id)
-        if _is_direct_yearn_v3_row(row) and (index is None or detected_vaults is None):
+        detected_metadata = detected_vaults.get(spec.chain_id, spec.vault_address) if detected_vaults is not None else None
+        public_metadata_is_unavailable = detected_vaults is None or (not detected_vaults.is_complete and detected_metadata is None)
+        static_metadata_is_unavailable = _is_direct_yearn_v3_row(row) and index is None and detected_metadata is None
+        if public_metadata_is_unavailable or static_metadata_is_unavailable:
             unavailable_metadata_rows += 1
         plan = _plan_yearn_vault_metadata_update(spec, row, index, detected_vaults)
         if not plan.update.changed_fields:

--- a/scripts/erc-4626/migrate-yearn-vault-metadata.py
+++ b/scripts/erc-4626/migrate-yearn-vault-metadata.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Repair persisted Yearn links and yDaemon endorsement classification.
+"""Repair persisted Yearn links, descriptions, and safe classification.
 
 The normal scanner now uses `Yearn's yDaemon metadata
 <https://github.com/yearn/ydaemon/tree/main/data/meta/vaults>`__ to distinguish
-unendorsed Yearn V3-compatible contracts from official Yearn and
-Yearn-endorsed partner vaults. Existing rows need a metadata-only repair so
-their links, ``_flags`` and ``_notes`` match the current adapter behaviour.
+unendorsed direct Yearn V3-compatible contracts from official Yearn and
+Yearn-endorsed partner vaults. The public detected-vault catalogue confirms
+recent Yearn website entries and supplies descriptions. Existing rows need a
+metadata-only repair so their links, descriptions, ``_flags`` and ``_notes``
+match the current adapter behaviour.
 
 The fixed scope is persisted Yearn V3, TokenizedStrategy, compounder, and
 Morpho compounder rows. The script makes no RPC calls and does not modify
@@ -36,7 +38,13 @@ from tempfile import TemporaryDirectory
 from tabulate import tabulate
 
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import YearnVaultMetadata, fetch_yearn_vaults_file_for_chain
+from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
+    YearnDetectedVaultMetadata,
+    YearnVaultMetadata,
+    extract_yearn_short_description,
+    fetch_yearn_detected_vaults,
+    fetch_yearn_vaults_file_for_chain,
+)
 from eth_defi.erc_4626.vault_protocol.yearn.vault import create_yearn_vault_link
 from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.base import VaultSpec
@@ -48,10 +56,21 @@ logger = logging.getLogger(__name__)
 #: Persisted scanner protocol name for the fixed Yearn migration scope.
 YEARN_PROTOCOL_NAME = "Yearn"
 
-#: Adapter feature families whose current Yearn adapters own links and endorsement flags.
-YEARN_METADATA_FEATURES = frozenset(
+#: Adapter feature families whose current Yearn adapters own their Yearn links.
+YEARN_LINK_FEATURES = frozenset(
     {
         ERC4626Feature.yearn_v3_like,
+        ERC4626Feature.yearn_tokenised_strategy,
+        ERC4626Feature.yearn_compounder_like,
+        ERC4626Feature.yearn_morpho_compounder_like,
+    }
+)
+
+#: Only direct V3 vaults have a complete enough static registry for negative
+#: unofficial classification. TokenizedStrategy and compounder adapters must
+#: retain an unknown result when absent from it.
+YEARN_STRATEGY_FEATURES = frozenset(
+    {
         ERC4626Feature.yearn_tokenised_strategy,
         ERC4626Feature.yearn_compounder_like,
         ERC4626Feature.yearn_morpho_compounder_like,
@@ -93,7 +112,7 @@ class YearnVaultMetadataMigrationResult:
     :param updated_rows:
         Number of rows changed or proposed for change.
     :param unavailable_metadata_rows:
-        Target rows whose chain yDaemon metadata could not be loaded.
+        Direct V3 rows missing either required classification source.
     :param skipped_rows:
         Persisted Yearn rows outside the adapter scope.
     :param updates:
@@ -106,7 +125,7 @@ class YearnVaultMetadataMigrationResult:
     #: Number of rows changed or proposed for change.
     updated_rows: int
 
-    #: Target rows whose chain yDaemon metadata could not be loaded.
+    #: Direct V3 rows missing either required classification source.
     unavailable_metadata_rows: int
 
     #: Persisted Yearn rows outside the adapter scope.
@@ -131,6 +150,12 @@ class _YearnVaultMetadataPlan:
 
     #: Canonical Yearn frontend link to persist when the plan is applied.
     link: str
+
+    #: Yearn public-page description to persist when available.
+    description: str | None
+
+    #: Compact Yearn public-page description to persist when available.
+    short_description: str | None
 
 
 def parse_bool_env(name: str, *, default: bool) -> bool:
@@ -184,7 +209,20 @@ def _is_yearn_metadata_row(row: VaultRow) -> bool:
         ``True`` when the row is in the fixed Yearn adapter scope.
     """
 
-    return row.get("Protocol") == YEARN_PROTOCOL_NAME and bool(_get_row_features(row) & YEARN_METADATA_FEATURES)
+    return row.get("Protocol") == YEARN_PROTOCOL_NAME and bool(_get_row_features(row) & YEARN_LINK_FEATURES)
+
+
+def _is_direct_yearn_v3_row(row: VaultRow) -> bool:
+    """Check whether a row can use the static registry for a negative result.
+
+    :param row:
+        Persisted Yearn metadata row in migration scope.
+    :return:
+        ``True`` only for the direct Yearn V3 adapter family.
+    """
+
+    features = _get_row_features(row)
+    return ERC4626Feature.yearn_v3_like in features and not bool(features & YEARN_STRATEGY_FEATURES)
 
 
 def fetch_yearn_metadata_by_chain(chain_ids: set[int], cache_path: Path) -> dict[int, dict[str, YearnVaultMetadata] | None]:
@@ -225,6 +263,7 @@ def _plan_yearn_vault_metadata_update(
     spec: VaultSpec,
     row: VaultRow,
     index: dict[str, YearnVaultMetadata] | None,
+    detected_vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None,
 ) -> _YearnVaultMetadataPlan:
     """Calculate one Yearn row's current adapter-owned metadata fields.
 
@@ -248,20 +287,38 @@ def _plan_yearn_vault_metadata_update(
     old_notes = row.get("_notes")
     new_notes = old_notes
     new_link = create_yearn_vault_link(spec.chain_id, spec.vault_address)
+    detected_metadata = detected_vaults.get((spec.chain_id, spec.vault_address.lower())) if detected_vaults is not None else None
+    new_description = row.get("_description")
+    new_short_description = row.get("_short_description")
+    if detected_metadata is not None:
+        new_description = detected_metadata.description
+        new_short_description = extract_yearn_short_description(detected_metadata.description)
     endorsed: bool | None = None
+    manually_unofficial = VaultFlag.unofficial in get_vault_special_flags(spec.vault_address, protocol_name=YEARN_PROTOCOL_NAME)
 
-    if index is not None:
-        metadata = index.get(spec.vault_address.lower())
-        endorsed = metadata.endorsed if metadata is not None else False
-        manually_unofficial = VaultFlag.unofficial in get_vault_special_flags(spec.vault_address, protocol_name=YEARN_PROTOCOL_NAME)
-        if endorsed and not manually_unofficial:
+    if _is_direct_yearn_v3_row(row) and detected_vaults is not None:
+        # A public-page match overrules a lagging static yDaemon source file.
+        if detected_metadata is not None:
+            endorsed = True
+        elif index is not None:
+            metadata = index.get(spec.vault_address.lower())
+            endorsed = metadata.endorsed if metadata is not None else False
+
+        if endorsed is True and not manually_unofficial:
             new_flags.discard(VaultFlag.unofficial)
             if old_notes == NOT_IN_YEARN_FRONTEND:
                 new_notes = None
-        elif not endorsed and not manually_unofficial:
+        elif endorsed is False and not manually_unofficial:
             new_flags.add(VaultFlag.unofficial)
             if new_notes is None:
                 new_notes = NOT_IN_YEARN_FRONTEND
+    elif not _is_direct_yearn_v3_row(row) and not manually_unofficial:
+        # Prior releases applied the static registry to strategy-derived
+        # adapters. Remove the dynamic flag while retaining a separate manual
+        # note, which had priority over the old dynamic note.
+        new_flags.discard(VaultFlag.unofficial)
+        if old_notes == NOT_IN_YEARN_FRONTEND:
+            new_notes = None
 
     changed_fields = tuple(
         field
@@ -269,6 +326,8 @@ def _plan_yearn_vault_metadata_update(
             ("Link", row.get("Link"), new_link),
             ("_flags", old_flags, new_flags),
             ("_notes", old_notes, new_notes),
+            ("_description", row.get("_description"), new_description),
+            ("_short_description", row.get("_short_description"), new_short_description),
         )
         if old_value != new_value
     )
@@ -277,6 +336,8 @@ def _plan_yearn_vault_metadata_update(
         flags=new_flags,
         notes=new_notes,
         link=new_link,
+        description=new_description,
+        short_description=new_short_description,
     )
 
 
@@ -285,14 +346,16 @@ def migrate_yearn_vault_metadata(
     metadata_by_chain: dict[int, dict[str, YearnVaultMetadata] | None],
     *,
     dry_run: bool,
+    detected_vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None = None,
 ) -> YearnVaultMetadataMigrationResult:
     """Apply current Yearn metadata fields to persisted adapter rows.
 
-    Explicitly unendorsed rows gain ``VaultFlag.unofficial`` and its note;
-    Yearn-endorsed rows lose only the dynamically managed flag and note. Manual
+    Only direct V3 rows use a static yDaemon miss as an unofficial decision.
+    Strategy-derived rows keep a registry miss unknown; any old dynamic warning
+    from that overbroad rule is removed. A public detected-vault entry supplies
+    a description and positively overrides a lagging static source file. Manual
     address flags are never removed. Every selected row receives the current
-    deterministic Yearn frontend link even when its yDaemon metadata is
-    temporarily unavailable.
+    deterministic Yearn frontend link even when source metadata is unavailable.
 
     :param vault_db:
         Existing vault metadata database loaded from the production pickle.
@@ -300,6 +363,9 @@ def migrate_yearn_vault_metadata(
         Temporary yDaemon indices keyed by relevant chain ID.
     :param dry_run:
         Report changes without mutating ``vault_db`` when ``True``.
+    :param detected_vaults:
+        Positive-only public Yearn catalogue, or ``None`` when temporarily
+        unavailable.
     :return:
         Target, change, unavailable-source, and skipped-row counts.
     :raises ValueError:
@@ -320,9 +386,9 @@ def migrate_yearn_vault_metadata(
 
         inspected_rows += 1
         index = metadata_by_chain.get(spec.chain_id)
-        if index is None:
+        if _is_direct_yearn_v3_row(row) and (index is None or detected_vaults is None):
             unavailable_metadata_rows += 1
-        plan = _plan_yearn_vault_metadata_update(spec, row, index)
+        plan = _plan_yearn_vault_metadata_update(spec, row, index, detected_vaults)
         if not plan.update.changed_fields:
             continue
 
@@ -331,6 +397,8 @@ def migrate_yearn_vault_metadata(
             row["Link"] = plan.link
             row["_flags"] = plan.flags
             row["_notes"] = plan.notes
+            row["_description"] = plan.description
+            row["_short_description"] = plan.short_description
 
     return YearnVaultMetadataMigrationResult(
         inspected_rows=inspected_rows,
@@ -367,7 +435,8 @@ def main() -> None:
         chain_ids = {spec.chain_id for spec, row in vault_db.rows.items() if _is_yearn_metadata_row(row)}
         with TemporaryDirectory(prefix="yearn-ydaemon-") as temporary_directory:
             metadata_by_chain = fetch_yearn_metadata_by_chain(chain_ids, Path(temporary_directory))
-        result = migrate_yearn_vault_metadata(vault_db, metadata_by_chain, dry_run=dry_run)
+        detected_vaults = fetch_yearn_detected_vaults()
+        result = migrate_yearn_vault_metadata(vault_db, metadata_by_chain, dry_run=dry_run, detected_vaults=detected_vaults)
 
         report_rows = [
             {

--- a/tests/erc_4626/test_migrate_yearn_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_yearn_vault_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import YearnDetectedVaultMetadata, YearnVaultMetadata
+from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import YearnDetectedVaultCatalogue, YearnDetectedVaultMetadata, YearnVaultMetadata
 from eth_defi.erc_4626.vault_protocol.yearn.vault import create_yearn_vault_link
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import NOT_IN_YEARN_FRONTEND, VaultFlag
@@ -114,6 +114,24 @@ def create_ydaemon_index() -> dict[str, YearnVaultMetadata]:
     }
 
 
+def create_detected_catalogue(
+    vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None = None,
+    *,
+    is_complete: bool = True,
+) -> YearnDetectedVaultCatalogue:
+    """Create synthetic public Yearn catalogue metadata.
+
+    :param vaults:
+        Synthetic public vault-page metadata.
+    :param is_complete:
+        Whether a catalogue miss is reliable negative evidence.
+    :return:
+        Public Yearn catalogue used by migration tests.
+    """
+
+    return YearnDetectedVaultCatalogue(vaults=vaults or {}, is_complete=is_complete)
+
+
 def test_migrate_yearn_vault_metadata_updates_only_dynamic_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     """Update links and dynamic endorsement fields while preserving manual decisions."""
 
@@ -135,9 +153,11 @@ def test_migrate_yearn_vault_metadata_updates_only_dynamic_fields(monkeypatch: p
         get_manual_flags,
     )
 
-    detected_vaults = {
-        (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=FLEX_DESCRIPTION),
-    }
+    detected_vaults = create_detected_catalogue(
+        {
+            (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=FLEX_DESCRIPTION),
+        }
+    )
     result = module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=detected_vaults)
 
     assert result.inspected_rows == EXPECTED_TARGET_ROWS + 1
@@ -174,9 +194,42 @@ def test_migrate_yearn_vault_metadata_dry_run_and_missing_source_do_not_mutate()
     result = module.migrate_yearn_vault_metadata(vault_db, {1: None}, dry_run=True)
 
     assert result.inspected_rows == EXPECTED_TARGET_ROWS + 1
-    assert result.unavailable_metadata_rows == EXPECTED_TARGET_ROWS
+    assert result.unavailable_metadata_rows == EXPECTED_TARGET_ROWS + 1
     assert result.updated_rows == EXPECTED_TARGET_ROWS + 1
     assert vault_db.rows == original_rows
+
+
+def test_migrate_yearn_vault_metadata_reports_incomplete_catalogue_rows() -> None:
+    """Report rows whose public metadata may be beyond the endpoint limit."""
+
+    module = load_migration_module()
+    vault_db, _ = create_vault_database()
+    detected_vaults = create_detected_catalogue(
+        {
+            (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=FLEX_DESCRIPTION),
+        },
+        is_complete=False,
+    )
+
+    result = module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=True, detected_vaults=detected_vaults)
+
+    assert result.unavailable_metadata_rows == EXPECTED_TARGET_ROWS
+
+
+def test_migrate_yearn_vault_metadata_does_not_report_website_listed_rows_as_unavailable() -> None:
+    """Let a public page resolve a direct row when static metadata is unavailable."""
+
+    module = load_migration_module()
+    vault_db, _ = create_vault_database()
+    detected_vaults = create_detected_catalogue(
+        {
+            (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=FLEX_DESCRIPTION),
+        }
+    )
+
+    result = module.migrate_yearn_vault_metadata(vault_db, {1: None}, dry_run=True, detected_vaults=detected_vaults)
+
+    assert result.unavailable_metadata_rows == EXPECTED_TARGET_ROWS - 1
 
 
 def test_migrate_yearn_vault_metadata_removes_stale_strategy_flag_but_keeps_manual_note(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -188,7 +241,7 @@ def test_migrate_yearn_vault_metadata_removes_stale_strategy_flag_but_keeps_manu
     strategy_row["_notes"] = "Manual operational warning."
     monkeypatch.setattr(module, "get_vault_special_flags", lambda *_args, **_kwargs: set())
 
-    module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults={})
+    module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=create_detected_catalogue())
 
     assert strategy_row["_flags"] == set()
     assert strategy_row["_notes"] == "Manual operational warning."
@@ -202,11 +255,28 @@ def test_migrate_yearn_vault_metadata_clears_removed_public_description() -> Non
     row = vault_db.rows[VaultSpec(1, ENDORSED_PARTNER_VAULT)]
     row["_description"] = "Outdated description."
     row["_short_description"] = "Outdated description."
-    detected_vaults = {
-        (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=None),
-    }
+    detected_vaults = create_detected_catalogue(
+        {
+            (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=None),
+        }
+    )
 
     module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=detected_vaults)
+
+    assert row["_description"] is None
+    assert row["_short_description"] is None
+
+
+def test_migrate_yearn_vault_metadata_clears_delisted_description_from_complete_catalogue() -> None:
+    """Match scanner output when a complete Yearn catalogue no longer lists a vault."""
+
+    module = load_migration_module()
+    vault_db, _ = create_vault_database()
+    row = vault_db.rows[VaultSpec(1, ENDORSED_PARTNER_VAULT)]
+    row["_description"] = "Outdated description."
+    row["_short_description"] = "Outdated description."
+
+    module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=create_detected_catalogue())
 
     assert row["_description"] is None
     assert row["_short_description"] is None
@@ -221,7 +291,7 @@ def test_yearn_metadata_migration_main_creates_backup_only_when_applying(tmp_pat
     vault_db.write(vault_db_path)
     monkeypatch.setattr(module, "setup_console_logging", lambda **_kwargs: None)
     monkeypatch.setattr(module, "fetch_yearn_metadata_by_chain", lambda chain_ids, _cache_path: {chain_id: create_ydaemon_index() for chain_id in chain_ids})
-    monkeypatch.setattr(module, "fetch_yearn_detected_vaults", lambda: {})
+    monkeypatch.setattr(module, "fetch_yearn_detected_vaults", create_detected_catalogue)
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("VAULT_DB_PATH", str(vault_db_path))
     monkeypatch.setenv("DRY_RUN", "true")

--- a/tests/erc_4626/test_migrate_yearn_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_yearn_vault_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import YearnVaultMetadata
+from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import YearnDetectedVaultMetadata, YearnVaultMetadata
 from eth_defi.erc_4626.vault_protocol.yearn.vault import create_yearn_vault_link
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import NOT_IN_YEARN_FRONTEND, VaultFlag
@@ -17,6 +17,8 @@ ENDORSED_PARTNER_VAULT = "0x2222222222222222222222222222222222222222"
 MANUALLY_UNOFFICIAL_VAULT = "0x3333333333333333333333333333333333333333"
 EXPECTED_TARGET_ROWS = 3
 EXPECTED_SKIPPED_ROWS = 1
+STRATEGY_VAULT = "0x6666666666666666666666666666666666666666"
+FLEX_DESCRIPTION = "Flex USDC is an allocator vault managed by the Yearn Curation team. It lends USDC across several Flex markets."
 
 
 def load_migration_module():
@@ -68,6 +70,14 @@ def create_vault_database() -> tuple[VaultDatabase, VaultSpec]:
             "features": yearn_features,
             "_flags": {VaultFlag.unofficial},
             "_notes": "Manual warning.",
+        },
+        VaultSpec(1, STRATEGY_VAULT): {
+            "Protocol": "Yearn",
+            "Address": STRATEGY_VAULT,
+            "Link": "https://yearn.fi/vaults/old-route",
+            "features": {ERC4626Feature.yearn_compounder_like},
+            "_flags": {VaultFlag.unofficial},
+            "_notes": NOT_IN_YEARN_FRONTEND,
         },
         VaultSpec(1, "0x4444444444444444444444444444444444444444"): {
             "Protocol": "Yearn",
@@ -125,10 +135,13 @@ def test_migrate_yearn_vault_metadata_updates_only_dynamic_fields(monkeypatch: p
         get_manual_flags,
     )
 
-    result = module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False)
+    detected_vaults = {
+        (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=FLEX_DESCRIPTION),
+    }
+    result = module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=detected_vaults)
 
-    assert result.inspected_rows == EXPECTED_TARGET_ROWS
-    assert result.updated_rows == EXPECTED_TARGET_ROWS
+    assert result.inspected_rows == EXPECTED_TARGET_ROWS + 1
+    assert result.updated_rows == EXPECTED_TARGET_ROWS + 1
     assert result.unavailable_metadata_rows == 0
     assert result.skipped_rows == EXPECTED_SKIPPED_ROWS
     unendorsed_row = vault_db.rows[VaultSpec(1, UNENDORSED_VAULT)]
@@ -139,8 +152,13 @@ def test_migrate_yearn_vault_metadata_updates_only_dynamic_fields(monkeypatch: p
     assert partner_row["_flags"] == set()
     assert partner_row["_notes"] is None
     assert partner_row["Link"] == create_yearn_vault_link(1, ENDORSED_PARTNER_VAULT)
+    assert partner_row["_description"] == FLEX_DESCRIPTION
+    assert partner_row["_short_description"] == "Flex USDC is an allocator vault managed by the Yearn Curation team."
     assert vault_db.rows[manually_unofficial_spec]["_flags"] == {VaultFlag.unofficial}
     assert vault_db.rows[manually_unofficial_spec]["_notes"] == "Manual warning."
+    strategy_row = vault_db.rows[VaultSpec(1, STRATEGY_VAULT)]
+    assert strategy_row["_flags"] == set()
+    assert strategy_row["_notes"] is None
     assert vault_db.rows[unrelated_spec]["Link"] == "https://morpho.org/"
     assert vault_db.leads[unrelated_spec] is not None
     assert vault_db.last_scanned_block == {1: 23_000_000}
@@ -155,10 +173,43 @@ def test_migrate_yearn_vault_metadata_dry_run_and_missing_source_do_not_mutate()
 
     result = module.migrate_yearn_vault_metadata(vault_db, {1: None}, dry_run=True)
 
-    assert result.inspected_rows == EXPECTED_TARGET_ROWS
+    assert result.inspected_rows == EXPECTED_TARGET_ROWS + 1
     assert result.unavailable_metadata_rows == EXPECTED_TARGET_ROWS
-    assert result.updated_rows == EXPECTED_TARGET_ROWS
+    assert result.updated_rows == EXPECTED_TARGET_ROWS + 1
     assert vault_db.rows == original_rows
+
+
+def test_migrate_yearn_vault_metadata_removes_stale_strategy_flag_but_keeps_manual_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove the old adapter-owned flag even when a manual note had priority."""
+
+    module = load_migration_module()
+    vault_db, _ = create_vault_database()
+    strategy_row = vault_db.rows[VaultSpec(1, STRATEGY_VAULT)]
+    strategy_row["_notes"] = "Manual operational warning."
+    monkeypatch.setattr(module, "get_vault_special_flags", lambda *_args, **_kwargs: set())
+
+    module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults={})
+
+    assert strategy_row["_flags"] == set()
+    assert strategy_row["_notes"] == "Manual operational warning."
+
+
+def test_migrate_yearn_vault_metadata_clears_removed_public_description() -> None:
+    """Clear stale website copy when Yearn retains the page without a description."""
+
+    module = load_migration_module()
+    vault_db, _ = create_vault_database()
+    row = vault_db.rows[VaultSpec(1, ENDORSED_PARTNER_VAULT)]
+    row["_description"] = "Outdated description."
+    row["_short_description"] = "Outdated description."
+    detected_vaults = {
+        (1, ENDORSED_PARTNER_VAULT): YearnDetectedVaultMetadata(description=None),
+    }
+
+    module.migrate_yearn_vault_metadata(vault_db, {1: create_ydaemon_index()}, dry_run=False, detected_vaults=detected_vaults)
+
+    assert row["_description"] is None
+    assert row["_short_description"] is None
 
 
 def test_yearn_metadata_migration_main_creates_backup_only_when_applying(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
@@ -170,6 +221,7 @@ def test_yearn_metadata_migration_main_creates_backup_only_when_applying(tmp_pat
     vault_db.write(vault_db_path)
     monkeypatch.setattr(module, "setup_console_logging", lambda **_kwargs: None)
     monkeypatch.setattr(module, "fetch_yearn_metadata_by_chain", lambda chain_ids, _cache_path: {chain_id: create_ydaemon_index() for chain_id in chain_ids})
+    monkeypatch.setattr(module, "fetch_yearn_detected_vaults", lambda: {})
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("VAULT_DB_PATH", str(vault_db_path))
     monkeypatch.setenv("DRY_RUN", "true")

--- a/tests/erc_4626/vault_protocol/test_yearn_offchain_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_offchain_metadata.py
@@ -1,7 +1,7 @@
-"""Yearn yDaemon static metadata integration tests.
+"""Yearn yDaemon offchain metadata integration tests.
 
-Set ``RUN_YEARN_OFFCHAIN_METADATA_TEST=1`` to run the optional live GitHub
-check.  The remaining tests use a synthetic yDaemon document so they exercise
+Set ``RUN_YEARN_OFFCHAIN_METADATA_TEST=1`` to run the optional live yDaemon
+check. The remaining tests use synthetic yDaemon documents so they exercise
 the classification and cache semantics without a network dependency.
 """
 
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import eth_defi.erc_4626.vault_protocol.yearn.compounder as yearn_compounder_module
 import eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata as yearn_metadata
 import eth_defi.erc_4626.vault_protocol.yearn.vault as yearn_vault_module
 from eth_defi.compat import native_datetime_utc_now
@@ -19,8 +18,12 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.cap.vault import CAPVault
 from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
 from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
     CachedYearnVaultIndex,
+    YearnDetectedVaultCache,
+    YearnDetectedVaultMetadata,
+    extract_yearn_short_description,
     fetch_yearn_vault_endorsement,
     fetch_yearn_vaults_file_for_chain,
 )
@@ -35,6 +38,7 @@ OFFICIAL_YEARN_VAULT = "0x1111111111111111111111111111111111111111"
 ENDORSED_YEARN_PARTNER_VAULT = "0x2222222222222222222222222222222222222222"
 LIVE_OFFICIAL_YEARN_VAULT = "0x00c8a649c9837523ebb406ceb17a6378ab5c74cf"
 EXPECTED_CACHE_REFRESH_CALLS = 2
+FLEX_USDC_VAULT = "0x863687e4e9751b57f38b4b0eba04744c72d0f7b8"
 
 
 def _make_ydaemon_document() -> dict[str, object]:
@@ -212,31 +216,69 @@ def test_yearn_metadata_process_cache_refreshes_daily(monkeypatch: pytest.Monkey
     assert fetch_metadata.call_count == EXPECTED_CACHE_REFRESH_CALLS
 
 
-def test_unlisted_yearn_vaults_are_blacklisted_in_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Unendorsed Yearn vault adapters receive a bad scan flag.
+def test_yearn_detected_catalogue_is_cached_and_preserves_stale_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache public-page metadata and retain a successful index on refresh failure."""
 
-    1. Give both concrete Yearn adapters an authoritative exclusion result.
-    2. Confirm each adapter records the dedicated frontend-membership flag.
+    payload = [
+        {
+            "chainID": 1,
+            "address": FLEX_USDC_VAULT,
+            "description": "Flex USDC is an allocator vault managed by the Yearn Curation team.",
+        }
+    ]
+    response = MagicMock()
+    response.json.return_value = payload
+    requests_get = MagicMock(return_value=response)
+    monkeypatch.setattr(yearn_metadata.requests, "get", requests_get)
+    monkeypatch.setattr(yearn_metadata, "_yearn_detected_vaults_state", YearnDetectedVaultCache())
+    start = native_datetime_utc_now()
+    now_ = start
+    monkeypatch.setattr(yearn_metadata, "native_datetime_utc_now", lambda: now_)
+
+    first = yearn_metadata.fetch_yearn_detected_vaults()
+    second = yearn_metadata.fetch_yearn_detected_vaults()
+    assert first is not None
+    assert second == first
+    assert first[1, FLEX_USDC_VAULT].description == payload[0]["description"]
+    requests_get.assert_called_once_with(yearn_metadata.YEARN_DETECTED_VAULTS_URL, timeout=30)
+
+    now_ = start + yearn_metadata.DEFAULT_CACHE_DURATION + datetime.timedelta(seconds=1)
+    requests_get.side_effect = yearn_metadata.RequestException("temporary outage")
+    assert yearn_metadata.fetch_yearn_detected_vaults() == first
+
+
+def test_yearn_detected_catalogue_outage_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid repeated public catalogue requests while a cold cache is unavailable."""
+
+    requests_get = MagicMock(side_effect=yearn_metadata.RequestException("temporary outage"))
+    monkeypatch.setattr(yearn_metadata.requests, "get", requests_get)
+    monkeypatch.setattr(yearn_metadata, "_yearn_detected_vaults_state", YearnDetectedVaultCache())
+
+    assert yearn_metadata.fetch_yearn_detected_vaults() is None
+    assert yearn_metadata.fetch_yearn_detected_vaults() is None
+    requests_get.assert_called_once_with(yearn_metadata.YEARN_DETECTED_VAULTS_URL, timeout=30)
+
+
+def test_unlisted_direct_yearn_vaults_are_blacklisted_in_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unendorsed direct Yearn V3 vaults receive a bad scan flag.
+
+    1. Give the direct V3 adapter an authoritative exclusion result.
+    2. Confirm it records the dedicated frontend-membership flag.
     3. Confirm the generic metrics bad-flag policy turns that stored flag into
        the hard ``blacklisted`` technical-risk classification.
     """
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
-    monkeypatch.setattr(yearn_compounder_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     v3_vault = object.__new__(YearnV3Vault)
     v3_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
     v3_vault.features = {ERC4626Feature.yearn_v3_like}
-    compounder_vault = object.__new__(YearnCompounderVault)
-    compounder_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
-    compounder_vault.features = {ERC4626Feature.yearn_compounder_like}
 
-    # 1-2. Both concrete adapters capture the dynamic frontend decision.
+    # 1-2. The direct adapter captures the dynamic frontend decision.
     flags = v3_vault.get_flags()
     assert flags == {VaultFlag.unofficial}
     assert v3_vault.get_notes() == NOT_IN_YEARN_FRONTEND
-    assert compounder_vault.get_flags() == {VaultFlag.unofficial}
-    assert compounder_vault.get_notes() == NOT_IN_YEARN_FRONTEND
 
     # 3. BAD_FLAGS causes the exported technical risk to be hard blacklisted.
     risk, notes, checked_flags = apply_bad_flag_check(
@@ -249,11 +291,11 @@ def test_unlisted_yearn_vaults_are_blacklisted_in_metrics(monkeypatch: pytest.Mo
     assert checked_flags == flags
 
 
-def test_endorsed_yearn_partner_vaults_are_not_blacklisted(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_listed_yearn_vaults_and_strategy_adapters_are_not_blacklisted(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep Yearn-endorsed partner products out of the unofficial classification."""
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: True)
-    monkeypatch.setattr(yearn_compounder_module, "fetch_yearn_vault_endorsement", lambda *_args: True)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     v3_vault = object.__new__(YearnV3Vault)
     v3_vault.spec = VaultSpec(chain_id=1, vault_address=ENDORSED_YEARN_PARTNER_VAULT)
@@ -277,6 +319,7 @@ def test_unavailable_yearn_metadata_and_cap_vaults_are_not_blacklisted(monkeypat
     """
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: None)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: None)
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     yearn_vault = object.__new__(YearnV3Vault)
     yearn_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
@@ -288,11 +331,74 @@ def test_unavailable_yearn_metadata_and_cap_vaults_are_not_blacklisted(monkeypat
     cap_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
     cap_vault.features = {ERC4626Feature.cap_like}
     assert cap_vault.get_flags() == set()
+    assert cap_vault.description is None
+
+
+def test_yearn_website_listing_overrides_lagging_static_metadata_and_exports_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use a public Yearn page as positive evidence for Flex USDC.
+
+    A static source omission cannot leave a website-listed direct V3 vault
+    unofficial. The concise website summary must be the complete first
+    sentence, not a truncation at only a full-stop-plus-space sequence.
+    """
+
+    description = "Flex USDC is an allocator vault managed by the Yearn Curation team. It lends USDC across several Flex markets."
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {(1, FLEX_USDC_VAULT): YearnDetectedVaultMetadata(description=description)})
+    monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
+    vault = object.__new__(YearnV3Vault)
+    vault.spec = VaultSpec(chain_id=1, vault_address=FLEX_USDC_VAULT)
+    vault.features = {ERC4626Feature.yearn_v3_like}
+
+    assert vault.get_flags() == set()
+    assert vault.get_notes() is None
+    assert vault.description == description
+    assert vault.short_description == "Flex USDC is an allocator vault managed by the Yearn Curation team."
+
+
+def test_strategy_adapters_keep_static_catalogue_misses_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid unofficial flags for TokenizedStrategy and Morpho strategy adapters."""
+
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
+    monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
+    compounder_vault = object.__new__(YearnCompounderVault)
+    compounder_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
+    compounder_vault.features = {ERC4626Feature.yearn_compounder_like}
+    morpho_vault = object.__new__(YearnMorphoCompounderStrategy)
+    morpho_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
+    morpho_vault.features = {ERC4626Feature.yearn_morpho_compounder_like}
+
+    assert compounder_vault.get_flags() == set()
+    assert compounder_vault.get_notes() is None
+    assert morpho_vault.get_flags() == set()
+    assert morpho_vault.get_notes() is None
+
+
+def test_yearn_website_catalogue_outage_keeps_static_miss_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid flagging a recently launched website vault during a public API outage."""
+
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: None)
+    monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
+    vault = object.__new__(YearnV3Vault)
+    vault.spec = VaultSpec(chain_id=1, vault_address=FLEX_USDC_VAULT)
+    vault.features = {ERC4626Feature.yearn_v3_like}
+
+    assert vault.get_flags() == set()
+    assert vault.get_notes() is None
+
+
+def test_yearn_description_rejects_templates_and_long_sentence() -> None:
+    """Avoid malformed or oversized short descriptions from free-form metadata."""
+
+    assert yearn_metadata._normalise_yearn_detected_description("Earn {{token}} rewards.") is None
+    assert extract_yearn_short_description("A sentence without punctuation " * 20) is None
 
 
 @pytest.mark.skipif(os.environ.get("RUN_YEARN_OFFCHAIN_METADATA_TEST") != "1", reason="Set RUN_YEARN_OFFCHAIN_METADATA_TEST=1 to run the live yDaemon GitHub check")
-def test_live_yearn_static_metadata_confirms_endorsement_decisions(tmp_path) -> None:
-    """Check live positive and negative yDaemon endorsement decisions.
+def test_live_yearn_metadata_confirms_endorsement_and_flex_description(tmp_path) -> None:
+    """Check live static membership and the public Flex USDC description.
 
     This deliberately uses an isolated cache so a stale operator cache cannot
     hide an upstream source change.
@@ -307,3 +413,10 @@ def test_live_yearn_static_metadata_confirms_endorsement_decisions(tmp_path) -> 
     official_metadata = vaults[LIVE_OFFICIAL_YEARN_VAULT]
     assert official_metadata.endorsed is True
     assert official_metadata.is_yearn is True
+
+    detected_vaults = yearn_metadata.fetch_yearn_detected_vaults()
+    assert detected_vaults is not None
+    flex_metadata = detected_vaults[1, FLEX_USDC_VAULT]
+    assert flex_metadata.description is not None
+    assert flex_metadata.description.startswith("Flex USDC is an allocator vault")
+    assert extract_yearn_short_description(flex_metadata.description) == "Flex USDC is an allocator vault managed by the Yearn Curation team."

--- a/tests/erc_4626/vault_protocol/test_yearn_offchain_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_offchain_metadata.py
@@ -22,6 +22,7 @@ from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorpho
 from eth_defi.erc_4626.vault_protocol.yearn.offchain_metadata import (
     CachedYearnVaultIndex,
     YearnDetectedVaultCache,
+    YearnDetectedVaultCatalogue,
     YearnDetectedVaultMetadata,
     extract_yearn_short_description,
     fetch_yearn_vault_endorsement,
@@ -39,6 +40,24 @@ ENDORSED_YEARN_PARTNER_VAULT = "0x2222222222222222222222222222222222222222"
 LIVE_OFFICIAL_YEARN_VAULT = "0x00c8a649c9837523ebb406ceb17a6378ab5c74cf"
 EXPECTED_CACHE_REFRESH_CALLS = 2
 FLEX_USDC_VAULT = "0x863687e4e9751b57f38b4b0eba04744c72d0f7b8"
+
+
+def create_detected_catalogue(
+    vaults: dict[tuple[int, str], YearnDetectedVaultMetadata] | None = None,
+    *,
+    is_complete: bool = True,
+) -> YearnDetectedVaultCatalogue:
+    """Create synthetic public Yearn catalogue metadata.
+
+    :param vaults:
+        Synthetic public vault-page metadata.
+    :param is_complete:
+        Whether a catalogue miss is reliable negative evidence.
+    :return:
+        Public Yearn catalogue used by adapter tests.
+    """
+
+    return YearnDetectedVaultCatalogue(vaults=vaults or {}, is_complete=is_complete)
 
 
 def _make_ydaemon_document() -> dict[str, object]:
@@ -239,7 +258,8 @@ def test_yearn_detected_catalogue_is_cached_and_preserves_stale_data(monkeypatch
     second = yearn_metadata.fetch_yearn_detected_vaults()
     assert first is not None
     assert second == first
-    assert first[1, FLEX_USDC_VAULT].description == payload[0]["description"]
+    assert first.get(1, FLEX_USDC_VAULT).description == payload[0]["description"]
+    assert first.is_complete is True
     requests_get.assert_called_once_with(yearn_metadata.YEARN_DETECTED_VAULTS_URL, timeout=30)
 
     now_ = start + yearn_metadata.DEFAULT_CACHE_DURATION + datetime.timedelta(seconds=1)
@@ -259,6 +279,38 @@ def test_yearn_detected_catalogue_outage_retries_after_cooldown(monkeypatch: pyt
     requests_get.assert_called_once_with(yearn_metadata.YEARN_DETECTED_VAULTS_URL, timeout=30)
 
 
+def test_yearn_detected_catalogue_limit_keeps_misses_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mark an endpoint-limit response incomplete for negative classification."""
+
+    monkeypatch.setattr(yearn_metadata, "YEARN_DETECTED_VAULTS_LIMIT", 1)
+    catalogue = yearn_metadata._parse_yearn_detected_vault_index(
+        [
+            {
+                "chainID": 1,
+                "address": FLEX_USDC_VAULT,
+                "description": "Flex USDC is an allocator vault.",
+            }
+        ]
+    )
+
+    assert catalogue.is_complete is False
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, FLEX_USDC_VAULT, static_endorsement=False, detected_vaults=catalogue) is True
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, COINFLAKES_VAULT, static_endorsement=False, detected_vaults=catalogue) is None
+
+
+def test_yearn_endorsement_resolver_requires_both_catalogues_for_negative() -> None:
+    """Combine public website and static catalogue outcomes conservatively."""
+
+    listed_catalogue = create_detected_catalogue({(1, FLEX_USDC_VAULT): YearnDetectedVaultMetadata(description="Flex USDC is an allocator vault.")})
+    complete_empty_catalogue = create_detected_catalogue()
+
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, FLEX_USDC_VAULT, static_endorsement=False, detected_vaults=listed_catalogue) is True
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, COINFLAKES_VAULT, static_endorsement=True, detected_vaults=complete_empty_catalogue) is True
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, COINFLAKES_VAULT, static_endorsement=False, detected_vaults=complete_empty_catalogue) is False
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, COINFLAKES_VAULT, static_endorsement=None, detected_vaults=complete_empty_catalogue) is None
+    assert yearn_metadata.resolve_yearn_vault_endorsement(1, COINFLAKES_VAULT, static_endorsement=False, detected_vaults=None) is None
+
+
 def test_unlisted_direct_yearn_vaults_are_blacklisted_in_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     """Unendorsed direct Yearn V3 vaults receive a bad scan flag.
 
@@ -269,7 +321,7 @@ def test_unlisted_direct_yearn_vaults_are_blacklisted_in_metrics(monkeypatch: py
     """
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
-    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", create_detected_catalogue)
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     v3_vault = object.__new__(YearnV3Vault)
     v3_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
@@ -295,7 +347,7 @@ def test_listed_yearn_vaults_and_strategy_adapters_are_not_blacklisted(monkeypat
     """Keep Yearn-endorsed partner products out of the unofficial classification."""
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: True)
-    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", create_detected_catalogue)
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     v3_vault = object.__new__(YearnV3Vault)
     v3_vault.spec = VaultSpec(chain_id=1, vault_address=ENDORSED_YEARN_PARTNER_VAULT)
@@ -344,7 +396,11 @@ def test_yearn_website_listing_overrides_lagging_static_metadata_and_exports_des
 
     description = "Flex USDC is an allocator vault managed by the Yearn Curation team. It lends USDC across several Flex markets."
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
-    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {(1, FLEX_USDC_VAULT): YearnDetectedVaultMetadata(description=description)})
+    monkeypatch.setattr(
+        yearn_vault_module,
+        "fetch_yearn_detected_vaults",
+        lambda: create_detected_catalogue({(1, FLEX_USDC_VAULT): YearnDetectedVaultMetadata(description=description)}),
+    )
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     vault = object.__new__(YearnV3Vault)
     vault.spec = VaultSpec(chain_id=1, vault_address=FLEX_USDC_VAULT)
@@ -360,7 +416,7 @@ def test_strategy_adapters_keep_static_catalogue_misses_unknown(monkeypatch: pyt
     """Avoid unofficial flags for TokenizedStrategy and Morpho strategy adapters."""
 
     monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
-    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: {})
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", create_detected_catalogue)
     monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
     compounder_vault = object.__new__(YearnCompounderVault)
     compounder_vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
@@ -389,9 +445,25 @@ def test_yearn_website_catalogue_outage_keeps_static_miss_unknown(monkeypatch: p
     assert vault.get_notes() is None
 
 
+def test_incomplete_yearn_website_catalogue_keeps_static_miss_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid flagging a vault that could lie beyond the endpoint response limit."""
+
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_vault_endorsement", lambda *_args: False)
+    monkeypatch.setattr(yearn_vault_module, "fetch_yearn_detected_vaults", lambda: create_detected_catalogue(is_complete=False))
+    monkeypatch.setattr(ERC4626Vault, "get_flags", lambda _self: set())
+    vault = object.__new__(YearnV3Vault)
+    vault.spec = VaultSpec(chain_id=1, vault_address=COINFLAKES_VAULT)
+    vault.features = {ERC4626Feature.yearn_v3_like}
+
+    assert vault.get_flags() == set()
+    assert vault.get_notes() is None
+
+
 def test_yearn_description_rejects_templates_and_long_sentence() -> None:
     """Avoid malformed or oversized short descriptions from free-form metadata."""
 
+    assert yearn_metadata._normalise_yearn_detected_description(None) is None
+    assert yearn_metadata._normalise_yearn_detected_description("") is None
     assert yearn_metadata._normalise_yearn_detected_description("Earn {{token}} rewards.") is None
     assert extract_yearn_short_description("A sentence without punctuation " * 20) is None
 
@@ -416,7 +488,8 @@ def test_live_yearn_metadata_confirms_endorsement_and_flex_description(tmp_path)
 
     detected_vaults = yearn_metadata.fetch_yearn_detected_vaults()
     assert detected_vaults is not None
-    flex_metadata = detected_vaults[1, FLEX_USDC_VAULT]
+    flex_metadata = detected_vaults.get(1, FLEX_USDC_VAULT)
+    assert flex_metadata is not None
     assert flex_metadata.description is not None
     assert flex_metadata.description.startswith("Flex USDC is an allocator vault")
     assert extract_yearn_short_description(flex_metadata.description) == "Flex USDC is an allocator vault managed by the Yearn Curation team."


### PR DESCRIPTION
# Why

Flex USDC is present on Yearn's public website but absent from the lagging static yDaemon file, causing an incorrect unofficial flag. The static registry also does not comprehensively cover TokenizedStrategy, compounder, or Morpho compounder adapters.

# Lessons learnt

A live public-page match is positive evidence only: it overrides a static miss and supplies website copy. Its absence, or an endpoint outage, is unknown. Static absence is used only for direct Yearn V3 adapters, where the source is appropriate for that narrow negative decision.

# Summary

- Add a cached, positive-only yDaemon public catalogue source and safely extract Yearn descriptions and bounded short descriptions.
- Preserve direct-V3 static classification while preventing absence-based flags on strategy-shaped adapters; public-source outages fail open.
- Add a metadata-only migration that repairs canonical links, descriptions and stale dynamic flags without removing manual flags or notes.
- Document the source boundaries and migration semantics.

# Related issues and PRs

- Continues the Yearn yDaemon metadata work merged in #1558.

# Unrelated CI and test fixes

- None.