### PR TITLE
feat: add concise vault strategy categories and Morini FX tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Add concise public strategy-category descriptions and classify Morini Capital foreign-currency vaults with the new FX category (2026-09-11)
 - feat: Classify every Enzyme Blue and Onyx vault as discretionary trading by default and migrate cached tags (2026-09-08)
 - feat: Export documented vault strategy categories with quality-filtered TVL and one-month return aggregates, plus a local category-breakdown helper (2026-09-04)
 - feat: Add canonical signed per-period vault flow values, expose gross directional values and counts only from individually extracted events, estimate netted stablecoin ERC-4626 flows from daily vault states, and deprecate the legacy top-level netflow export (2026-08-31)

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -31,6 +31,7 @@ from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
+from eth_defi.vault.strategy_tag import StrategyTag, lookup_curator_strategy_tags
 
 logger = logging.getLogger(__name__)
 
@@ -553,6 +554,15 @@ class AccountableVault(ERC4626Vault):  # noqa: PLR0904
         if self.accountable_metadata:
             return self.accountable_metadata.get("short_description")
         return None
+
+    def get_strategy_tags(self) -> set[StrategyTag] | None:
+        """Return curator-maintained strategy tags for supported products.
+
+        :return:
+            Strategy tags for a reviewed curator product, otherwise ``None``.
+        """
+
+        return lookup_curator_strategy_tags(self.chain_id, self.address)
 
     @property
     def manager_name(self) -> str | None:

--- a/eth_defi/erc_4626/vault_protocol/morpho/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/tags.py
@@ -17,6 +17,12 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: - https://3f.xyz/
     #: - https://app.morpho.org/ethereum/vault/0xBEEf3f3A04e28895f3D5163d910474901981183D/3f-x-steakhouse-usdc
     "0xbeef3f3a04e28895f3d5163d910474901981183d": {StrategyTag.rwa, StrategyTag.rwa_lending},
+    #: Vault: Morini RLUSD Emerging Yield on Ethereum.
+    #: Added: 2026-09-11 from the public vault metadata database.
+    "0x810b29d043eb851ba4cf80b1b194ed5177e70958": {StrategyTag.fx},
+    #: Vault: Morini USDC Emerging Yield on Ethereum.
+    #: Added: 2026-09-11 from the public vault metadata database.
+    "0x58e0f0b81576f23c5f002d949b2bb11a5d2714d6": {StrategyTag.fx},
 }
 
 

--- a/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
@@ -27,6 +27,7 @@ from eth_defi.erc_4626.vault_protocol.t3tris.offchain_metadata import T3trisVaul
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int, convert_uint256_bytes_to_address
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import DEPOSIT_CLOSED_BY_ADMIN, VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.strategy_tag import StrategyTag, lookup_curator_strategy_tags
 
 logger = logging.getLogger(__name__)
 
@@ -611,6 +612,15 @@ class T3trisVault(ERC4626Vault):
         parts = [metadata.get("category"), metadata.get("rating")]
         parts.extend(metadata.get("attributes") or [])
         return ", ".join(part for part in parts if part) or None
+
+    def get_strategy_tags(self) -> set[StrategyTag] | None:
+        """Return curator-maintained strategy tags for supported products.
+
+        :return:
+            Strategy tags for a reviewed curator product, otherwise ``None``.
+        """
+
+        return lookup_curator_strategy_tags(self.chain_id, self.address)
 
     @property
     def manager_name(self) -> str | None:

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -30,6 +30,7 @@ from eth_defi.vault.flag import VaultFlag
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
 from eth_defi.vault.lower_case_dict import LowercaseDict
 from eth_defi.vault.price_source import PriceSource
+from eth_defi.vault.strategy_tag import StrategyTag, lookup_curator_strategy_tags
 
 MIDAS_HOMEPAGE = "https://midas.app/products"
 MIDAS_CONTRACTS_GITHUB = "https://github.com/midas-apps/contracts"
@@ -339,6 +340,15 @@ class MidasVault(VaultBase):
         if metadata:
             return metadata.short_description
         return self.product.short_description or "Midas tokenised investment product with NAV published through the Midas oracle pipeline"
+
+    def get_strategy_tags(self) -> set[StrategyTag] | None:
+        """Return curator-maintained strategy tags for supported Midas products.
+
+        :return:
+            Strategy tags for a reviewed curator product, otherwise ``None``.
+        """
+
+        return lookup_curator_strategy_tags(self.chain_id, self.address)
 
     @property
     def manager_name(self) -> str | None:

--- a/eth_defi/vault/strategy_tag.py
+++ b/eth_defi/vault/strategy_tag.py
@@ -72,6 +72,10 @@ class StrategyTag(str, enum.Enum):
     #: Example vault: pmalt (Hyperliquid).
     pair_trading = "pair_trading"
 
+    #: Trades foreign currencies.
+    #: Example vault: Morini FXArbUSDTRY (Accountable).
+    fx = "fx"
+
     #: Captures funding-rate differences, commonly between perpetual futures markets.
     #: Example vault: Extended and Nado arbitrage (Atoma).
     funding_rate_arbitrage = "funding_rate_arbitrage"
@@ -161,144 +165,189 @@ class StrategyTagMetadata(TypedDict):
     #: Human-readable category label without Markdown links.
     label: str
 
-    #: Exactly two sentences explaining the evidence-based tagging rule.
+    #: Short, plain-language summary of the investment activity.
     description: str
 
 
-#: Public presentation labels and category rules for every strategy tag.
+#: Public presentation labels and summaries for every strategy tag.
 #:
-#: Descriptions deliberately contain exactly two sentences so API consumers can
-#: display them consistently without having to truncate prose.
+#: Descriptions are deliberately brief so API consumers can display them in a
+#: summary table without truncating the activity being described.
 STRATEGY_TAG_METADATA: dict[StrategyTag, StrategyTagMetadata] = {
     StrategyTag.unknown: {
         "label": "Unknown strategy",
-        "description": "We use this tag only when research has explicitly established that the vault's strategy is unknown. It does not mean that an unresearched vault has been classified.",
+        "description": "The investment approach is unknown.",
     },
     StrategyTag.directional_trading: {
         "label": "Directional trading",
-        "description": "The vault takes [directional exposure](https://tradingstrategy.ai/glossary/directional-strategy) to one or more markets and can benefit or lose from their direction. We apply this tag when the documented strategy intentionally expresses such a market view.",
+        "description": "Takes [long or short positions](https://tradingstrategy.ai/glossary/directional-strategy) to profit from rising or falling markets.",
     },
     StrategyTag.directional_leverage: {
         "label": "Directional leverage",
-        "description": "The vault maintains a fixed leveraged long or short position in an underlying asset. We apply this tag when documented leverage creates direct directional exposure rather than reflecting a trading signal or execution method.",
+        "description": "Amplifies a fixed long or short position with borrowed capital.",
     },
     StrategyTag.trend_following: {
         "label": "Trend following",
-        "description": "The vault takes positions designed to follow sustained [market trends](https://tradingstrategy.ai/glossary/trend-following). We apply this tag when trend-following is documented as part of the investment process.",
+        "description": "Rides [sustained price movements](https://tradingstrategy.ai/glossary/trend-following), buying strength or selling weakness.",
     },
     StrategyTag.discretionary_trading: {
         "label": "Discretionary trading",
-        "description": "The vault uses a manager's [judgement](https://tradingstrategy.ai/glossary/discretionary-investment-management) to select or manage positions. We apply this tag when the strategy documentation identifies discretionary decision-making.",
+        "description": "A [human manager](https://tradingstrategy.ai/glossary/discretionary-investment-management) chooses and adjusts positions using judgement and market insight.",
     },
     StrategyTag.algorithmic_trading: {
         "label": "Algorithmic trading",
-        "description": "The vault uses [programmed rules](https://tradingstrategy.ai/glossary/algorithmic-trading) to select, execute, or manage positions. We apply this tag when automation is a documented part of the strategy rather than an implementation detail alone.",
+        "description": "[Software-driven rules](https://tradingstrategy.ai/glossary/algorithmic-trading) choose, execute and manage trades automatically.",
     },
     StrategyTag.arbitrage: {
         "label": "Arbitrage",
-        "description": "The vault seeks to capture price differences between markets or related instruments. We apply this tag when the manager or protocol documents arbitrage as a return source.",
+        "description": "Buys where prices are lower and sells where they are higher.",
     },
     StrategyTag.delta_neutral: {
         "label": "Delta neutral",
-        "description": "The vault seeks to offset [directional market exposure](https://tradingstrategy.ai/glossary/delta-neutral) while earning non-directional returns. We apply this tag when the strategy documents a delta-neutral or market-neutral construction.",
+        "description": "Balances [long and short exposure](https://tradingstrategy.ai/glossary/delta-neutral) to reduce the impact of market direction.",
     },
     StrategyTag.statistical_arbitrage: {
         "label": "Statistical arbitrage",
-        "description": "The vault trades quantitatively identified [pricing patterns](https://tradingstrategy.ai/glossary/statistical-arbitrage) or statistical relationships. We apply this tag when statistical arbitrage is documented rather than inferred from quantitative branding.",
+        "description": "Uses [statistical patterns](https://tradingstrategy.ai/glossary/statistical-arbitrage) to trade temporary pricing gaps between related markets.",
     },
     StrategyTag.mean_reversion: {
         "label": "Mean reversion",
-        "description": "The vault trades [price moves](https://tradingstrategy.ai/glossary/mean-reversion) expected to return towards an average or equilibrium. We apply this tag when mean reversion is explicitly described by the strategy.",
+        "description": "Trades on the expectation that [prices will return towards their usual range](https://tradingstrategy.ai/glossary/mean-reversion).",
     },
     StrategyTag.grid_trading: {
         "label": "Grid trading",
-        "description": "The vault places orders at predefined price intervals to trade a market range. We apply this tag when the manager documents a grid-based execution strategy.",
+        "description": "Places staggered buy and sell orders across a price range.",
     },
     StrategyTag.pair_trading: {
         "label": "Pair trading",
-        "description": "The vault trades the relative price of two related assets rather than a single asset's direction. We apply this tag when the strategy documents paired long and short exposure.",
+        "description": "Trades one related asset against another to profit from relative price changes.",
+    },
+    StrategyTag.fx: {
+        "label": "FX",
+        "description": "Trading related to foreign currencies.",
     },
     StrategyTag.funding_rate_arbitrage: {
         "label": "Funding-rate arbitrage",
-        "description": "The vault seeks to capture [funding-rate differences](https://tradingstrategy.ai/glossary/funding-rate), commonly across perpetual futures markets. We apply this tag when funding payments are a documented return source.",
+        "description": "Balances opposing futures positions to collect differences in recurring [funding payments](https://tradingstrategy.ai/glossary/funding-rate).",
     },
     StrategyTag.lending: {
         "label": "Lending",
-        "description": "The vault supplies assets to a [lending market](https://tradingstrategy.ai/glossary/lending-protocol) to earn interest. We apply this tag to documented lending strategies, including protocol-wide defaults where every supported vault is a lender.",
+        "description": "Supplies assets to [lending markets](https://tradingstrategy.ai/glossary/lending-protocol) and earns interest from borrowers.",
     },
     StrategyTag.lending_optimisation: {
         "label": "Lending optimisation",
-        "description": "The vault allocates supplied assets between lending opportunities to improve yield. We apply this tag when active lending allocation or optimisation is documented.",
+        "description": "Moves capital between lending markets to pursue the best available yield.",
     },
     StrategyTag.lending_looping: {
         "label": "Lending looping",
-        "description": "The vault borrows against supplied collateral to [recursively increase lending exposure](https://tradingstrategy.ai/glossary/recursive-looping). We apply this tag when the documented strategy uses a lending loop rather than simple lending.",
+        "description": "Repeatedly [borrows and resupplies assets](https://tradingstrategy.ai/glossary/recursive-looping) to amplify lending returns and risk.",
     },
     StrategyTag.market_making: {
         "label": "Market making",
-        "description": "The vault provides [executable liquidity](https://tradingstrategy.ai/glossary/market-making) to buyers and sellers. We apply this tag when the vault's documented strategy is to make markets rather than merely invest in a liquidity pool.",
+        "description": "Continuously [offers to buy and sell](https://tradingstrategy.ai/glossary/market-making), earning from the spread between prices.",
     },
     StrategyTag.liquidity_provider: {
         "label": "Liquidity provider",
-        "description": "The vault supplies capital to a venue or protocol as a [liquidity provider](https://tradingstrategy.ai/glossary/liquidity-provider). We apply this tag when the documented role is liquidity provision, including passive provision without active quoting.",
+        "description": "[Supplies capital that others can trade against](https://tradingstrategy.ai/glossary/liquidity-provider), earning fees or rewards.",
     },
     StrategyTag.market_maker: {
         "label": "Market maker",
-        "description": "The vault operates a strategy that quotes or supplies both sides of a market. We apply this tag when the documented activity is active market making.",
+        "description": "Actively quotes both buy and sell prices to keep a market liquid.",
     },
     StrategyTag.market_making_amm: {
         "label": "AMM market making",
-        "description": "The vault actively makes markets by supplying liquidity through an automated market maker. We apply this tag when the strategy itself performs market making on an AMM.",
+        "description": "Supplies assets to automated trading pools and earns a share of trading fees.",
     },
     StrategyTag.market_making_clob: {
         "label": "CLOB market making",
-        "description": "The vault provides liquidity through a central limit order book. We apply this tag when the strategy documents order-book market making.",
+        "description": "Posts buy and sell orders on an order book to earn trading spreads.",
     },
     StrategyTag.multistrategy: {
         "label": "Multi-strategy",
-        "description": "The vault combines multiple distinct investment strategies. We apply this tag only when the manager documents more than one strategy as part of the mandate.",
+        "description": "Combines several investment approaches within one portfolio.",
     },
     StrategyTag.index: {
         "label": "Index",
-        "description": "The vault tracks a predefined market or asset index in an index-fund style. We apply this tag when the documented objective is index exposure or replication.",
+        "description": "Tracks a defined basket of assets to mirror its overall market performance.",
     },
     StrategyTag.perpetual_futures: {
         "label": "Perpetual futures",
-        "description": "The vault trades [perpetual futures contracts](https://tradingstrategy.ai/glossary/perpetual-future). We apply this tag to documented perpetual-futures strategies and native perpetual-DEX defaults unless an explicit exception is maintained.",
+        "description": "Trades [futures contracts without an expiry date](https://tradingstrategy.ai/glossary/perpetual-future), often using leverage.",
     },
     StrategyTag.amm: {
         "label": "Automated market maker",
-        "description": "The vault uses an [automated market maker](https://tradingstrategy.ai/glossary/amm) as its liquidity venue. We apply this tag for AMM venue exposure even when the vault is not itself an active market-making strategy.",
+        "description": "Trades or supplies liquidity through [pools where prices adjust automatically](https://tradingstrategy.ai/glossary/amm).",
     },
     StrategyTag.rwa: {
         "label": "Real-world assets",
-        "description": "The vault invests in [real-world assets](https://tradingstrategy.ai/glossary/rwa) or their tokenised representations. We apply this tag when the underlying exposure is documented as real-world assets.",
+        "description": "Invests in [tokenised claims on assets and income from outside crypto markets](https://tradingstrategy.ai/glossary/rwa).",
     },
     StrategyTag.rwa_credit: {
         "label": "RWA credit",
-        "description": "The vault provides credit backed by real-world assets. We apply this tag when the strategy documents real-world asset collateral or credit exposure.",
+        "description": "Finances loans secured by property, invoices or other real-world assets.",
     },
     StrategyTag.rwa_lending: {
         "label": "RWA lending",
-        "description": "The vault lends against real-world assets. We apply this tag when the documented lending strategy has real-world asset exposure.",
+        "description": "Lends money to real-world borrowers or against real-world collateral.",
     },
     StrategyTag.rwa_royalties: {
         "label": "RWA royalties",
-        "description": "The vault invests in real-world royalty streams. We apply this tag when the documented assets are contractual royalty payments.",
+        "description": "Buys rights to income from music, media or other royalty streams.",
     },
     StrategyTag.money_market_fund: {
         "label": "Money-market fund",
-        "description": "The vault invests in money-market instruments. We apply this tag when the documented mandate is a money-market fund or equivalent cash-management product.",
+        "description": "Holds short-term, highly liquid debt instruments for steady income.",
     },
     StrategyTag.venture_funding: {
         "label": "Venture funding",
-        "description": "The vault invests in early-stage companies or projects in a venture-capital style. We apply this tag when the documented mandate is venture funding rather than public-market exposure.",
+        "description": "Backs early-stage companies or projects in pursuit of long-term growth.",
     },
     StrategyTag.carry_trade: {
         "label": "Carry trade",
-        "description": "The vault seeks return from the [carry](https://tradingstrategy.ai/glossary/carry-trade) of an asset or position. We apply this tag when carry is a documented return source, including cash-and-carry structures.",
+        "description": "Earns [recurring income from holding assets or balancing related positions](https://tradingstrategy.ai/glossary/carry-trade).",
     },
 }
+
+
+#: Morini Capital manages foreign-currency strategies across several vault
+#: protocols. These chain-scoped addresses were reviewed from the public vault
+#: metadata database on 2026-09-11.
+MORINI_CAPITAL_STRATEGY_TAGS = frozenset({StrategyTag.fx})
+
+#: Chain-scoped classifications that follow a curator across vault protocols.
+CURATOR_STRATEGY_TAGS: dict[tuple[int, str], frozenset[StrategyTag]] = {
+    #: Accountable: https://piku.co/vaults/detail/aFXArbUSDTRY
+    (1, "0x99351baed3d8ab544ccb08af96a105910fda71e7"): MORINI_CAPITAL_STRATEGY_TAGS,
+    #: Midas: https://piku.co/vaults/detail/StockMarketTRBasisTrade
+    (1, "0x827ce7e8e35861d9ac7fe002755767b695a5594a"): MORINI_CAPITAL_STRATEGY_TAGS,
+    #: Midas: https://piku.co/vaults/detail/CarryTradeUSDTRYLeverage
+    (1, "0x2bf11d2e04bc40daa95c24b8b90ec4f5c57dd326"): MORINI_CAPITAL_STRATEGY_TAGS,
+    #: Morpho: Morini RLUSD Emerging Yield
+    (1, "0x810b29d043eb851ba4cf80b1b194ed5177e70958"): MORINI_CAPITAL_STRATEGY_TAGS,
+    #: Morpho: Morini USDC Emerging Yield
+    (1, "0x58e0f0b81576f23c5f002d949b2bb11a5d2714d6"): MORINI_CAPITAL_STRATEGY_TAGS,
+    #: T3tris: Morini StockMarketTRBasisTrade Vault
+    (4663, "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672"): MORINI_CAPITAL_STRATEGY_TAGS,
+}
+
+
+def lookup_curator_strategy_tags(chain_id: int, address: str) -> set[StrategyTag] | None:
+    """Look up a cross-protocol curator classification.
+
+    Curator classifications are chain-scoped because the same contract address
+    can identify unrelated deployments on different EVM networks. Returning a
+    fresh set prevents callers from mutating the maintained source mapping.
+
+    :param chain_id:
+        EVM chain identifier.
+    :param address:
+        Vault contract or share-token address.
+    :return:
+        Curator-maintained strategy tags, or ``None`` when no mapping exists.
+    """
+
+    tags = CURATOR_STRATEGY_TAGS.get((chain_id, address.lower()))
+    return set(tags) if tags is not None else None
 
 
 def lookup_strategy_tags(

--- a/scripts/erc-4626/migrate-vault-strategy-tags.py
+++ b/scripts/erc-4626/migrate-vault-strategy-tags.py
@@ -66,7 +66,7 @@ from eth_defi.tokenised_fund.securitize.tags import STRATEGY_TAGS as SECURITIZE_
 from eth_defi.tokenised_fund.spiko.tags import STRATEGY_TAGS as SPIKO_STRATEGY_TAGS
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.strategy_tag import StrategyTag, lookup_strategy_tags
+from eth_defi.vault.strategy_tag import StrategyTag, lookup_curator_strategy_tags, lookup_strategy_tags
 from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -373,6 +373,7 @@ def resolve_strategy_tags(spec: VaultSpec, row: VaultRow) -> tuple[set[StrategyT
         row lacks usable detection metadata or a maintained resolver.
     """
 
+    curator_tags = lookup_curator_strategy_tags(spec.chain_id, spec.vault_address)
     detection = row.get("_detection_data")
     if not isinstance(detection, ERC4262VaultDetection):
         return None
@@ -381,22 +382,29 @@ def resolve_strategy_tags(spec: VaultSpec, row: VaultRow) -> tuple[set[StrategyT
     native_feature = next((feature for feature in NATIVE_STRATEGY_TAG_RESOLVERS if feature in detection.features), None)
     native_resolver = NATIVE_STRATEGY_TAG_RESOLVERS.get(native_feature) if native_feature is not None else None
     if native_resolver is not None:
-        return native_resolver(spec.vault_address), f"{protocol_name} native resolver"
+        return native_resolver(spec.vault_address) | (curator_tags or set()), f"{protocol_name} native resolver"
 
     evm_feature = next((feature for feature in EVM_ADAPTER_FEATURE_PRIORITY if feature in detection.features), None)
     if evm_feature is None:
+        if curator_tags is not None:
+            return curator_tags, f"{protocol_name} curator tag resolver"
         # Do not clear a manually persisted classification merely because this
         # migration has not yet learned about the adapter.
         return None
 
     evm_resolver = EVM_STRATEGY_TAG_RESOLVERS.get(evm_feature)
     if evm_resolver is None:
+        if curator_tags is not None:
+            return curator_tags, f"{protocol_name} curator tag resolver"
         # The scanner will instantiate the higher-priority adapter, but this
         # migration deliberately does not construct adapters or make RPC calls.
         # Preserve any existing manual tags until a direct resolver is added.
         return None
 
-    return evm_resolver(spec.vault_address), f"{protocol_name} tag resolver"
+    adapter_tags = evm_resolver(spec.vault_address)
+    if curator_tags is not None:
+        adapter_tags = (adapter_tags or set()) | curator_tags
+    return adapter_tags, f"{protocol_name} tag resolver"
 
 
 def collect_strategy_tag_updates(vault_db: VaultDatabase) -> tuple[tuple[StrategyTagUpdate, ...], int, int]:

--- a/tests/erc_4626/test_migrate_vault_strategy_tags.py
+++ b/tests/erc_4626/test_migrate_vault_strategy_tags.py
@@ -286,6 +286,38 @@ def test_migrate_vault_strategy_tags_resolves_liquid_royalty_rows() -> None:
     assert result == ({StrategyTag.rwa_royalties}, "Liquid Royalty tag resolver")
 
 
+@pytest.mark.parametrize(
+    ("chain_id", "address", "feature", "expected_tags"),
+    (
+        (1, "0x99351baed3d8ab544ccb08af96a105910fda71e7", ERC4626Feature.accountable_like, {StrategyTag.fx}),
+        (1, "0x827ce7e8e35861d9ac7fe002755767b695a5594a", ERC4626Feature.midas_like, {StrategyTag.fx}),
+        (1, "0x2bf11d2e04bc40daa95c24b8b90ec4f5c57dd326", ERC4626Feature.midas_like, {StrategyTag.fx}),
+        (1, "0x810b29d043eb851ba4cf80b1b194ed5177e70958", ERC4626Feature.morpho_v2_like, {StrategyTag.fx, StrategyTag.lending}),
+        (1, "0x58e0f0b81576f23c5f002d949b2bb11a5d2714d6", ERC4626Feature.morpho_v2_like, {StrategyTag.fx, StrategyTag.lending}),
+        (4663, "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672", ERC4626Feature.t3tris_like, {StrategyTag.fx}),
+    ),
+)
+def test_migrate_vault_strategy_tags_resolves_morini_capital_rows(
+    chain_id: int,
+    address: str,
+    feature: ERC4626Feature,
+    expected_tags: set[StrategyTag],
+) -> None:
+    """Every Morini Capital row found in the public database receives FX."""
+
+    migration = load_migration_module()
+    spec = VaultSpec(chain_id, address)
+    row = {
+        "_detection_data": create_detection(spec, {feature}),
+    }
+
+    result = migration.resolve_strategy_tags(spec, row)
+
+    assert result is not None
+    tags, _source = result
+    assert tags == expected_tags
+
+
 def test_migrate_vault_strategy_tags_resolves_enzyme_blue_rows() -> None:
     """Enzyme Blue rows use the shared default and documented tag mapping."""
 

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -235,12 +235,18 @@ def test_strategy_category_export_excludes_stale_records() -> None:
     assert categories["lending"]["one_month_apy"] == 0.10
 
 
-def test_strategy_tag_metadata_covers_every_tag_with_two_sentences() -> None:
+def test_strategy_tag_metadata_covers_every_tag_with_short_descriptions() -> None:
     """Keep the public category catalogue complete and concise."""
+    max_description_length = 100
+
     assert set(STRATEGY_TAG_METADATA) == set(StrategyTag)
     assert all(metadata["label"] and "[" not in metadata["label"] for metadata in STRATEGY_TAG_METADATA.values())
-    descriptions_without_markdown_links = (re.sub(r"\]\([^)]*\)", "]", metadata["description"]) for metadata in STRATEGY_TAG_METADATA.values())
-    assert all(description.count(".") == 2 for description in descriptions_without_markdown_links)
+    descriptions = [re.sub(r"\]\([^)]*\)", "]", metadata["description"]) for metadata in STRATEGY_TAG_METADATA.values()]
+    assert all(description.count(".") == 1 for description in descriptions)
+    assert all(len(description) <= max_description_length for description in descriptions)
+    assert all("the vault" not in description.lower() and "this vault" not in description.lower() for description in descriptions)
+    assert all("we " not in description.lower() for description in descriptions)
+    assert all("documented assets" not in description.lower() for description in descriptions)
 
 
 def test_strategy_category_export_skips_a_tag_without_current_catalogue_metadata(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/erc_4626/vault_protocol/test_lending_strategy_tags.py
+++ b/tests/erc_4626/vault_protocol/test_lending_strategy_tags.py
@@ -51,3 +51,22 @@ def test_3f_steakhouse_usdc_has_rwa_lending_tags() -> None:
         StrategyTag.rwa,
         StrategyTag.rwa_lending,
     }
+
+
+@pytest.mark.parametrize(
+    "address",
+    (
+        "0x810b29d043eb851ba4cf80b1b194ed5177e70958",
+        "0x58e0f0b81576f23c5f002d949b2bb11a5d2714d6",
+    ),
+)
+def test_morini_morpho_vaults_have_fx_and_lending_tags(address: str) -> None:
+    """Morini's Morpho products retain lending alongside their FX activity."""
+
+    vault = _make_vault(MorphoV2Vault)
+    vault.vault_address = HexAddress(address)
+
+    assert vault.get_strategy_tags() == {
+        StrategyTag.fx,
+        StrategyTag.lending,
+    }

--- a/tests/erc_4626/vault_protocol/test_strategy_tags.py
+++ b/tests/erc_4626/vault_protocol/test_strategy_tags.py
@@ -1,16 +1,23 @@
 """Tests for maintained vault strategy classifications."""
 
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
 from eth_typing import HexAddress
 
 from eth_defi.enzyme.onyx_vault import EnzymeVault
+from eth_defi.erc_4626.vault_protocol.accountable.vault import AccountableVault
 from eth_defi.erc_4626.vault_protocol.atoma.vault import ATOMA_VAULT_2_ADDRESS, ATOMA_VAULT_ADDRESS, AtomaVault
 from eth_defi.erc_4626.vault_protocol.axis.constants import AXIS_ETHEREUM_STAKED_USDX_VAULT
 from eth_defi.erc_4626.vault_protocol.axis.vault import AxisVault
 from eth_defi.erc_4626.vault_protocol.ethena.vault import EthenaVault
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
 from eth_defi.erc_4626.vault_protocol.symbiotic.vault import SymbioticVault
+from eth_defi.erc_4626.vault_protocol.t3tris.vault import T3trisVault
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
 from eth_defi.erc_4626.vault_protocol.yieldnest.vault import YNRWAX_VAULT_ADDRESS, YieldNestVault
+from eth_defi.midas.vault import MidasVault
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.strategy_tag import StrategyTag
 
@@ -180,3 +187,24 @@ def test_missing_strategy_tags_return_none() -> None:
 
     assert vault.get_strategy_tags() is None
     assert VaultBase.get_strategy_tags(vault) is None
+
+
+@pytest.mark.parametrize(
+    ("resolver", "chain_id", "address"),
+    (
+        (AccountableVault.get_strategy_tags, 1, "0x99351baed3d8ab544ccb08af96a105910fda71e7"),
+        (MidasVault.get_strategy_tags, 1, "0x827ce7e8e35861d9ac7fe002755767b695a5594a"),
+        (MidasVault.get_strategy_tags, 1, "0x2bf11d2e04bc40daa95c24b8b90ec4f5c57dd326"),
+        (T3trisVault.get_strategy_tags, 4663, "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672"),
+    ),
+)
+def test_morini_capital_adapters_return_fx_strategy_tag(
+    resolver: Callable[[object], set[StrategyTag] | None],
+    chain_id: int,
+    address: str,
+) -> None:
+    """Non-Morpho Morini products expose FX through their scan adapters."""
+
+    vault = SimpleNamespace(chain_id=chain_id, address=HexAddress(address))
+
+    assert resolver(vault) == {StrategyTag.fx}


### PR DESCRIPTION
## Why

Strategy-category descriptions are displayed in compact public summary tables, but the existing two-sentence copy mixed user-facing explanations with internal classification policy. Morini Capital's foreign-currency products also lacked a dedicated FX category across their Accountable, Midas, Morpho and T3tris deployments.

## Lessons learnt

Searching the current vault metadata database by curator identity found six Morini products across four protocols, rather than only the three products covered by the existing handwritten Piku metadata. Curator classifications therefore need chain-scoped, cross-protocol address mappings, while protocol defaults such as Morpho lending must be preserved when adding the curator tag.

## Summary

- Replace all strategy-category descriptions with short, plain-language activity summaries while retaining applicable Trading Strategy glossary links.
- Add the stable `fx` strategy tag with the public label `FX` and description `Trading related to foreign currencies.`
- Classify all six Morini Capital vaults found in the metadata database, preserving `lending` on the two Morpho products.
- Expose the curator classification through Accountable, Midas and T3tris scan adapters and the metadata migration path.
- Add focused coverage for catalogue presentation, adapter resolution, Morpho defaults and migration results.
- Add the dated feature entry to `CHANGELOG.md`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
