### PR TITLE
feat: deploy Lagoon vaults with Lighter API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2
 
 - feat: Add concise public strategy-category descriptions and classify Morini Capital foreign-currency vaults with the new FX category (2026-09-11)
+- feat: Add deployment-time Lighter account activation and API-key registration for Lagoon vaults, including private deployment-report output and an end-to-end ETH perpetual trading tutorial (2026-09-11)
 - feat: Classify every Enzyme Blue and Onyx vault as discretionary trading by default and migrate cached tags (2026-09-08)
 - feat: Export documented vault strategy categories with quality-filtered TVL and one-month return aggregates, plus a local category-breakdown helper (2026-09-04)
 - feat: Add canonical signed per-period vault flow values, expose gross directional values and counts only from individually extracted events, estimate netted stablecoin ERC-4626 flows from daily vault states, and deprecate the legacy top-level netflow export (2026-08-31)

--- a/docs/source/api/lagoon/index.rst
+++ b/docs/source/api/lagoon/index.rst
@@ -10,6 +10,7 @@ This module provides tools for interacting with Lagoon vaults, including:
 - Deposits and redemptions
 - CoW Swap integration for vault trading
 - GMX perpetuals integration for vault trading
+- Lighter account activation and perpetuals integration
 - Offchain metadata fetching
 
 Tutorials
@@ -19,6 +20,8 @@ Tutorials
 - :ref:`lagoon-gmx` - Trading GMX perpetuals from a Lagoon vault
 - :ref:`lagoon-velora` - Velora integration
 - :ref:`lagoon-hyperliquid` - Deploying on HyperEVM with Hypercore deposits
+- ``scripts/lagoon/lagoon-lighter-example.py`` - Deploying a Lagoon vault with a Lighter API key
+- ``scripts/lagoon/lagoon-lighter-trade-example.py`` - Trading an ETH perpetual with the deployed API key
 
 .. autosummary::
    :toctree: _autosummary_lagoon
@@ -27,6 +30,7 @@ Tutorials
    eth_defi.lagoon.vault
    eth_defi.lagoon.deployment
    eth_defi.erc_4626.vault_protocol.lagoon.deposit_redeem
+   eth_defi.erc_4626.vault_protocol.lagoon.funding
    eth_defi.lagoon.cowswap
    eth_defi.lagoon.config
    eth_defi.lagoon.analysis

--- a/docs/source/api/lighter/index.rst
+++ b/docs/source/api/lighter/index.rst
@@ -22,15 +22,17 @@ The guarded Lagoon/Safe surface supports the manual mainnet custody lifecycle:
 - Guard whitelisting for Lighter ``deposit`` / ``withdraw`` /
   ``withdrawPendingBalance`` L1 calls
 - Safe-owned ``changePubKey`` API-key registration
-- Lagoon-vault helpers for USDC deposits, secure Lighter withdrawals and
-  pending-balance claims
+- Lagoon-vault helper for the minimum USDC activation deposit
 - Account valuation via public Lighter account NAV fields
-- Small manual ETH perpetual round trips through the optional Lighter SDK
+- Deployment-time trading API-key generation without an SDK dependency;
+  the separate trading tutorial uses Lighter's official SDK for order signing
 
 Tutorials
 ~~~~~~~~~
 
 - :doc:`Lighter: benchmark pools </tutorials/lighter-vault-benchmark>` - Benchmark Lighter pool performance, equity curves, and rolling returns
+- ``scripts/lagoon/lagoon-lighter-example.py`` - Deploy and activate a Lagoon vault with a Lighter API key
+- ``scripts/lagoon/lagoon-lighter-trade-example.py`` - Deploy, open and close a small ETH perpetual, and read NAV
 
 For architecture details, API endpoint reference, DuckDB schema, and
 fee model documentation, see
@@ -47,6 +49,7 @@ fee model documentation, see
    eth_defi.lighter.session
    eth_defi.lighter.constants
    eth_defi.lighter.api
+   eth_defi.lighter.api_key
    eth_defi.lighter.deployment
    eth_defi.lighter.lagoon
    eth_defi.lighter.pubkey

--- a/docs/superpowers/plans/2026-09-10-lagoon-lighter-api-key-deployment.md
+++ b/docs/superpowers/plans/2026-09-10-lagoon-lighter-api-key-deployment.md
@@ -1,0 +1,379 @@
+# Lagoon Lighter API-key deployment plan
+
+> **Scope:** Implement this only in the `web3-ethereum-defi` repository and
+> the `eth-defi` Python package. Do not add trade-executor configuration or
+> runtime trading support; that work belongs to another agent.
+
+> **Follow-up:** The later, separately requested
+> `scripts/lagoon/lagoon-lighter-trade-example.py` uses the official Lighter
+> SDK only as a tutorial-time dependency for order signing. The deployment
+> path and the `eth-defi` package remain independent of that SDK.
+
+**Goal:** Add an opt-in Lagoon deployment flag which makes the minimum proper
+Lagoon deposit needed to activate the Safe-owned Lighter account, creates and
+registers a trading API key while the deployment signer still controls the
+Safe, and stores the key and activation details in the deployment report.
+
+**Baseline:** This plan was written against
+`5d7633ec229fdba94ea38129019b4ca9c571e57e`. Rebase before implementation and
+adjust locations if the Lagoon or Lighter modules have moved.
+
+## Design decisions
+
+- Add one flag: `LagoonConfig.generate_lighter_api_key: bool = False`.
+- When enabled, use API-key index `MIN_API_KEY_INDEX` by default and allow the
+  caller to override only the index.
+- Deposit exactly `LIGHTER_MIN_MAINNET_USDC`, currently 1 USDC. Do not add a
+  configurable activation amount or a second activation flag.
+- Generate the key with native Python code in `eth-defi`. Do not add or retain
+  a dependency on the Lighter Python SDK.
+- Port only the Goldilocks extension-field and ECgFp5 scalar multiplication
+  needed to derive a Lighter public key from a random private scalar. Do not
+  port order signing, authentication tokens, nonces, withdrawals, Poseidon2,
+  API models, or an asynchronous API client.
+- Register the public key during deployment with the existing direct Safe
+  multisig `changePubKey` transaction. The Safe guard evaluates this
+  transaction; it is not sent through `TradingStrategyModuleV0`. Registration
+  must happen before the deployer adds the final Safe owners and raises the
+  Safe threshold.
+- Use the package's existing `requests`-based `LighterSession` for account,
+  collateral and registered-key polling.
+- Fund the Safe through Lagoon's normal request, valuation, settlement and
+  share-claim lifecycle. Never transfer USDC directly to the Safe as an
+  unaccounted donation.
+- Return a successful deployment report only after the Lighter API exposes the
+  account, credits the collateral and reports the registered public key.
+- Do not introduce recovery records, resumable stages, status enums, partial
+  result exceptions, idempotency machinery or a second deployment entry point.
+  A failed deployment raises at the failing operation and retains the existing
+  transaction logging.
+- Never place the private key in logs, `repr()`, exception messages or the
+  default public JSON representation.
+- Requiring both manager roles to equal the deployer is a deliberate first
+  version limitation. Deployments configured with separate production manager
+  addresses cannot enable this flag because the deployment wallet could not
+  execute the Lagoon funding lifecycle; role handover is outside this plan.
+
+No Solidity or ABI changes are needed.
+
+## Preconditions
+
+Run a read-only validation before the first deployment transaction when the
+flag is enabled. Require all of the following:
+
+- `lighter_deployment` is the canonical Ethereum Lighter deployment;
+- Web3 chain ID is 1 and the Lagoon underlying token is native Ethereum USDC;
+- this is a new, full Lagoon deployment, not guard-only, satellite, or an
+  existing Safe/vault configuration;
+- `deployer` is a `HotWallet`, because the flow needs ERC-20 transfers and the
+  initial 1-of-1 Safe transaction;
+- the effective valuation manager and primary asset manager both equal the
+  deployer address;
+- `lighter_api_key_index` is within the range accepted by `changePubKey`;
+- `max_settlement_amount`, if supplied, permits at least
+  `LIGHTER_MIN_MAINNET_USDC`; and
+- the deployer holds at least `LIGHTER_MIN_MAINNET_USDC`, in addition to enough
+  ETH for the normal deployment transactions.
+
+Do not run these Lighter-specific checks when the flag is false. Existing
+Lagoon deployments must behave exactly as before.
+
+## Deployment sequence
+
+Keep the operation inside `deploy_automated_lagoon_vault()` so it is part of
+the same deployment ceremony:
+
+1. Validate all Lighter preconditions before broadcasting anything.
+2. Deploy the Safe, Lagoon vault, module and guard using the existing flow.
+3. Transfer module ownership to the Safe and perform the existing guarded Safe
+   configuration while the deployer is its sole threshold-1 owner.
+4. Subscribe `LIGHTER_MIN_MAINNET_USDC` through Lagoon, update valuation,
+   settle the deposit and claim the deployer's Lagoon shares.
+5. Deposit that amount from the Lagoon Safe to Lighter through the guarded
+   module.
+6. Poll Lighter's public API until the account exists and its collateral is at
+   least `LIGHTER_MIN_MAINNET_USDC`, retaining the existing 0.000010 USDC
+   rounding tolerance.
+7. Generate a fresh private/public API-key pair locally.
+8. Register the public key by calling the existing
+   `execute_change_pubkey()` helper through the still-threshold-1 Safe.
+9. Poll `/api/v1/apikeys` until the selected slot contains the exact generated
+   public key.
+10. Add the configured final Safe owners and set the production threshold.
+11. Return `LagoonAutomatedDeployment` with the Lighter setup details.
+
+Steps 7–10 must remain adjacent. In particular, no unrelated deployment work
+should be added between key registration and final Safe ownership setup.
+
+## Implementation tasks
+
+### 1. Add native Lighter API-key generation
+
+Create `eth_defi/lighter/api_key.py` with a frozen, slotted value object:
+
+```python
+@dataclass(slots=True, frozen=True)
+class LighterApiKey:
+    api_key_index: int
+    private_key: str = field(repr=False)
+    public_key: str
+```
+
+Add:
+
+```python
+def generate_lighter_api_key(
+    api_key_index: int = MIN_API_KEY_INDEX,
+) -> LighterApiKey:
+    ...
+```
+
+The generator must:
+
+- validate the API-key index using the existing limits in
+  `eth_defi.lighter.pubkey`;
+- sample a uniformly random, non-zero scalar as
+  `secrets.randbelow(ECGFP5_SCALAR_ORDER - 1) + 1`;
+- serialise the private scalar in the 40-byte little-endian form used by
+  Lighter;
+- derive the 40-byte Goldilocks ECgFp5 public key and return both values in the
+  same hex form accepted by Lighter; and
+- pass the public key through `validate_lighter_pubkey()` before returning.
+
+Port the minimum arithmetic from pinned revisions of the official Apache-2.0
+`elliottech/lighter-go` and `elliottech/poseidon_crypto` implementations.
+Record the upstream URLs, commit hashes and licence in the module docstring and
+comments beside any copied constants. Keep the arithmetic private to this
+module unless another existing `eth-defi` call site needs it.
+
+This Python implementation is for one-off local key generation, not a general
+Lighter signer. Document that it is not constant-time and do not expose a
+generic curve API.
+
+### 2. Remove the Lighter SDK surface
+
+Refactor `eth_defi/lighter/api.py` to use synchronous `LighterSession` calls
+for only the deployment operations:
+
+- select the lowest-index account returned by
+  `/api/v1/accountsByL1Address?l1_address=<safe>`, matching the existing SDK
+  behaviour;
+- reuse `fetch_lighter_account_by_index()` and
+  `parse_lighter_account_equity()` for collateral polling; and
+- fetch `/api/v1/apikeys` with `account_index` and `api_key_index`, then confirm
+  that the requested slot contains the expected public key after decoding both
+  values to bytes, avoiding false mismatches from hex prefix or case.
+
+Use the existing polling interval and timeout constants. Log each wait without
+logging key material.
+
+Remove `import_lighter()` and SDK-backed account wrappers. Remove the SDK-only
+manual trade sizing, order round-trip and withdrawal helpers after confirming
+with `rg` that their only caller is
+  `scripts/lagoon/lagoon-lighter-example.py`. Simplify that script to the
+  activation/key-registration verification described in task 7, including
+  deleting its deployment-resume/load machinery. Remove the
+  `LIGHTER_TUTORIAL_DEPLOYMENT_FILE`, `LIGHTER_RECOVERY_WITHDRAW_USDC` and
+  `LIGHTER_WITHDRAW_TIMEOUT` inputs, their branches and helpers, and all
+  "continue failed run" metadata and messages. Do not recreate trading or
+  withdrawal signing in this plan.
+
+Remove the SDK import/check from the real valuation test. NAV already comes
+from the public REST endpoint and does not require a trading key.
+
+Do not add a `lighter-sdk` Poetry dependency or optional extra.
+
+### 3. Promote the Lagoon funding helper
+
+Move the live-capable implementation of `fund_lagoon_vault()` from
+`eth_defi/erc_4626/vault_protocol/lagoon/testing.py` to
+`eth_defi/erc_4626/vault_protocol/lagoon/funding.py`.
+
+Keep a compatibility import in `lagoon.testing`. Preserve the existing
+transaction sequence, polling and return contract. Use
+`TokenDetails.convert_to_raw()` and do not introduce a result or
+transaction-inventory dataclass.
+
+The deployer is the activation depositor and receives Lagoon shares for the
+`LIGHTER_MIN_MAINNET_USDC` supplied. Before the Lighter deposit, verify that the
+Safe received the settled assets.
+
+Add the new production module to the Lagoon API documentation index.
+
+### 4. Make the guarded Lighter deposit observable
+
+Update `deposit_usdc_from_lagoon_safe_into_lighter()` in
+`eth_defi/lighter/lagoon.py` to return the successful Lighter deposit
+transaction hash. Keep the approval hash in normal transaction logging rather
+than creating a result object.
+
+Pass the configured Lighter contract address into the approval and deposit
+calls instead of relying on a second hard-coded address. Retain route 0 and
+resolve the asset index from the configured Ethereum deployment.
+
+### 5. Register the key before final Safe ownership
+
+Add these fields to `LagoonConfig` and mirror them in the direct keyword
+interface of `deploy_automated_lagoon_vault()`:
+
+```python
+generate_lighter_api_key: bool = False
+lighter_api_key_index: int = MIN_API_KEY_INDEX
+```
+
+After the account is credited:
+
+- call `generate_lighter_api_key()`;
+- call the existing `execute_change_pubkey()` with the deployer-owned Safe;
+- verify the exact public key through the REST API; and
+- only then call `add_new_safe_owners()` and raise the threshold.
+
+Do not leave key registration to a later command. `execute_change_pubkey()`
+builds, signs and executes a direct Safe transaction which is checked by the
+guard. A production threshold may require multiple owners, whereas the
+deployment signer can execute it while the Safe is still 1-of-1.
+
+### 6. Extend the deployment report without leaking the key
+
+Add one frozen, slotted `LighterAccountSetup` value object with only:
+
+- account index;
+- API-key index;
+- private key, typed as `str | None` and declared with `repr=False`;
+- public key;
+- activation amount;
+- Lighter deposit transaction hash;
+- `changePubKey` transaction hash; and
+- observed collateral.
+
+Add `lighter_account_setup: LighterAccountSetup | None` to
+`LagoonAutomatedDeployment`.
+
+Keep `as_json_friendly_dict()` secret-free by default. Add an explicit
+`include_secrets: bool = False` argument; only the true form includes the
+private key. Ensure `pformat()`, `repr()`, logs and exceptions always use the
+secret-free form. A successful live deployment always has a private key, while
+hydrating a redacted report sets it to `None`; code needing credentials must
+reject that value explicitly. Preserve backwards-compatible deserialisation
+when the whole new field is absent.
+
+Add one `LagoonAutomatedDeployment.write_json_file()` helper which calls the
+secret-bearing form when explicitly requested and creates the file with mode
+`0600` and exclusive-create semantics. Both tutorials must use this one writer.
+Console rendering must use `pformat()`, which never includes the private key;
+never print the report contents. Do not add a persistence framework.
+
+### 7. Keep one real verification path
+
+Simplify `scripts/lagoon/lagoon-lighter-example.py` so the relevant mode:
+
+- deploys a fresh Lagoon vault with the new flag;
+- performs the fixed `LIGHTER_MIN_MAINNET_USDC` activation deposit;
+- registers the key during deployment;
+- confirms the report contains the account and key metadata; and
+- fetches account equity through `LighterSession`.
+
+Remove the SDK, trade round-trip, withdrawal, deployment loading, all three
+recovery/timeout environment variables named in task 2, and "continue failed
+run" paths. The script writes the secret-bearing report once with mode `0600`,
+but only prints a separately generated redacted form. Guard this manual mainnet
+check with the remaining deployment environment variables and never print the
+private key. This is the required real-provider check for the external
+integration; record the dated, redacted result in the eventual pull request.
+
+## Tests
+
+### Native key tests
+
+Add `tests/lighter/test_lighter_api_key.py`:
+
+- fixed private scalars produce golden public keys generated independently by
+  the pinned official Go implementation;
+- the smallest and largest valid API-key indices are accepted and adjacent
+  invalid indices are rejected;
+- monkeypatched `secrets.randbelow()` proves non-zero scalar handling and byte
+  order; and
+- neither `repr(key)` nor validation errors contain the private key.
+
+The golden vectors are essential: round-tripping solely through the new Python
+code would not detect a compatible-but-wrong curve implementation. Store the
+pinned Go commit hash beside the vectors so an implementer can regenerate them.
+
+### REST helper tests
+
+Use a small fake `LighterSession` response object to cover:
+
+- account discovery by Safe address;
+- empty and malformed account responses;
+- collateral polling, including the existing rounding tolerance and timeout;
+- registered-key polling with exact index/public-key matching; and
+- HTTP or malformed-response failures without key leakage.
+
+No test may import or install the Lighter SDK.
+
+### Deployment orchestration test
+
+Add a focused test under `tests/lagoon/` with mocked Lighter HTTP responses and
+mocked transaction helpers. Run the real deployment orchestration far enough
+to assert this order:
+
+```text
+Lagoon subscription and settlement
+→ guarded LIGHTER_MIN_MAINNET_USDC Lighter deposit
+→ Lighter account/collateral visible
+→ native key generation
+→ Safe changePubKey execution
+→ REST key verification
+→ final Safe owners and threshold
+→ deployment report returned
+```
+
+Assert the amount is exactly `LIGHTER_MIN_MAINNET_USDC`, the configured contract
+address is used, and no external HTTP request or SDK import occurs. Also assert
+that a failure before REST key verification prevents final Safe ownership setup
+and prevents a successful report from being returned.
+
+Parameterise preflight failures so each invalid configuration is rejected
+before any transaction helper is called: wrong chain, token or Lighter
+deployment; non-`HotWallet` deployer; existing/partial deployment; manager
+mismatch; insufficient settlement cap or USDC balance; and invalid key index.
+
+### Report tests
+
+Extend the existing Lagoon deployment-report tests to cover:
+
+- old reports without `lighter_account_setup` still load;
+- public JSON omits the private key;
+- a new redacted report loads with `private_key is None`;
+- explicit secret-bearing JSON round-trips the private key;
+- `repr()` and formatted output omit the private key; and
+- the report writer uses mode `0600`, refuses to overwrite an existing file,
+  and the formatted deployment summary remains redacted.
+
+Keep the existing Anvil tests for the guarded deposit and `changePubKey`
+execution. They already cover the onchain boundaries; do not duplicate the
+whole Lagoon deployment on a second fork fixture.
+
+Run only the focused test files with the repository's required environment:
+
+```shell
+source .local-test.env && poetry run pytest tests/lighter/test_lighter_api_key.py tests/lighter/test_valuation.py tests/lighter/test_lighter_change_pubkey.py tests/lagoon/<deployment-test-file>.py
+```
+
+Then format only the touched Python files with `poetry run ruff format` and run
+the corresponding focused Ruff checks. Do not build Sphinx locally.
+
+## Completion criteria
+
+- With the flag false, Lagoon deployment output and transaction flow are
+  unchanged.
+- With the flag true on Ethereum, deployment accounts for and deposits exactly
+  `LIGHTER_MIN_MAINNET_USDC`, observes the Lighter account, generates and
+  registers an API key before final Safe ownership setup, verifies it by REST,
+  and returns it in the protected deployment report.
+- The opt-in path explicitly rejects configurations whose valuation manager or
+  primary asset manager differs from the deployer.
+- The package and its tests contain no Lighter SDK import or dependency.
+- The private key is absent from default serialisation, formatting, logs and
+  errors.
+- There is no recovery state machine or general Lighter trading implementation.

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -8,15 +8,17 @@ Lagoon automatised vault consists of
 - TradingStrategyModuleV0 module enabling guarded automated trade executor for the Safe
 - Support deployments with Forge and Etherscan verification
 
-Any Safe must be deployed as 1-of-1 deployer address multisig and multisig holders changed after the deployment.
+The Safe starts as a 1-of-1 deployer-owned multisig. Requested owners and the
+final threshold are configured during deployment; the deployer remains an owner.
 """
 
 import copy
+import json
 import logging
 import os
 import time
 from contextlib import nullcontext
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from decimal import Decimal
 from io import StringIO
 from pathlib import Path
@@ -42,6 +44,7 @@ from eth_defi.deploy import deploy_contract
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.lagoon.beacon_proxy import deploy_beacon_proxy
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonSatelliteVault, LagoonVault
 from eth_defi.foundry.forge import deploy_contract_with_forge
 from eth_defi.gas import apply_gas, estimate_gas_price
@@ -50,7 +53,13 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.hyperliquid.block import HYPEREVM_FAST_BLOCK_GAS_LIMIT
 from eth_defi.hyperliquid.core_writer import CORE_DEPOSIT_WALLET, CORE_WRITER_ADDRESS
 from eth_defi.hyperliquid.guard_whitelist import get_core_deposit_wallet
+from eth_defi.lighter.api import LIGHTER_MIN_MAINNET_USDC, wait_for_lighter_account, wait_for_lighter_api_key, wait_for_lighter_collateral
+from eth_defi.lighter.api_key import generate_lighter_api_key as generate_lighter_api_key_pair
+from eth_defi.lighter.constants import LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID
 from eth_defi.lighter.deployment import LighterDeployment, setup_lighter_whitelisting
+from eth_defi.lighter.lagoon import deposit_usdc_from_lagoon_safe_into_lighter
+from eth_defi.lighter.pubkey import MAX_API_KEY_INDEX, MIN_API_KEY_INDEX, execute_change_pubkey
+from eth_defi.lighter.session import create_lighter_session
 from eth_defi.provider.anvil import is_anvil
 from eth_defi.safe.deployment import (
     DEFAULT_TX_CONFIRMATION_TIMEOUT,
@@ -95,7 +104,7 @@ LAGOON_SETTLEMENT_LIMIT_INTERNAL_VERSION = 3
 #:
 #: Some L2s — Arbitrum in particular — under-estimate ``eth_estimateGas`` for
 #: simple guard-configuration calls (e.g. ``allowReceiver``), causing the
-#: transaction to revert on-chain with "out of gas" even though the estimate
+#: transaction to revert onchain with "out of gas" even though the estimate
 #: was accepted.  A multiplier on the estimate avoids this; the sender is still
 #: only charged for gas actually used, so over-provisioning the limit is free.
 DEFAULT_DEPLOYMENT_GAS_MULTIPLIER = 2.0
@@ -106,6 +115,12 @@ DEFAULT_DEPLOYMENT_GAS_MULTIPLIER = 2.0
 #: The 40-vault batch, including CoreWriter and USDC setup, is regression-tested
 #: to consume less than 2M gas on the fixed HyperEVM fork.
 HYPERCORE_MULTICALL_CHUNK_SIZE = 40
+
+#: Maximum wait for a load-balanced read RPC to observe activation funding.
+LIGHTER_ACTIVATION_BALANCE_TIMEOUT = 120
+
+#: Delay between Safe-balance reads after Lagoon settlement.
+LIGHTER_ACTIVATION_BALANCE_POLL_SECONDS = 5
 
 
 CONTRACTS_ROOT = Path(os.path.dirname(__file__)) / ".." / ".." / ".." / ".." / "contracts"
@@ -408,6 +423,17 @@ class LagoonConfig:
     #: Lighter (zk-rollup perps DEX, Ethereum L1) deployment for whitelisting
     lighter_deployment: "LighterDeployment | None" = None
 
+    #: Activate the Safe-owned Lighter account and register a trading API key.
+    #:
+    #: This Ethereum-only deployment ceremony funds the Safe through Lagoon,
+    #: deposits :data:`LIGHTER_MIN_MAINNET_USDC`, then performs ``changePubKey``
+    #: before the requested Safe owners and threshold are configured. The
+    #: deployer remains an owner, matching the existing Lagoon deployment flow.
+    generate_lighter_api_key: bool = False
+
+    #: User API-key slot to register during Lighter activation.
+    lighter_api_key_index: int = MIN_API_KEY_INDEX
+
     #: CCTP V2 deployment for cross-chain USDC transfers
     cctp_deployment: CCTPDeployment | None = None
 
@@ -552,6 +578,40 @@ class WhitelistEntry:
 
 
 @dataclass(slots=True, frozen=True)
+class LighterAccountSetup:
+    """Registered Lighter account details created by Lagoon deployment.
+
+    The private key is present only on a successful in-memory deployment or a
+    deliberately secret-bearing report. Redacted report hydration sets it to
+    ``None``.
+    """
+
+    #: Lighter account owned by the deployed Safe.
+    account_index: int
+
+    #: Registered Lighter API-key slot.
+    api_key_index: int
+
+    #: Private key for downstream trading, never included in ``repr()``.
+    private_key: str | None = field(repr=False)
+
+    #: Registered 40-byte Lighter public key.
+    public_key: str
+
+    #: Fixed Lagoon-accounted amount deposited to activate Lighter.
+    activation_amount: Decimal
+
+    #: Lighter L1 deposit transaction hash.
+    deposit_tx_hash: str
+
+    #: Safe ``changePubKey`` transaction hash.
+    change_pubkey_tx_hash: str
+
+    #: Collateral observed by the Lighter public API after activation.
+    observed_collateral: Decimal
+
+
+@dataclass(slots=True, frozen=True)
 class LagoonAutomatedDeployment:
     """Capture information of the lagoon automated deployment.
 
@@ -596,6 +656,9 @@ class LagoonAutomatedDeployment:
     #: Items whitelisted on the guard during deployment.
     whitelisted_items: tuple[WhitelistEntry, ...] = ()
 
+    #: Optional Lighter activation and API-key registration completed during deployment.
+    lighter_account_setup: LighterAccountSetup | None = None
+
     @property
     def safe(self) -> Safe:
         return self.vault.safe
@@ -638,6 +701,16 @@ class LagoonAutomatedDeployment:
             "Safe salt nonce": self.safe_salt_nonce,
         }
 
+        if self.lighter_account_setup is not None:
+            fields.update(
+                {
+                    "Lighter account": self.lighter_account_setup.account_index,
+                    "Lighter API-key index": self.lighter_account_setup.api_key_index,
+                    "Lighter public key": self.lighter_account_setup.public_key,
+                    "Lighter collateral": self.lighter_account_setup.observed_collateral,
+                }
+            )
+
         if not self.is_satellite:
             vault = self.vault
             fields["Vault"] = vault.address
@@ -650,7 +723,7 @@ class LagoonAutomatedDeployment:
 
         return fields
 
-    def as_json_friendly_dict(self) -> dict[str, Any]:
+    def as_json_friendly_dict(self, *, include_secrets: bool = False) -> dict[str, Any]:
         """Get JSON-serialisable deployment data.
 
         :class:`LagoonAutomatedDeployment` contains live Web3 contract and
@@ -658,6 +731,10 @@ class LagoonAutomatedDeployment:
         captures the deployment as plain JSON values, keeping enough addresses
         and parameters to reconstruct the deployment object with
         :py:meth:`from_json_friendly_dict`.
+
+        :param include_secrets:
+            Include the Lighter API private key. Use this only for a local file
+            created with restrictive permissions.
 
         :return:
             JSON-serialisable Lagoon deployment information.
@@ -681,7 +758,22 @@ class LagoonAutomatedDeployment:
             "gas_used": str(self.gas_used) if self.gas_used is not None else None,
             "safe_salt_nonce": self.safe_salt_nonce,
             "whitelisted_items": [asdict(entry) for entry in self.whitelisted_items],
+            "lighter_account_setup": None,
         }
+
+        if self.lighter_account_setup is not None:
+            lighter_data = {
+                "account_index": self.lighter_account_setup.account_index,
+                "api_key_index": self.lighter_account_setup.api_key_index,
+                "public_key": self.lighter_account_setup.public_key,
+                "activation_amount": str(self.lighter_account_setup.activation_amount),
+                "deposit_tx_hash": self.lighter_account_setup.deposit_tx_hash,
+                "change_pubkey_tx_hash": self.lighter_account_setup.change_pubkey_tx_hash,
+                "observed_collateral": str(self.lighter_account_setup.observed_collateral),
+            }
+            if include_secrets:
+                lighter_data["private_key"] = self.lighter_account_setup.private_key
+            data["lighter_account_setup"] = lighter_data
 
         if not self.is_satellite:
             vault = self.vault
@@ -697,13 +789,35 @@ class LagoonAutomatedDeployment:
 
         return data
 
+    def write_json_file(self, path: Path, *, include_secrets: bool = False) -> None:
+        """Create a private deployment-report file without overwriting data.
+
+        Deployment reports may contain API private keys when explicitly
+        requested, so both redacted and secret-bearing files are created with
+        mode ``0600``. The exclusive create also prevents accidental loss of a
+        previous report.
+
+        :param path:
+            New report path. Its parent directory is created when needed.
+        :param include_secrets:
+            Include the Lighter API private key in the report.
+        :return:
+            ``None`` after the complete JSON document is written.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(self.as_json_friendly_dict(include_secrets=include_secrets), indent=2, sort_keys=True) + "\n"
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as report_file:
+            report_file.write(payload)
+
     @classmethod
     def from_json_friendly_dict(cls, web3: Web3, data: dict[str, Any]) -> "LagoonAutomatedDeployment":
         """Recreate deployment information from JSON data.
 
         This recreates the live Web3 contract and vault reader objects from
-        addresses stored by :py:meth:`as_json_friendly_dict`. The JSON payload
-        does not contain private keys or signed transactions.
+        addresses stored by :py:meth:`as_json_friendly_dict`. The payload may
+        contain a Lighter private key only when its writer explicitly requested
+        secret-bearing output; it never contains signed transactions.
 
         :param web3:
             Web3 connection for the deployment chain.
@@ -763,6 +877,20 @@ class LagoonAutomatedDeployment:
                 require_denomination_token=True,
             )
 
+        lighter_data = data.get("lighter_account_setup")
+        lighter_account_setup = None
+        if lighter_data is not None:
+            lighter_account_setup = LighterAccountSetup(
+                account_index=int(lighter_data["account_index"]),
+                api_key_index=int(lighter_data["api_key_index"]),
+                private_key=lighter_data.get("private_key"),
+                public_key=lighter_data["public_key"],
+                activation_amount=Decimal(lighter_data["activation_amount"]),
+                deposit_tx_hash=lighter_data["deposit_tx_hash"],
+                change_pubkey_tx_hash=lighter_data["change_pubkey_tx_hash"],
+                observed_collateral=Decimal(lighter_data["observed_collateral"]),
+            )
+
         return cls(
             chain_id=chain_id,
             vault=vault,
@@ -780,6 +908,7 @@ class LagoonAutomatedDeployment:
             gas_used=Decimal(data["gas_used"]) if data.get("gas_used") else None,
             safe_salt_nonce=data.get("safe_salt_nonce"),
             whitelisted_items=tuple(WhitelistEntry(**entry) for entry in data.get("whitelisted_items", [])),
+            lighter_account_setup=lighter_account_setup,
         )
 
     def pformat(self) -> str:
@@ -1166,7 +1295,7 @@ def deploy_lagoon(
 
         When deployer is a :class:`~eth_defi.hotwallet.HotWallet`, uses its
         internal nonce counter (avoids stale reads from load-balanced RPCs).
-        For a plain :class:`LocalAccount`, falls back to on-chain nonce lookup.
+        For a plain :class:`LocalAccount`, falls back to onchain nonce lookup.
         """
         if isinstance(deployer, HotWallet):
             return deployer.allocate_nonce(), deployer.account
@@ -2117,6 +2246,215 @@ def setup_guard(
     return entries
 
 
+def _validate_lighter_api_key_deployment_config(
+    *,
+    web3: Web3,
+    deployer: LocalAccount | HotWallet,
+    parameters: LagoonDeploymentParameters,
+    primary_asset_manager: HexAddress,
+    lighter_deployment: LighterDeployment | None,
+    generate_lighter_api_key: bool,
+    lighter_api_key_index: int,
+    guard_only: bool,
+    satellite_chain: bool,
+    existing_vault_address: HexAddress | str | None,
+    existing_safe_address: HexAddress | str | None,
+    max_settlement_amount: Decimal | None,
+) -> None:
+    """Validate the narrow Ethereum Lighter activation deployment topology.
+
+    All checks execute before the first deployment transaction. The normal
+    Lagoon deployer remains unchanged unless the opt-in flag is set.
+
+    :param web3:
+        Web3 connection for the prospective deployment.
+    :param deployer:
+        Deployment signer.
+    :param parameters:
+        Lagoon vault parameters.
+    :param primary_asset_manager:
+        First configured Lagoon asset manager.
+    :param lighter_deployment:
+        Lighter guard deployment configuration.
+    :param generate_lighter_api_key:
+        Whether Lighter activation is enabled.
+    :param lighter_api_key_index:
+        Requested Lighter API-key index.
+    :param guard_only:
+        Whether only a guard is being deployed.
+    :param satellite_chain:
+        Whether this is a satellite deployment.
+    :param existing_vault_address:
+        Optional existing Lagoon vault address.
+    :param existing_safe_address:
+        Optional existing Safe address.
+    :param max_settlement_amount:
+        Optional Lagoon asset-manager settlement cap.
+    :return:
+        ``None`` after validation.
+    """
+    if not generate_lighter_api_key:
+        return
+
+    if not isinstance(deployer, HotWallet):
+        message = "generate_lighter_api_key requires a HotWallet deployer"
+        raise TypeError(message)
+    if web3.eth.chain_id != LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID:
+        message = f"generate_lighter_api_key is supported only on Ethereum chain ID {LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID}"
+        raise ValueError(message)
+    if lighter_deployment is None:
+        message = "generate_lighter_api_key requires lighter_deployment"
+        raise ValueError(message)
+    canonical_lighter = LighterDeployment.create_ethereum()
+    if Web3.to_checksum_address(lighter_deployment.zk_lighter) != canonical_lighter.zk_lighter or Web3.to_checksum_address(lighter_deployment.usdc) != canonical_lighter.usdc:
+        message = "generate_lighter_api_key requires the canonical Ethereum Lighter deployment"
+        raise ValueError(message)
+    if Web3.to_checksum_address(parameters.underlying) != canonical_lighter.usdc:
+        message = "generate_lighter_api_key requires native Ethereum USDC as Lagoon underlying"
+        raise ValueError(message)
+    if guard_only or satellite_chain or existing_vault_address or existing_safe_address:
+        message = "generate_lighter_api_key requires a new full Lagoon vault deployment"
+        raise ValueError(message)
+    if Web3.to_checksum_address(primary_asset_manager) != Web3.to_checksum_address(deployer.address):
+        message = "generate_lighter_api_key requires the deployer as the primary asset manager"
+        raise ValueError(message)
+    if Web3.to_checksum_address(parameters.valuationManager) != Web3.to_checksum_address(deployer.address):
+        message = "generate_lighter_api_key requires the deployer as the valuation manager"
+        raise ValueError(message)
+    if not MIN_API_KEY_INDEX <= lighter_api_key_index <= MAX_API_KEY_INDEX:
+        raise ValueError(f"lighter_api_key_index must be {MIN_API_KEY_INDEX}..{MAX_API_KEY_INDEX}")
+    if max_settlement_amount is not None and max_settlement_amount < LIGHTER_MIN_MAINNET_USDC:
+        raise ValueError(f"max_settlement_amount must be at least {LIGHTER_MIN_MAINNET_USDC} for Lighter activation")
+
+    usdc = fetch_erc20_details(web3, canonical_lighter.usdc, chain_id=LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID)
+    if usdc.fetch_balance_of(deployer.address) < LIGHTER_MIN_MAINNET_USDC:
+        raise ValueError(f"Deployer needs at least {LIGHTER_MIN_MAINNET_USDC} {usdc.symbol} for Lighter activation")
+
+
+def _activate_lighter_account(
+    *,
+    web3: Web3,
+    deployer: HotWallet,
+    safe: Safe,
+    vault_address: HexAddress,
+    module_address: HexAddress,
+    vault_abi: str,
+    lighter_deployment: LighterDeployment,
+    api_key_index: int,
+) -> LighterAccountSetup:
+    """Fund, activate and register a Lighter API key for a newly deployed Safe.
+
+    This intentionally performs one linear, fail-fast ceremony while the
+    deployer can execute the Safe as its initial sole owner. There is no
+    automatic recovery state: an interrupted ceremony is reported as a failed
+    deployment so an operator can inspect the onchain state before taking
+    another action.
+
+    :param web3:
+        Ethereum Web3 connection.
+    :param deployer:
+        Initial sole Safe owner and Lagoon asset manager. The existing Lagoon
+        deployment flow retains the deployer when adding requested owners.
+    :param safe:
+        Newly deployed Safe.
+    :param vault_address:
+        Newly deployed Lagoon vault address.
+    :param module_address:
+        Trading strategy module address.
+    :param vault_abi:
+        Packaged Lagoon vault ABI selection.
+    :param lighter_deployment:
+        Canonical Ethereum Lighter contracts.
+    :param api_key_index:
+        Lighter API-key slot to register.
+    :return:
+        Generated key material and confirmed activation metadata.
+    """
+    chain_id = web3.eth.chain_id
+    lighter_vault = LagoonVault(
+        web3,
+        VaultSpec(chain_id, vault_address),
+        trading_strategy_module_address=module_address,
+        vault_abi=vault_abi,
+        default_block_identifier="latest",
+    )
+    activation_token = fetch_erc20_details(web3, lighter_deployment.usdc, chain_id=chain_id)
+    safe_balance_before = activation_token.fetch_balance_of(safe.address)
+    fund_lagoon_vault(
+        web3=web3,
+        vault_address=vault_address,
+        asset_manager=deployer.address,
+        test_account_with_balance=deployer.address,
+        trading_strategy_module_address=module_address,
+        amount=LIGHTER_MIN_MAINNET_USDC,
+        hot_wallet=deployer,
+    )
+    expected_raw_amount = activation_token.convert_to_raw(LIGHTER_MIN_MAINNET_USDC)
+    balance_deadline = time.monotonic() + LIGHTER_ACTIVATION_BALANCE_TIMEOUT
+    while True:
+        safe_balance_after_funding = activation_token.fetch_balance_of(safe.address)
+        funded_raw_amount = activation_token.convert_to_raw(safe_balance_after_funding - safe_balance_before)
+        if funded_raw_amount >= expected_raw_amount:
+            break
+        if time.monotonic() >= balance_deadline:
+            message = "Lagoon activation funding did not credit the expected Lighter deposit amount to the Safe"
+            raise RuntimeError(message)
+        logger.warning(
+            "Lagoon activation funding is not visible on the read RPC; retrying in %d seconds",
+            LIGHTER_ACTIVATION_BALANCE_POLL_SECONDS,
+        )
+        time.sleep(LIGHTER_ACTIVATION_BALANCE_POLL_SECONDS)
+
+    deposit_tx_hash = deposit_usdc_from_lagoon_safe_into_lighter(
+        web3=web3,
+        hot_wallet=deployer,
+        vault=lighter_vault,
+        usdc=activation_token,
+        deposit_usdc=LIGHTER_MIN_MAINNET_USDC,
+        zk_lighter=lighter_deployment.zk_lighter,
+    )
+
+    session = create_lighter_session()
+    try:
+        account_index = wait_for_lighter_account(session, safe.address)
+        observed_collateral = wait_for_lighter_collateral(
+            session,
+            account_index,
+            LIGHTER_MIN_MAINNET_USDC,
+        )
+        api_key = generate_lighter_api_key_pair(api_key_index)
+        change_pubkey_tx_hash = execute_change_pubkey(
+            web3=web3,
+            safe=safe,
+            owner_private_key=deployer.private_key.hex(),
+            account_index=account_index,
+            api_key_index=api_key.api_key_index,
+            pubkey=bytes.fromhex(api_key.public_key.removeprefix("0x")),
+            zk_lighter=lighter_deployment.zk_lighter,
+            hot_wallet=deployer,
+        )
+        wait_for_lighter_api_key(
+            session,
+            account_index,
+            api_key.api_key_index,
+            api_key.public_key,
+            timeout=900,
+        )
+    finally:
+        session.close()
+
+    return LighterAccountSetup(
+        account_index=account_index,
+        api_key_index=api_key.api_key_index,
+        private_key=api_key.private_key,
+        public_key=api_key.public_key,
+        activation_amount=LIGHTER_MIN_MAINNET_USDC,
+        deposit_tx_hash=deposit_tx_hash,
+        change_pubkey_tx_hash=Web3.to_hex(change_pubkey_tx_hash),
+        observed_collateral=observed_collateral,
+    )
+
+
 def deploy_automated_lagoon_vault(
     *,
     web3: Web3,
@@ -2134,6 +2472,8 @@ def deploy_automated_lagoon_vault(
     velora: bool = False,
     gmx_deployment: GMXDeployment | None = None,
     lighter_deployment: "LighterDeployment | None" = None,
+    generate_lighter_api_key: bool = False,
+    lighter_api_key_index: int = MIN_API_KEY_INDEX,
     cctp_deployment: CCTPDeployment | None = None,
     hypercore_vaults: list[HexAddress | str] | None = None,
     any_hypercore_vault: bool = False,
@@ -2170,7 +2510,8 @@ def deploy_automated_lagoon_vault(
     - Multiple asset-manager keys may share the same Guard rights; today this
       mainly supports separate FreqTrade and GMX trading keys, but other
       workflows may use the same pattern in the future
-    - Any Safe must be deployed as 1-of-1 deployer address multisig and multisig holders changed after the deployment.
+    - The Safe starts 1-of-1 with the deployer; requested owners and the final
+      threshold are configured before this function returns.
 
     .. warning::
 
@@ -2216,6 +2557,14 @@ def deploy_automated_lagoon_vault(
         ``max_settlement_amount`` and ``settlement_cooldown``, are ignored in favour of the values on the
         configuration object.
 
+    :param generate_lighter_api_key:
+        Activate a canonical Ethereum Lighter account with the fixed 1 USDC
+        Lagoon subscription and register a new API key before the Safe owners
+        are finalised. Defaults to ``False``.
+
+    :param lighter_api_key_index:
+        Automated Lighter API-key slot to register when activation is enabled.
+
     :param max_settlement_amount:
         Optional maximum gross Lagoon settlement for one asset-manager module
         transaction, expressed in human-readable underlying-token units as a
@@ -2237,7 +2586,7 @@ def deploy_automated_lagoon_vault(
         Deploy a new version of the guard smart contract and skip deploying the actual vault.
 
     :param from_the_scratch:
-        Need to deloy a fee registry contract as well.
+        Deploy a fee registry contract as well.
 
         A new chain deployment.
 
@@ -2268,6 +2617,8 @@ def deploy_automated_lagoon_vault(
         velora = config.velora
         gmx_deployment = config.gmx_deployment
         lighter_deployment = config.lighter_deployment
+        generate_lighter_api_key = config.generate_lighter_api_key
+        lighter_api_key_index = config.lighter_api_key_index
         cctp_deployment = config.cctp_deployment
         any_hypercore_vault = config.any_hypercore_vault
         any_asset = config.any_asset
@@ -2318,6 +2669,21 @@ def deploy_automated_lagoon_vault(
     asset_manager = primary_asset_manager
     if parameters.valuationManager is None:
         parameters.valuationManager = primary_asset_manager
+
+    _validate_lighter_api_key_deployment_config(
+        web3=web3,
+        deployer=deployer,
+        parameters=parameters,
+        primary_asset_manager=primary_asset_manager,
+        lighter_deployment=lighter_deployment,
+        generate_lighter_api_key=generate_lighter_api_key,
+        lighter_api_key_index=lighter_api_key_index,
+        guard_only=guard_only,
+        satellite_chain=satellite_chain,
+        existing_vault_address=existing_vault_address,
+        existing_safe_address=existing_safe_address,
+        max_settlement_amount=max_settlement_amount,
+    )
 
     legacy = vault_abi == LEGACY_LAGOON_VAULT_JSON
 
@@ -2385,7 +2751,7 @@ def deploy_automated_lagoon_vault(
             deployer.sync_nonce(web3)
             # Apply a safety multiplier over the node's gas estimate. On Arbitrum
             # (incl. Sepolia) eth_estimateGas under-estimates guard-setup calls
-            # like allowReceiver, which then revert on-chain with "out of gas".
+            # like allowReceiver, which then revert onchain with "out of gas".
             # Falls back to the default auto-estimate if estimation raises.
             gas_limit = None
             try:
@@ -2469,7 +2835,7 @@ def deploy_automated_lagoon_vault(
 
         # When no HotWallet is available, Safe deployment bypasses nonce
         # tracking (uses LocalAccount directly via safe-eth-py).  Sync so
-        # subsequent deploys use the correct on-chain nonce.
+        # subsequent deploys use the correct onchain nonce.
         # When HotWallet IS available, nonce was already allocated via
         # hot_wallet.allocate_nonce() inside deploy_safe_with_deterministic_address.
         if isinstance(deployer, HotWallet) and safe_salt_nonce is None:
@@ -2668,6 +3034,7 @@ def deploy_automated_lagoon_vault(
     assert_transaction_success_with_explanation(web3, tx_hash, timeout=DEFAULT_TX_CONFIRMATION_TIMEOUT)
 
     gas_estimate = estimate_gas_price(web3)
+    lighter_account_setup = None
 
     if not guard_only and not satellite_chain:
         # 2. USDC.approve() for redemptions on Safe
@@ -2697,6 +3064,20 @@ def deploy_automated_lagoon_vault(
             gnosis_sleep = 20.0
             logger.info("Gnosis GS206 sync issue sleep %s seconds", gnosis_sleep)
             time.sleep(gnosis_sleep)
+
+        if generate_lighter_api_key:
+            assert isinstance(deployer, HotWallet)
+            assert lighter_deployment is not None
+            lighter_account_setup = _activate_lighter_account(
+                web3=web3,
+                deployer=deployer,
+                safe=safe,
+                vault_address=vault_contract.address,
+                module_address=module.address,
+                vault_abi=vault_abi,
+                lighter_deployment=lighter_deployment,
+                api_key_index=lighter_api_key_index,
+            )
 
         # 3. Set Gnosis to a true multisig
         # DOES NOT REMOVE DEPLOYER
@@ -2753,6 +3134,7 @@ def deploy_automated_lagoon_vault(
         gas_used=Decimal((start_balance - end_balance) / 10**18),
         safe_salt_nonce=safe_salt_nonce,
         whitelisted_items=tuple(whitelisted_items),
+        lighter_account_setup=lighter_account_setup,
     )
 
 

--- a/eth_defi/erc_4626/vault_protocol/lagoon/funding.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/funding.py
@@ -1,0 +1,160 @@
+"""Production funding helper for a new Lagoon vault.
+
+This is the normal Lagoon subscription lifecycle used by the Lighter account
+activation ceremony: request a deposit, post valuation, settle and claim the
+resulting shares. It intentionally does not transfer tokens directly to the
+Safe because that would bypass Lagoon accounting.
+
+Authoritative Lagoon documentation:
+
+- Deposit lifecycle: https://docs.lagoon.finance/vault/deposit-and-withdraw-flows
+- Valuation and settlement:
+  https://docs.lagoon.finance/vault/how-to/update-the-vault-valuation-and-settle-requests
+"""
+
+import logging
+import time
+from decimal import Decimal
+
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.contract.contract import ContractFunction
+
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
+from eth_defi.token import TokenDiskCache
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+logger = logging.getLogger(__name__)
+
+
+def fund_lagoon_vault(  # noqa: PLR0917
+    web3: Web3,
+    vault_address: HexAddress,
+    asset_manager: HexAddress,
+    test_account_with_balance: HexAddress,
+    trading_strategy_module_address: HexAddress,
+    amount: Decimal = Decimal(500),
+    nav: Decimal = Decimal(0),
+    hot_wallet: HotWallet | None = None,
+    token_cache: TokenDiskCache | None = None,
+) -> None:
+    """Fund a Lagoon Safe through the complete ERC-7540 subscription lifecycle.
+
+    The asset manager posts the valuations and settles the subscription. The
+    depositor approves and requests the deposit, then claims its Lagoon shares
+    after settlement. ``HotWallet`` mode signs all calls for mainnet deployment;
+    the unlocked-account fallback is retained for Anvil tests. A zero ``nav``
+    identifies initial funding and causes the required first zero valuation to
+    be posted; a non-zero ``nav`` assumes the vault has already been activated.
+
+    :param web3:
+        Web3 connection to the vault chain.
+    :param vault_address:
+        Onchain Lagoon vault address.
+    :param asset_manager:
+        Address allowed to post valuation and settle the vault.
+    :param test_account_with_balance:
+        Depositor holding the underlying token.
+    :param trading_strategy_module_address:
+        TradingStrategyModuleV0 address used for settlement.
+    :param amount:
+        Human-readable underlying-token subscription amount.
+    :param nav:
+        Human-readable NAV posted for settlement.
+    :param hot_wallet:
+        Optional signer for a real deployment.
+    :param token_cache:
+        Optional ERC-20 metadata cache.
+    :return:
+        ``None`` after settlement and share claim complete.
+    """
+    assert vault_address.startswith("0x"), f"Vault address should be an address, got: {vault_address}"
+    assert asset_manager.startswith("0x"), f"asset_manager should be an address, got: {asset_manager}"
+    assert test_account_with_balance.startswith("0x"), f"test_account_with_balance should be an address, got: {test_account_with_balance}"
+    assert trading_strategy_module_address.startswith("0x"), f"trading_strategy_module_address should be an address, got: {trading_strategy_module_address}"
+
+    if hot_wallet is not None:
+        signer = Web3.to_checksum_address(hot_wallet.address)
+        if any(Web3.to_checksum_address(address) != signer for address in (asset_manager, test_account_with_balance)):
+            message = "HotWallet funding requires the signer to be both the Lagoon asset manager and depositor"
+            raise ValueError(message)
+
+    vault = create_vault_instance(
+        web3,
+        vault_address,
+        features={ERC4626Feature.lagoon_like},
+        default_block_identifier="latest",
+        require_denomination_token=True,
+        token_cache=token_cache,
+    )
+    assert isinstance(vault, LagoonVault), f"Vault is not a Lagoon vault: {vault}"
+    vault.trading_strategy_module_address = trading_strategy_module_address
+
+    denomination_token = vault.denomination_token
+    depositor_balance = denomination_token.fetch_balance_of(test_account_with_balance)
+    assert depositor_balance >= amount, f"Depositor {test_account_with_balance} has {depositor_balance} {denomination_token.symbol} but needs {amount}"
+    raw_amount = denomination_token.convert_to_raw(amount)
+
+    def send(bound_func: ContractFunction, sender: HexAddress, description: str, gas: int = 1_000_000) -> HexBytes:
+        """Send one Lagoon lifecycle transaction.
+
+        Use the configured ``HotWallet`` on live networks and the specified
+        unlocked account in test environments.
+
+        :param bound_func: Bound contract function to execute.
+        :param sender: Unlocked sender used when no ``HotWallet`` was supplied.
+        :param description: Human-readable operation included in logs.
+        :param gas: Transaction gas limit.
+        :return: Confirmed transaction hash.
+        """
+        if hot_wallet is not None:
+            logger.info("Broadcasting Lagoon funding transaction: %s", description)
+            tx_hash = hot_wallet.transact_and_broadcast_with_contract(bound_func, gas_limit=gas)
+        else:
+            tx_hash = bound_func.transact({"from": sender, "gas": gas})
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        return tx_hash
+
+    if nav == 0:
+        send(vault.post_new_valuation(Decimal(0)), asset_manager, "Post initial valuation")
+    approval_tx_hash = send(denomination_token.approve(vault.address, amount), test_account_with_balance, f"Approve {amount} for vault deposit")
+    wait_for_transaction_receipt_robust(web3, approval_tx_hash)
+    send(vault.request_deposit(test_account_with_balance, raw_amount), test_account_with_balance, f"Request {amount} deposit to vault")
+    valuation_tx_hash = send(vault.post_new_valuation(nav), asset_manager, "Post valuation for settlement")
+    # :py:meth:`ContractFunction.build_transaction` estimates the dependent
+    # settlement through the fallback provider pool. Wait until every read
+    # provider sees the valuation to avoid a stale ``WrongNewTotalAssets()``.
+    wait_for_transaction_receipt_robust(web3, valuation_tx_hash, confirmation_block_count=0, confirmation_block_time=0)
+    settle_tx_hash = send(vault.settle_via_trading_strategy_module(nav), asset_manager, "Settle vault deposits")
+    wait_for_transaction_receipt_robust(web3, settle_tx_hash, confirmation_block_count=0, confirmation_block_time=0)
+
+    claim_attempts = 12
+    claim_retry_delay = 5
+    claimable_raw_amount = 0
+    for attempt in range(1, claim_attempts + 1):
+        claimable_raw_amount = vault.vault_contract.functions.maxDeposit(test_account_with_balance).call()
+        if claimable_raw_amount > 0:
+            break
+        logger.warning(
+            "Lagoon settlement is not visible on the read RPC, retrying %d/%d in %d seconds",
+            attempt,
+            claim_attempts,
+            claim_retry_delay,
+        )
+        time.sleep(claim_retry_delay)
+
+    if claimable_raw_amount == 0:
+        raise RuntimeError(f"Lagoon deposit settlement was mined, but maxDeposit({test_account_with_balance}) stayed 0 after {claim_attempts * claim_retry_delay} seconds")
+
+    send(vault.finalise_deposit(test_account_with_balance, raw_amount=claimable_raw_amount), test_account_with_balance, f"Claim shares for {test_account_with_balance}")
+    logger.info(
+        "Lagoon funding complete: Safe balance %s %s, depositor shares %s",
+        vault.underlying_token.fetch_balance_of(vault.safe_address),
+        vault.underlying_token.symbol,
+        vault.share_token.fetch_balance_of(test_account_with_balance),
+    )

--- a/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
@@ -1,216 +1,22 @@
 """Lagoon unit test helpers."""
 
 import logging
-import time
-from decimal import Decimal
 
+from eth_typing import HexAddress
 from hexbytes import HexBytes
 from web3 import Web3
 
-from eth_typing import HexAddress
-
 from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.event_reader.conversion import convert_uint256_string_to_int, convert_uin256_to_bytes
-from eth_defi.event_reader.multicall_batcher import EncodedCall
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault  # noqa: F401
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.event_reader.conversion import convert_uin256_to_bytes
+from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.hotwallet import HotWallet
-from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.token import TokenDiskCache
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 logger = logging.getLogger(__name__)
-
-
-def fund_lagoon_vault(
-    web3: Web3,
-    vault_address: HexAddress,
-    asset_manager: HexAddress,
-    test_account_with_balance: HexAddress,
-    trading_strategy_module_address: HexAddress,
-    amount=Decimal(500),
-    nav=Decimal(0),
-    hot_wallet: HotWallet | None = None,
-    token_cache: TokenDiskCache | None = None,
-):
-    """Deposit tokens into a Lagoon vault so the Safe holds funds.
-
-    Supports two transaction signing modes:
-
-    - **Anvil mode** (default): uses ``.transact({"from": ...})`` for unlocked
-      accounts on Anvil forks.  This is the mode used by pytest fixtures.
-    - **HotWallet mode**: when *hot_wallet* is provided, signs and broadcasts
-      each transaction via :py:meth:`HotWallet.transact_and_broadcast_with_contract`.
-      Use this for real deployments and scripts.
-
-    Example (Anvil mode — pytest)::
-
-        fund_lagoon_vault(
-            web3,
-            vault.address,
-            asset_manager,
-            depositor,
-            module.address,
-            amount=Decimal(500),
-        )
-
-    Example (HotWallet mode — deploy script)::
-
-        deployer = HotWallet.from_private_key(os.environ["PRIVATE_KEY"])
-        deployer.sync_nonce(web3)
-        fund_lagoon_vault(
-            web3,
-            vault.address,
-            deployer.address,
-            deployer.address,
-            module.address,
-            amount=Decimal(2),
-            hot_wallet=deployer,
-        )
-
-    :param web3:
-        Web3 connection to the chain where the vault lives.
-
-    :param vault_address:
-        On-chain address of the Lagoon vault.
-
-    :param asset_manager:
-        Address that has the ``updateNewTotalAssets`` + ``settleDeposit``
-        role on the vault.
-
-    :param test_account_with_balance:
-        Address that holds the denomination token and will deposit.
-
-    :param trading_strategy_module_address:
-        Address of the ``TradingStrategyModuleV0`` guard contract.
-
-    :param amount:
-        Human-readable amount to deposit (e.g. ``Decimal(500)`` for 500 USDC).
-
-    :param nav:
-        NAV value to post during settlement (usually ``Decimal(0)`` for
-        initial funding).
-
-    :param hot_wallet:
-        When provided, all transactions are signed with this wallet
-        instead of using Anvil's unlocked-account shortcut.
-    """
-
-    assert vault_address.startswith("0x"), f"Vault address should be an address, got: {vault_address}"
-    assert asset_manager.startswith("0x"), f"asset_manager should be an address, got: {asset_manager}"
-    assert test_account_with_balance.startswith("0x"), f"test_account_with_balance should be an address, got: {test_account_with_balance}"
-    assert trading_strategy_module_address.startswith("0x"), f"trading_strategy_module_address should be an address, got: {trading_strategy_module_address}"
-
-    vault = create_vault_instance(
-        web3,
-        vault_address,
-        features={ERC4626Feature.lagoon_like},
-        default_block_identifier="latest",
-        require_denomination_token=True,
-        token_cache=token_cache,
-    )
-    assert isinstance(vault, LagoonVault), f"Vault is not a Lagoon vault: {vault}"
-
-    vault.trading_strategy_module_address = trading_strategy_module_address
-
-    denomination_token = vault.denomination_token
-    depositor_balance = denomination_token.fetch_balance_of(test_account_with_balance)
-    assert depositor_balance >= amount, f"Depositor {test_account_with_balance} has {depositor_balance} {denomination_token.symbol} (token {denomination_token.address}) but needs {amount}. Vault denomination token: {denomination_token.symbol} at {denomination_token.address}"
-    raw_amount = denomination_token.convert_to_raw(amount)
-
-    def _send(bound_func, description: str, gas: int = 1_000_000):
-        """Sign and broadcast a single transaction."""
-        if hot_wallet is not None:
-            logger.info("Broadcasting (HotWallet): %s", description)
-            tx_hash = hot_wallet.transact_and_broadcast_with_contract(bound_func, gas_limit=gas)
-        else:
-            tx_hash = bound_func.transact({"from": test_account_with_balance, "gas": gas})
-        assert_transaction_success_with_explanation(web3, tx_hash)
-        return tx_hash
-
-    def _send_as_manager(bound_func, description: str, gas: int = 1_000_000):
-        """Sign and broadcast as asset manager."""
-        if hot_wallet is not None:
-            logger.info("Broadcasting (HotWallet): %s", description)
-            tx_hash = hot_wallet.transact_and_broadcast_with_contract(bound_func, gas_limit=gas)
-        else:
-            tx_hash = bound_func.transact({"from": asset_manager, "gas": gas})
-        assert_transaction_success_with_explanation(web3, tx_hash)
-        return tx_hash
-
-    # 1. Post initial valuation (needed for fresh vaults)
-    _send_as_manager(vault.post_new_valuation(Decimal(0)), "Post initial valuation")
-
-    # 2. Approve denomination token for vault deposit
-    approval_tx_hash = _send(
-        denomination_token.approve(vault.address, amount),
-        f"Approve {amount} for vault deposit",
-    )
-    wait_for_transaction_receipt_robust(web3, approval_tx_hash)
-
-    # 3. Put to deposit queue
-    deposit_func = vault.request_deposit(test_account_with_balance, raw_amount)
-    _send(deposit_func, f"Request {amount} deposit to vault")
-
-    # 4. Update NAV and settle
-    _send_as_manager(vault.post_new_valuation(nav), "Post valuation for settlement")
-    settle_tx_hash = _send_as_manager(vault.settle_via_trading_strategy_module(nav), "Settle vault deposits")
-    # No confirmation wait needed: the maxDeposit() poll loop below already
-    # tolerates stale reads, so we only need receipt visibility here.
-    wait_for_transaction_receipt_robust(web3, settle_tx_hash, confirmation_block_count=0, confirmation_block_time=0)
-
-    # 5. Claim shares (ERC-7540: settlement mints shares to the vault contract,
-    #    depositor must call deposit() to transfer them to their wallet)
-    #
-    #    This looks like it should be safe to do immediately after settleDeposit()
-    #    has been mined, because _send_as_manager() above waits for the settlement
-    #    transaction receipt. On a local Anvil fork this is true: the same JSON-RPC
-    #    endpoint handles writes and reads, so the next maxDeposit() call sees the
-    #    freshly settled epoch.
-    #
-    #    On live chains this helper is often used with a MultiProviderWeb3 setup
-    #    where writes go to the sequencer / transaction provider and reads go to
-    #    one or more public RPC providers. These read providers can trail the
-    #    sequencer by a few seconds. We first wait until all configured read
-    #    providers can see the settlement receipt, but this still does not prove
-    #    every future eth_call will hit a backend with fresh Lagoon epoch state.
-    #    If we call finalise_deposit() during this window, it internally reads
-    #    maxDeposit(depositor). A stale read returns zero or an unclaimable epoch,
-    #    then the transaction builder estimates gas for deposit(0, depositor).
-    #    Lagoon rejects that path with the custom error RequestIdNotClaimable()
-    #    (selector 0x912d1a73).
-    #
-    #    Poll for an actually claimable deposit before building the final claim
-    #    transaction. We also pass the raw claimable amount explicitly to
-    #    finalise_deposit() so the amount used for gas estimation is the same
-    #    value we just observed as claimable, instead of doing a second hidden
-    #    maxDeposit() read in finalise_deposit().
-    claim_attempts = 12
-    claim_retry_delay = 5
-    claimable_raw_amount = 0
-    for attempt in range(1, claim_attempts + 1):
-        claimable_raw_amount = vault.vault_contract.functions.maxDeposit(test_account_with_balance).call()
-        if claimable_raw_amount > 0:
-            break
-
-        logger.info(
-            "Lagoon deposit settlement is not visible on the read RPC yet, maxDeposit(%s) is 0, retrying %d/%d in %d seconds",
-            test_account_with_balance,
-            attempt,
-            claim_attempts,
-            claim_retry_delay,
-        )
-        time.sleep(claim_retry_delay)
-
-    if claimable_raw_amount == 0:
-        raise RuntimeError(f"Lagoon deposit settlement was mined, but maxDeposit({test_account_with_balance}) stayed 0 after {claim_attempts * claim_retry_delay} seconds. The deposit request is not yet claimable on the read RPC, or settlement did not mark it claimable.")
-
-    finalise_func = vault.finalise_deposit(test_account_with_balance, raw_amount=claimable_raw_amount)
-    _send(finalise_func, f"Claim shares for {test_account_with_balance}")
-
-    share_balance = vault.share_token.fetch_balance_of(test_account_with_balance)
-    balance = vault.underlying_token.fetch_balance_of(vault.safe_address)
-    logger.info("Vault funded: Safe balance is %s %s, depositor shares: %s", balance, vault.underlying_token.symbol, share_balance)
 
 
 def redeem_vault_shares(

--- a/eth_defi/lighter/README-lighter-guard.md
+++ b/eth_defi/lighter/README-lighter-guard.md
@@ -1,11 +1,11 @@
 # Lighter guard integration architecture
 
 Security architecture for depositing into and withdrawing from
-[Lighter](https://lighter.xyz) (a non-custodial, zero-fee perpetuals/spot DEX
+[Lighter](https://lighter.xyz) (a non-custodial perpetuals and spot DEX
 built as a zk-rollup on Ethereum L1) through an asset-managed Gnosis **Safe**
 controlled by `TradingStrategyModuleV0` / `GuardV0`.
 
-This document describes how the on-chain guard whitelisting works. It mirrors
+This document describes how the onchain guard whitelisting works. It mirrors
 the GMX (`eth_defi/gmx/README-GMX-Lagoon.md`) and Hypercore
 (`docs/README-Hypercore-guard.md`) guard integrations.
 
@@ -18,7 +18,7 @@ the GMX (`eth_defi/gmx/README-GMX-Lagoon.md`) and Hypercore
 > contract on Robinhood Chain (chain id 4663), but this repository has not
 > configured or verified that contract's address and ABI for guard use.
 >
-> Guard scope: **deposit / withdraw only** (the on-chain L1 custody flow).
+> Guard scope: **deposit / withdraw only** (the onchain L1 custody flow).
 > Lighter account creation happens when the Safe receives its first credited
 > deposit. On-book trading (`createOrder`) is signed with the Lighter API key,
 > and trading-key rotation (`changePubKey`) is a Safe-owner setup action outside
@@ -152,7 +152,7 @@ USDC and credits the Safe's Lighter account.
 2. claim:    performCall(ZkLighter, withdrawPendingBalance(safe, USDC_ASSET_INDEX, amount), 0)
 ```
 
-Funds are released on-chain directly to the Safe address.
+Funds are released onchain directly to the Safe address.
 
 ## Account valuation (off-chain)
 
@@ -170,11 +170,21 @@ balance and margin requirements so downstream systems, such as trade-executor,
 can report account state and size withdrawals without duplicating Lighter API
 parsing.
 
-The Lagoon + Lighter manual tutorial
-`scripts/lagoon/lagoon-lighter-example.py` uses this module after the ETH
-round-trip and before requesting the secure Lighter withdrawal. The guard still
-only authorises the L1 custody calls described above; valuation and trading are
-off-chain reads/signatures.
+The minimal deployment check is
+`scripts/lagoon/lagoon-lighter-example.py`. The API-key trading tutorial is
+`scripts/lagoon/lagoon-lighter-trade-example.py`: it deploys and activates a
+Lagoon vault, adds enough accounted collateral for a conservative small ETH
+position, opens and closes an ETH-USD long using the deployment-created API
+key, and then reads account NAV. It conservatively sizes the IOC order using
+the base and quote minimum fields, although Lighter documents those fields as
+maker-order constraints. The trading tutorial uses the official Lighter SDK
+for order signing and nonce management. The SDK is intentionally not an
+``eth-defi`` dependency. Follow the pinned, reproducible installation commands
+in the tutorial module docstring. Its Git revision, dependency workaround and
+compatibility warning are kept there as the single source of truth.
+
+The guard still only authorises the L1 custody calls described above;
+valuation and trading are off-chain reads and signatures.
 
 ## Account creation (deposit-driven — not a guard call)
 
@@ -196,17 +206,16 @@ account creation.
 
 Day-to-day trading uses an off-chain L2 API key. Creating one is two steps:
 
-1. **Generate** the API keypair off-chain (the `lighter-python` SDK; no L1 key
-   needed). Use indices 4–254 for automated keys: Lighter's dedicated
-   [API keys](https://apidocs.lighter.xyz/docs/api-keys) page says `{0,1,2,3}`
-   are reserved for desktop/mobile interfaces and repeats that these front-end
-   keys cannot be marked maker-only. Lighter's
-   [Get Started](https://apidocs.lighter.xyz/docs/get-started) page currently
-   says 2–254; this integration follows the stricter dedicated API-key page to
-   avoid overwriting keys used by the front-end.
+1. **Generate** the API keypair off-chain with
+   `generate_lighter_api_key` (no L1 key needed). Use indices 4–254 for
+   automated keys: Lighter's dedicated
+   [API keys](https://apidocs.lighter.xyz/docs/api-keys) page reserves
+   `{0,1,2,3}` for desktop and mobile interfaces. This integration follows
+   that dedicated page instead of the conflicting 2–254 range currently shown
+   on Lighter's introductory page.
 2. **Register** its public key on L1 via
    `ZkLighter.changePubKey(accountIndex, apiKeyIndex, pubKey)` — for a Safe this
-   is a **Safe transaction** (Lighter recommends the on-chain ChangePubKey for
+   is a **Safe transaction** (Lighter recommends the onchain ChangePubKey for
    multisigs). `changePubKey` binds to `msg.sender`'s registered account
    (`masterAccountIndex = validateAndGetAccountIndexFromAddress(msg.sender)`), so
    the Safe must already be a registered Lighter account.
@@ -261,9 +270,10 @@ tests reuse the same function.
   `setup_hypercore_whitelisting`.
 - **Deposit / withdraw only.** On-book trading (`createOrder`) and trading-key
   rotation (`changePubKey`) are out of guard scope; trading happens off-chain
-  via the Lighter L2 API. See the manual tutorial
-  `scripts/lagoon/lagoon-lighter-example.py` for the end-to-end lifecycle
-  (the off-chain trading steps cannot be simulated on a fork, like GMX keepers).
+  via the Lighter L2 API. See
+  `scripts/lagoon/lagoon-lighter-trade-example.py` for the deployment and
+  API-key trade flow. The off-chain trading steps cannot be simulated on an
+  Ethereum fork.
 
 ## Deployment note (library linking)
 

--- a/eth_defi/lighter/api.py
+++ b/eth_defi/lighter/api.py
@@ -1,534 +1,341 @@
-"""Lighter API helpers for manual trading workflows.
+"""REST helpers for Lighter account activation and API-key registration.
 
-This module follows the same ``api.py`` / ``session.py`` split as other
-exchange-style integrations in :mod:`eth_defi`. It wraps the optional
-``lighter-python`` SDK for scripts and manual integration tests. It covers
-account polling, API-key registration, small trade sizing and simple
-market-order round trips.
+These helpers use Lighter's public REST API and do not require the Lighter SDK
+or an API private key. Transaction signing belongs to downstream trading code;
+this module only waits for the state created by the Lagoon deployer.
 
-Authoritative documentation:
+Authoritative Lighter documentation:
 
-- Lighter API keys: https://apidocs.lighter.xyz/docs/api-keys
-- Deposits and withdrawals:
-  https://apidocs.lighter.xyz/docs/deposits-transfers-and-withdrawals
+- Account creation: https://apidocs.lighter.xyz/docs/create-accounts-programmatically
+- API keys: https://apidocs.lighter.xyz/docs/api-keys
 """
 
-import asyncio
 import logging
 import time
-from dataclasses import dataclass
-from decimal import ROUND_CEILING, Decimal
-from typing import Any, Callable
+from decimal import Decimal
+from http import HTTPStatus
+from typing import Any
 
-from safe_eth.safe import Safe
+from eth_typing import HexAddress
+from requests import Response
+from requests.exceptions import JSONDecodeError, RequestException
 from web3 import Web3
 
-from eth_defi.hotwallet import HotWallet
-from eth_defi.lighter.constants import LIGHTER_API_URL
-from eth_defi.lighter.pubkey import MIN_API_KEY_INDEX, build_change_pubkey_safe_tx, validate_lighter_pubkey
-from eth_defi.safe.execute import execute_safe_tx
+from eth_defi.lighter.session import LighterSession
+from eth_defi.lighter.valuation import fetch_lighter_account_by_index, parse_lighter_account_equity
 
 logger = logging.getLogger(__name__)
 
 #: Ethereum deposits and secure withdrawals have a documented 1 USDC minimum.
 LIGHTER_MIN_MAINNET_USDC = Decimal("1")
 
-#: ETH perpetual market index in the official Lighter SDK examples.
-LIGHTER_ETH_MARKET_INDEX = 0
-
-#: Seconds to wait after an L2 transaction before polling account state again.
+#: Seconds to wait before polling public Lighter state again.
 LIGHTER_STATE_POLL_SECONDS = 15
 
+#: Tolerance for Lighter API decimal rounding after an L1 USDC deposit.
+LIGHTER_COLLATERAL_TOLERANCE = Decimal("0.000010")
 
-@dataclass(slots=True)
-class LighterTradeAmounts:
-    """USDC and ETH sizes used by a Lighter manual trade.
+#: HTTP status returned while a deposited account is not indexed yet.
+HTTP_BAD_REQUEST = 400
 
-    :param deposit_usdc:
-        Suggested USDC deposit amount.
-    :param position_usdc:
-        Effective ETH long notional in USDC.
-    :param base_amount:
-        Lighter integer base amount for the ETH market order.
-    :param max_buy_price:
-        Worst acceptable buy price in Lighter integer price units.
-    :param min_quote_amount:
-        ETH market minimum quote amount, as reported by Lighter.
-    :param min_base_amount:
-        ETH market minimum base amount, as reported by Lighter.
-    """
+#: Lighter error code for a not-yet-indexed account.
+LIGHTER_ACCOUNT_NOT_FOUND_CODE = 21100
 
-    deposit_usdc: Decimal
-    position_usdc: Decimal
-    base_amount: int
-    max_buy_price: int
-    min_quote_amount: Decimal
-    min_base_amount: Decimal
+#: Lighter error code for a registered API key that is not indexed yet.
+LIGHTER_API_KEY_NOT_FOUND_CODE = 21109
 
 
-def import_lighter() -> Any:
-    """Import the optional Lighter SDK with an actionable error.
+def _is_transient_lighter_api_error(error: RequestException) -> bool:
+    """Check whether a failed Lighter request is safe to retry.
 
+    Connection failures have no response. For HTTP failures, retry only rate
+    limits and server errors; permanent client errors remain fail-fast.
+
+    :param error:
+        Requests transport or HTTP exception.
     :return:
-        Imported ``lighter`` module.
+        ``True`` for connection failures, HTTP 429 and HTTP 5xx responses.
     """
+    response = error.response
+    return response is None or response.status_code == HTTPStatus.TOO_MANY_REQUESTS or response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+def _wait_after_transient_lighter_api_error(
+    error: RequestException,
+    *,
+    deadline: float,
+    timeout: int,
+    operation: str,
+) -> None:
+    """Pause a polling loop after a transient Lighter API failure.
+
+    The caller retains its original overall deadline. This helper never hides
+    permanent HTTP errors and does not add resumable deployment state.
+
+    :param error:
+        Requests exception raised by the latest poll.
+    :param deadline:
+        Monotonic overall polling deadline.
+    :param timeout:
+        Original overall timeout in seconds, used in the terminal error.
+    :param operation:
+        Human-readable operation for logs and errors.
+    :return:
+        ``None`` after the retry delay.
+    """
+    if not _is_transient_lighter_api_error(error):
+        raise error
+    if time.monotonic() >= deadline:
+        raise TimeoutError(f"{operation} did not complete within {timeout} seconds after transient Lighter API failures") from error
+    logger.warning("Transient Lighter API failure while waiting for %s; retrying in %d seconds: %s", operation, LIGHTER_STATE_POLL_SECONDS, error)
+    time.sleep(LIGHTER_STATE_POLL_SECONDS)
+
+
+def _has_lighter_error_code(response: Response, expected_code: int) -> bool:
+    """Check a JSON error response for a known Lighter error code.
+
+    Gateways may return HTML or another non-JSON body for an HTTP 400. In that
+    case the caller falls through to :meth:`requests.Response.raise_for_status`
+    instead of leaking a JSON decoding error into a polling loop.
+
+    :param response:
+        Lighter HTTP response.
+    :param expected_code:
+        Lighter application error code to match.
+    :return:
+        ``True`` when the response contains the expected code.
+    """
+    if response.status_code != HTTP_BAD_REQUEST:
+        return False
     try:
-        import lighter  # type: ignore[import-not-found]  # noqa: PLC0415
-    except ImportError as e:
-        msg = "The full mainnet Lighter manual test needs the optional Lighter SDK. Install it with `poetry install -E lighter`, or use the full extras install command from pyproject.toml."
-        raise ImportError(msg) from e
-    return lighter
+        data = response.json()
+    except JSONDecodeError:
+        return False
+    return data.get("code") == expected_code
 
 
-def ceil_decimal(value: Decimal, step: Decimal) -> Decimal:
-    """Round a decimal up to the next step.
+def fetch_lighter_account_index(
+    session: LighterSession,
+    l1_address: HexAddress | str,
+    timeout: float = 30.0,
+) -> int | None:
+    """Fetch the lowest Lighter account index owned by an L1 address.
 
-    :param value:
-        Value to round.
-    :param step:
-        Rounding step.
+    Lighter can return multiple subaccounts for one L1 owner. The SDK path
+    previously selected the lowest index, so preserve that deterministic rule.
+
+    Authoritative endpoint documentation:
+    https://apidocs.lighter.xyz/reference/accountsbyl1address
+
+    :param session:
+        Configured Lighter HTTP session.
+    :param l1_address:
+        Safe address which owns the Lighter account.
+    :param timeout:
+        Per-request timeout in seconds.
     :return:
-        Rounded value.
+        The lowest account index, or ``None`` until Lighter exposes one.
     """
-    return (value / step).to_integral_value(rounding=ROUND_CEILING) * step
+    response = session.get(
+        f"{session.api_url}/api/v1/accountsByL1Address",
+        params={"l1_address": Web3.to_checksum_address(l1_address)},
+        timeout=timeout,
+    )
+    if _has_lighter_error_code(response, LIGHTER_ACCOUNT_NOT_FOUND_CODE):
+        return None
+    response.raise_for_status()
+    data = response.json()
+    accounts = data.get("sub_accounts") or data.get("subAccounts") or []
+    if not accounts:
+        return None
+
+    try:
+        return min(int(account["index"]) for account in accounts)
+    except (KeyError, TypeError, ValueError) as error:
+        message = "Lighter accountsByL1Address response contains an invalid account index"
+        raise ValueError(message) from error
 
 
-async def wait_for_lighter_account(lighter: Any, safe_address: str, timeout: int = 900) -> int:
-    """Wait until Lighter API exposes an account for an L1 owner.
+def wait_for_lighter_account(
+    session: LighterSession,
+    l1_address: HexAddress | str,
+    timeout: int = 900,
+) -> int:
+    """Wait for Lighter to expose a Safe-owned account.
 
-    :param lighter:
-        Imported Lighter SDK module.
-    :param safe_address:
-        L1 owner address, usually the Lagoon Safe.
+    An Ethereum L1 deposit is processed asynchronously by Lighter. This wait
+    is observable through concise logs and terminates with ``TimeoutError`` if
+    the account never becomes visible.
+
+    :param session:
+        Configured Lighter HTTP session.
+    :param l1_address:
+        Safe address which owns the account.
     :param timeout:
         Maximum wait in seconds.
     :return:
         Lighter account index.
     """
-    api_client = lighter.ApiClient(configuration=lighter.Configuration(host=LIGHTER_API_URL))
-    account_api = lighter.AccountApi(api_client)
     deadline = time.monotonic() + timeout
-    try:
-        while True:
-            try:
-                response = await account_api.accounts_by_l1_address(l1_address=safe_address)
-                if response.sub_accounts:
-                    account = min(response.sub_accounts, key=lambda item: int(item.index))
-                    logger.info(f"  Lighter account index: {account.index}")
-                    return int(account.index)
-            except lighter.ApiException as e:
-                message = getattr(getattr(e, "data", None), "message", str(e))
-                logger.info("Lighter account not visible yet for %s: %s", safe_address, message)
-
-            if time.monotonic() >= deadline:
-                raise TimeoutError(f"Lighter did not expose an account for {safe_address} within {timeout} seconds")
-            logger.info(f"  Waiting for Lighter account creation ({LIGHTER_STATE_POLL_SECONDS}s)...")
-            await asyncio.sleep(LIGHTER_STATE_POLL_SECONDS)
-    finally:
-        await api_client.close()
+    while True:
+        try:
+            account_index = fetch_lighter_account_index(session, l1_address)
+        except RequestException as error:
+            _wait_after_transient_lighter_api_error(error, deadline=deadline, timeout=timeout, operation=f"Lighter account creation for {l1_address}")
+            continue
+        if account_index is not None:
+            logger.info("Lighter account index for %s: %d", l1_address, account_index)
+            return account_index
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"Lighter did not expose an account for {l1_address} within {timeout} seconds")
+        logger.info("Waiting for Lighter account creation (%ds)", LIGHTER_STATE_POLL_SECONDS)
+        time.sleep(LIGHTER_STATE_POLL_SECONDS)
 
 
-async def fetch_lighter_account(lighter: Any, account_index: int) -> Any:
-    """Fetch a Lighter account by index.
-
-    :param lighter:
-        Imported Lighter SDK module.
-    :param account_index:
-        Lighter account index.
-    :return:
-        Detailed account model.
-    """
-    api_client = lighter.ApiClient(configuration=lighter.Configuration(host=LIGHTER_API_URL))
-    try:
-        return await lighter.AccountApi(api_client).account(by="index", value=str(account_index))
-    finally:
-        await api_client.close()
-
-
-def unwrap_lighter_account(account: Any) -> Any | None:
-    """Unwrap a Lighter account API response.
-
-    :param account:
-        Lighter account response. The SDK returns either a ``DetailedAccounts``
-        wrapper with an ``accounts`` list or the account object itself.
-    :return:
-        The first account object, or ``None`` if the response is empty.
-    """
-    if hasattr(account, "accounts"):
-        return account.accounts[0] if account.accounts else None
-    return account
-
-
-def get_eth_position(account: Any, market_index: int = LIGHTER_ETH_MARKET_INDEX) -> Decimal:
-    """Read a signed ETH position size from a Lighter account response.
-
-    :param account:
-        Lighter detailed account model.
-    :param market_index:
-        Lighter market index.
-    :return:
-        Signed ETH position amount.
-    """
-    account = unwrap_lighter_account(account)
-    if account is None:
-        return Decimal(0)
-
-    for position in account.positions:
-        if int(position.market_id) == market_index:
-            size = Decimal(str(position.position))
-            return size if int(position.sign) >= 0 else -size
-    return Decimal(0)
-
-
-def get_lighter_available_balance(account: Any) -> Decimal:
-    """Read the available USDC balance from a Lighter account response.
-
-    :param account:
-        Lighter account response.
-    :return:
-        Available USDC collateral.
-    """
-    account = unwrap_lighter_account(account)
-    if account is None:
-        return Decimal(0)
-    return Decimal(str(account.available_balance))
-
-
-def get_lighter_collateral(account: Any) -> Decimal:
-    """Read the total USDC collateral from a Lighter account response.
-
-    :param account:
-        Lighter account response.
-    :return:
-        Total USDC collateral.
-    """
-    account = unwrap_lighter_account(account)
-    if account is None:
-        return Decimal(0)
-    return Decimal(str(account.collateral))
-
-
-async def wait_for_lighter_collateral(
-    lighter: Any,
+def wait_for_lighter_collateral(
+    session: LighterSession,
     account_index: int,
     expected_usdc: Decimal,
     timeout: int = 900,
 ) -> Decimal:
-    """Wait until the Lighter account shows deposited collateral.
+    """Wait for a Lighter account to show collateral from an L1 deposit.
 
-    L1 deposits are asynchronous. The Ethereum transaction can be mined before
-    Lighter's API reflects the credited USDC balance, so callers must wait
-    before registering a trading key and opening a position.
+    The public account endpoint reports collateral after Lighter has processed
+    the mined L1 transaction. A small fixed tolerance accounts for decimal
+    display rounding in the public API response.
 
-    :param lighter:
-        Imported Lighter SDK module.
+    :param session:
+        Configured Lighter HTTP session.
     :param account_index:
         Lighter account index.
     :param expected_usdc:
-        Expected deposited USDC amount.
+        Human-readable collateral amount expected after activation.
     :param timeout:
         Maximum wait in seconds.
     :return:
-        Observed collateral.
+        Observed collateral in USDC.
     """
     deadline = time.monotonic() + timeout
-    acceptable_shortfall = Decimal("0.000010")
     while True:
-        account = await fetch_lighter_account(lighter, account_index)
-        collateral = get_lighter_collateral(account)
-        available = get_lighter_available_balance(account)
-        if collateral >= expected_usdc - acceptable_shortfall:
-            logger.info(f"  Lighter collateral credited: {collateral} USDC, available {available} USDC")
-            return collateral
+        try:
+            account = fetch_lighter_account_by_index(session, account_index)
+        except RequestException as error:
+            _wait_after_transient_lighter_api_error(error, deadline=deadline, timeout=timeout, operation=f"collateral for Lighter account {account_index}")
+            continue
+        equity = parse_lighter_account_equity(account)
+        if equity.collateral >= expected_usdc - LIGHTER_COLLATERAL_TOLERANCE:
+            logger.info(
+                "Lighter collateral credited for account %d: %s USDC, available %s USDC",
+                account_index,
+                equity.collateral,
+                equity.available_balance,
+            )
+            return equity.collateral
         if time.monotonic() >= deadline:
-            raise TimeoutError(f"Lighter collateral did not reach {expected_usdc} USDC within {timeout} seconds; current collateral {collateral}, available {available}")
-        logger.info(f"  Waiting for Lighter collateral credit; collateral {collateral} USDC, available {available} USDC")
-        await asyncio.sleep(LIGHTER_STATE_POLL_SECONDS)
+            raise TimeoutError(f"Lighter collateral did not reach {expected_usdc} USDC within {timeout} seconds; current collateral {equity.collateral}, available {equity.available_balance}")
+        logger.info(
+            "Waiting for Lighter collateral credit: collateral %s USDC, available %s USDC (%ds)",
+            equity.collateral,
+            equity.available_balance,
+            LIGHTER_STATE_POLL_SECONDS,
+        )
+        time.sleep(LIGHTER_STATE_POLL_SECONDS)
 
 
-def sdk_pubkey_to_bytes(public_key: str) -> bytes:
-    """Convert a Lighter SDK public-key string to on-chain bytes.
+def _normalise_public_key(public_key: str) -> bytes:
+    """Decode a Lighter public-key string without exposing it in errors.
 
     :param public_key:
-        SDK public-key string, ``0x`` plus 40 bytes.
+        Hexadecimal public key returned by Lighter.
     :return:
-        Raw public-key bytes for ``changePubKey``.
+        Decoded public-key bytes.
     """
-    pubkey = bytes.fromhex(public_key.removeprefix("0x"))
-    validate_lighter_pubkey(pubkey)
-    return pubkey
+    try:
+        return bytes.fromhex(public_key.removeprefix("0x"))
+    except ValueError as error:
+        message = "Lighter API response contains a malformed public key"
+        raise ValueError(message) from error
 
 
-async def register_lighter_api_key(  # noqa: PLR0917
-    lighter: Any,
-    web3: Web3,
-    safe: Safe,
-    hot_wallet: HotWallet,
+def fetch_lighter_api_key(
+    session: LighterSession,
     account_index: int,
     api_key_index: int,
-) -> str:
-    """Generate and register a Lighter API key through a Safe.
+    timeout: float = 30.0,
+) -> dict[str, Any] | None:
+    """Fetch one Lighter API-key record from the public account API.
 
-    :param lighter:
-        Imported Lighter SDK module.
-    :param web3:
-        Web3 connection.
-    :param safe:
-        Safe that owns the Lighter account.
-    :param hot_wallet:
-        1-of-1 Safe owner.
+    :param session:
+        Configured Lighter HTTP session.
     :param account_index:
         Lighter account index.
     :param api_key_index:
-        Lighter API-key slot.
+        Requested API-key slot.
+    :param timeout:
+        Per-request timeout in seconds.
     :return:
-        SDK API private key.
+        Matching API-key response object, or ``None`` if it is not visible.
     """
-    if api_key_index < MIN_API_KEY_INDEX:
-        raise ValueError(f"Use API key index {MIN_API_KEY_INDEX} or higher; lower indices are reserved by Lighter")
-
-    private_key, public_key, err = lighter.create_api_key()
-    if err is not None:
-        raise RuntimeError(f"Could not create Lighter API key: {err}")
-
-    pubkey = sdk_pubkey_to_bytes(public_key)
-    logger.info(f"\nRegistering Lighter API key index {api_key_index} via Safe changePubKey...")
-    gas_price = max(web3.eth.gas_price * 3, 2_000_000_000)
-    safe_tx = build_change_pubkey_safe_tx(web3, safe, account_index, api_key_index, pubkey)
-    safe_tx.sign(hot_wallet.private_key.hex())
-    tx_hash, tx = execute_safe_tx(
-        safe_tx,
-        tx_sender_private_key=hot_wallet.private_key.hex(),
-        tx_gas_price=gas_price,
-        hot_wallet=hot_wallet,
+    response = session.get(
+        f"{session.api_url}/api/v1/apikeys",
+        params={"account_index": account_index, "api_key_index": api_key_index},
+        timeout=timeout,
     )
-    logger.info(f"  changePubKey tx: {tx_hash.hex()} (nonce {tx['nonce']}, gas price {tx['gasPrice']})")
-    receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=300)
-    if receipt["status"] != 1:
-        raise RuntimeError(f"Lighter changePubKey transaction failed: {tx_hash.hex()}")
-
-    client = lighter.SignerClient(
-        url=LIGHTER_API_URL,
-        account_index=account_index,
-        api_private_keys={api_key_index: private_key},
-    )
-    try:
-        deadline = time.monotonic() + 300
-        while True:
-            err = client.check_client()
-            if err is None:
-                logger.info("  API key is active on Lighter")
-                return private_key
-            if time.monotonic() >= deadline:
-                raise TimeoutError(f"Registered API key was not accepted by Lighter within 300 seconds: {err}")
-            logger.info(f"  Waiting for API key activation ({LIGHTER_STATE_POLL_SECONDS}s): {err}")
-            await asyncio.sleep(LIGHTER_STATE_POLL_SECONDS)
-    finally:
-        await client.close()
+    if _has_lighter_error_code(response, LIGHTER_API_KEY_NOT_FOUND_CODE):
+        return None
+    response.raise_for_status()
+    data = response.json()
+    api_keys = data.get("api_keys") or data.get("apiKeys") or []
+    for api_key in api_keys:
+        try:
+            response_index = api_key.get("api_key_index", api_key.get("apiKeyIndex"))
+            if int(response_index) == api_key_index:
+                return api_key
+        except (AttributeError, TypeError, ValueError) as error:
+            message = "Lighter apikeys response contains an invalid API-key index"
+            raise ValueError(message) from error
+    return None
 
 
-async def resolve_eth_trade_amounts(
-    lighter: Any,
-    deposit_usdc: Decimal | None = None,
-    position_usdc: Decimal | None = None,
-) -> LighterTradeAmounts:
-    """Resolve Lighter ETH market minimums and choose manual-test sizes.
-
-    :param lighter:
-        Imported Lighter SDK module.
-    :param deposit_usdc:
-        Optional explicit deposit amount.
-    :param position_usdc:
-        Optional explicit position notional.
-    :return:
-        Trade amount configuration.
-    """
-    api_client = lighter.ApiClient(configuration=lighter.Configuration(host=LIGHTER_API_URL))
-    try:
-        details = await lighter.OrderApi(api_client).order_book_details(market_id=LIGHTER_ETH_MARKET_INDEX)
-        eth_market = details.order_book_details[0]
-        min_quote_amount = Decimal(str(eth_market.min_quote_amount))
-        min_base_amount = Decimal(str(eth_market.min_base_amount))
-        last_price = Decimal(str(eth_market.last_trade_price))
-        size_decimals = int(eth_market.size_decimals)
-
-        default_position_usdc = max(LIGHTER_MIN_MAINNET_USDC, min_quote_amount) + Decimal("1")
-        resolved_position_usdc = position_usdc if position_usdc is not None else default_position_usdc
-        if resolved_position_usdc < min_quote_amount:
-            raise ValueError(f"position_usdc={resolved_position_usdc} is below Lighter ETH market min_quote_amount={min_quote_amount}")
-
-        eth_size = max(min_base_amount, resolved_position_usdc / last_price)
-        eth_size = ceil_decimal(eth_size, Decimal(1) / Decimal(10**size_decimals))
-        base_amount = int(eth_size * Decimal(10**size_decimals))
-        max_buy_price = int((last_price * Decimal("1.05") * Decimal(100)).to_integral_value(rounding=ROUND_CEILING))
-        effective_position_usdc = eth_size * last_price
-
-        default_deposit_usdc = max(LIGHTER_MIN_MAINNET_USDC, effective_position_usdc + Decimal("5"))
-        resolved_deposit_usdc = deposit_usdc if deposit_usdc is not None else default_deposit_usdc
-        if resolved_deposit_usdc < LIGHTER_MIN_MAINNET_USDC:
-            raise ValueError(f"deposit_usdc={resolved_deposit_usdc} is below Lighter's {LIGHTER_MIN_MAINNET_USDC} USDC deposit minimum")
-        if resolved_deposit_usdc <= effective_position_usdc:
-            raise ValueError(f"deposit_usdc={resolved_deposit_usdc} must be larger than the test position notional {effective_position_usdc}")
-
-        logger.info("\nLighter ETH market minimums:")
-        logger.info(f"  min_quote_amount: {min_quote_amount} USDC")
-        logger.info(f"  min_base_amount:  {min_base_amount} ETH")
-        logger.info(f"  last price:       {last_price} USDC/ETH")
-        logger.info(f"  chosen deposit:   {resolved_deposit_usdc} USDC")
-        logger.info(f"  chosen position:  {effective_position_usdc:.6f} USDC ({eth_size} ETH)")
-
-        return LighterTradeAmounts(
-            deposit_usdc=resolved_deposit_usdc,
-            position_usdc=effective_position_usdc,
-            base_amount=base_amount,
-            max_buy_price=max_buy_price,
-            min_quote_amount=min_quote_amount,
-            min_base_amount=min_base_amount,
-        )
-    finally:
-        await api_client.close()
-
-
-async def wait_for_eth_position(
-    lighter: Any,
+def wait_for_lighter_api_key(
+    session: LighterSession,
     account_index: int,
-    predicate: Callable[[Decimal], bool],
-    description: str,
+    api_key_index: int,
+    expected_public_key: str,
     timeout: int = 300,
-) -> Decimal:
-    """Wait until the ETH position matches a predicate.
+) -> None:
+    """Wait until Lighter exposes a registered API key matching a public key.
 
-    :param lighter:
-        Imported Lighter SDK module.
+    :param session:
+        Configured Lighter HTTP session.
     :param account_index:
         Lighter account index.
-    :param predicate:
-        Function receiving the signed position.
-    :param description:
-        Human-readable wait target.
+    :param api_key_index:
+        Requested API-key slot.
+    :param expected_public_key:
+        Locally generated public key, encoded as hexadecimal.
     :param timeout:
         Maximum wait in seconds.
     :return:
-        Matching position.
+        ``None`` once the exact key is visible.
     """
+    expected = _normalise_public_key(expected_public_key)
     deadline = time.monotonic() + timeout
     while True:
-        account = await fetch_lighter_account(lighter, account_index)
-        position = get_eth_position(account)
-        if predicate(position):
-            logger.info(f"  ETH position {description}: {position}")
-            return position
+        try:
+            api_key = fetch_lighter_api_key(session, account_index, api_key_index)
+        except RequestException as error:
+            _wait_after_transient_lighter_api_error(error, deadline=deadline, timeout=timeout, operation=f"API key {api_key_index} for Lighter account {account_index}")
+            continue
+        if api_key is not None:
+            public_key = api_key.get("public_key", api_key.get("publicKey"))
+            if not isinstance(public_key, str):
+                message = "Lighter apikeys response does not contain a public key"
+                raise ValueError(message)
+            if _normalise_public_key(public_key) == expected:
+                logger.info("Lighter API key %d is active for account %d", api_key_index, account_index)
+                return
         if time.monotonic() >= deadline:
-            raise TimeoutError(f"ETH position did not become {description} within {timeout} seconds; current position {position}")
-        logger.info(f"  Waiting for ETH position to become {description}; current {position}")
-        await asyncio.sleep(LIGHTER_STATE_POLL_SECONDS)
-
-
-async def trade_eth_roundtrip(
-    lighter: Any,
-    account_index: int,
-    api_private_key: str,
-    api_key_index: int,
-    amounts: LighterTradeAmounts,
-) -> None:
-    """Open and close an ETH long on Lighter.
-
-    :param lighter:
-        Imported Lighter SDK module.
-    :param account_index:
-        Lighter account index.
-    :param api_private_key:
-        SDK API private key.
-    :param api_key_index:
-        Lighter API-key slot.
-    :param amounts:
-        Trade sizing information.
-    """
-    client = lighter.SignerClient(
-        url=LIGHTER_API_URL,
-        account_index=account_index,
-        api_private_keys={api_key_index: api_private_key},
-    )
-    try:
-        err = client.check_client()
-        if err is not None:
-            raise RuntimeError(f"Lighter API key check failed: {err}")
-
-        logger.info("\nOpening ETH long on Lighter...")
-        open_tx, open_response, err = await client.create_market_order(
-            market_index=LIGHTER_ETH_MARKET_INDEX,
-            client_order_index=int(time.time()),
-            base_amount=amounts.base_amount,
-            avg_execution_price=amounts.max_buy_price,
-            is_ask=False,
-            api_key_index=api_key_index,
-        )
-        if err is not None:
-            raise RuntimeError(f"Opening ETH long failed: {err}")
-        logger.info(f"  Open order tx: {open_tx}")
-        logger.info(f"  Open response: {open_response}")
-
-        opened_position = await wait_for_eth_position(lighter, account_index, lambda position: position > 0, "open")
-
-        logger.info("\nClosing ETH long on Lighter...")
-        close_tx, close_response, err = await client.create_market_order(
-            market_index=LIGHTER_ETH_MARKET_INDEX,
-            client_order_index=int(time.time()) + 1,
-            base_amount=amounts.base_amount,
-            avg_execution_price=1,
-            is_ask=True,
-            reduce_only=True,
-            api_key_index=api_key_index,
-        )
-        if err is not None:
-            raise RuntimeError(f"Closing ETH long failed: {err}")
-        logger.info(f"  Close order tx: {close_tx}")
-        logger.info(f"  Close response: {close_response}")
-
-        await wait_for_eth_position(lighter, account_index, lambda position: abs(position) < max(opened_position / Decimal(1000), Decimal("0.000001")), "closed")
-    finally:
-        await client.close()
-
-
-async def withdraw_from_lighter(
-    lighter: Any,
-    account_index: int,
-    api_private_key: str,
-    api_key_index: int,
-    withdraw_usdc: Decimal,
-) -> None:
-    """Request a secure USDC withdrawal from Lighter.
-
-    :param lighter:
-        Imported Lighter SDK module.
-    :param account_index:
-        Lighter account index.
-    :param api_private_key:
-        SDK API private key.
-    :param api_key_index:
-        Lighter API-key slot.
-    :param withdraw_usdc:
-        Human-readable USDC withdrawal amount.
-    """
-    if withdraw_usdc < LIGHTER_MIN_MAINNET_USDC:
-        raise ValueError(f"Lighter secure withdrawals have a {LIGHTER_MIN_MAINNET_USDC} USDC minimum, got {withdraw_usdc}")
-
-    client = lighter.SignerClient(
-        url=LIGHTER_API_URL,
-        account_index=account_index,
-        api_private_keys={api_key_index: api_private_key},
-    )
-    try:
-        logger.info(f"\nRequesting Lighter secure withdrawal of {withdraw_usdc} USDC...")
-        withdraw_tx, response, err = await client.withdraw(
-            asset_id=client.ASSET_ID_USDC,
-            route_type=client.ROUTE_PERP,
-            amount=float(withdraw_usdc),
-            api_key_index=api_key_index,
-        )
-        if err is not None:
-            raise RuntimeError(f"Lighter withdrawal request failed: {err}")
-        logger.info(f"  Withdraw tx: {withdraw_tx}")
-        logger.info(f"  Withdraw response: {response}")
-    finally:
-        await client.close()
+            raise TimeoutError(f"Lighter API key {api_key_index} was not visible for account {account_index} within {timeout} seconds")
+        logger.info("Waiting for Lighter API-key registration (%ds)", LIGHTER_STATE_POLL_SECONDS)
+        time.sleep(LIGHTER_STATE_POLL_SECONDS)

--- a/eth_defi/lighter/api_key.py
+++ b/eth_defi/lighter/api_key.py
@@ -1,0 +1,234 @@
+"""Native Lighter API-key generation.
+
+This module replaces the ``lighter-sdk`` dependency for the one operation the
+Lagoon deployer needs: generating a secret scalar and deriving its public key.
+It deliberately does *not* implement Lighter transaction signing, API
+authentication, nonce management or order submission.
+
+The arithmetic is a small, non-constant-time Python port of the ECgFp5 public
+key derivation in `poseidon_crypto`_ at commit
+``ca0ad1bc8dfe822c61ba7556d1d4d5bcc2ea4a26`` (Apache-2.0), as used by
+`lighter-go`_. It is suitable for one-off local key creation during deployment,
+not for a general-purpose cryptography API.
+
+.. _poseidon_crypto: https://github.com/elliottech/poseidon_crypto
+.. _lighter-go: https://github.com/elliottech/lighter-go
+"""
+
+import secrets
+from dataclasses import dataclass, field
+
+from eth_defi.lighter.pubkey import GOLDILOCKS_MODULUS, MAX_API_KEY_INDEX, MIN_API_KEY_INDEX, validate_lighter_pubkey
+
+#: Degree of the Goldilocks extension field used by ECgFp5.
+EXTENSION_DEGREE = 5
+
+#: Prime order of the ECgFp5 group from ``curve/ecgfp5/scalar_field.go``.
+ECGFP5_SCALAR_ORDER = 1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241
+
+_Fp5 = tuple[int, int, int, int, int]
+_Point = tuple[_Fp5, _Fp5, _Fp5, _Fp5]
+_ZERO: _Fp5 = (0, 0, 0, 0, 0)
+_ONE: _Fp5 = (1, 0, 0, 0, 0)
+_B: _Fp5 = (0, 263, 0, 0, 0)
+_B_MUL2: _Fp5 = (0, 526, 0, 0, 0)
+_B_MUL4: _Fp5 = (0, 1052, 0, 0, 0)
+_FOUR: _Fp5 = (4, 0, 0, 0, 0)
+
+#: ``(x, z, u, t)`` projective coordinates of the official generator.
+_GENERATOR: _Point = (
+    (12883135586176881569, 4356519642755055268, 5248930565894896907, 2165973894480315022, 2448410071095648785),
+    _ONE,
+    _ONE,
+    _FOUR,
+)
+_NEUTRAL: _Point = (_ZERO, _ONE, _ZERO, _ONE)
+
+
+@dataclass(slots=True, frozen=True)
+class LighterApiKey:
+    """A locally generated Lighter API-key pair.
+
+    The private scalar is intentionally excluded from ``repr()``. Store it only
+    in an explicitly secret-bearing deployment report.
+    """
+
+    #: Lighter API-key slot, 4 through 254.
+    api_key_index: int
+
+    #: 40-byte little-endian private scalar, hex encoded with a ``0x`` prefix.
+    private_key: str = field(repr=False)
+
+    #: 40-byte little-endian ECgFp5 public key, hex encoded with a ``0x`` prefix.
+    public_key: str
+
+
+def _fp5_add(left: _Fp5, right: _Fp5) -> _Fp5:
+    """Add two Goldilocks quintic-extension elements.
+
+    :param left: Left field element.
+    :param right: Right field element.
+    :return: Sum reduced by the Goldilocks modulus.
+    """
+    return tuple((left[i] + right[i]) % GOLDILOCKS_MODULUS for i in range(5))  # type: ignore[return-value]
+
+
+def _fp5_sub(left: _Fp5, right: _Fp5) -> _Fp5:
+    """Subtract two Goldilocks quintic-extension elements.
+
+    :param left: Left field element.
+    :param right: Right field element.
+    :return: Difference reduced by the Goldilocks modulus.
+    """
+    return tuple((left[i] - right[i]) % GOLDILOCKS_MODULUS for i in range(5))  # type: ignore[return-value]
+
+
+def _fp5_mul(left: _Fp5, right: _Fp5) -> _Fp5:
+    """Multiply elements in ``F_p[X] / (X**5 - 3)``.
+
+    :param left: Left field element.
+    :param right: Right field element.
+    :return: Product reduced in the quintic extension field.
+    """
+    result = [0] * EXTENSION_DEGREE
+    for left_index, left_value in enumerate(left):
+        for right_index, right_value in enumerate(right):
+            index = left_index + right_index
+            product = left_value * right_value
+            if index >= EXTENSION_DEGREE:
+                result[index - EXTENSION_DEGREE] += 3 * product
+            else:
+                result[index] += product
+    return tuple(value % GOLDILOCKS_MODULUS for value in result)  # type: ignore[return-value]
+
+
+def _fp5_square(value: _Fp5) -> _Fp5:
+    """Square a Goldilocks quintic-extension element.
+
+    :param value: Field element to square.
+    :return: Squared field element.
+    """
+    return _fp5_mul(value, value)
+
+
+def _fp5_inverse(value: _Fp5) -> _Fp5:
+    """Return the multiplicative inverse of a non-zero extension element.
+
+    :param value: Non-zero field element.
+    :return: Multiplicative inverse calculated by exponentiation.
+    """
+    if value == _ZERO:
+        message = "Cannot invert zero ECgFp5 element"
+        raise ValueError(message)
+
+    exponent = GOLDILOCKS_MODULUS**EXTENSION_DEGREE - 2
+    result = _ONE
+    base = value
+    while exponent:
+        if exponent & 1:
+            result = _fp5_mul(result, base)
+        base = _fp5_square(base)
+        exponent >>= 1
+    return result
+
+
+def _point_add(left: _Point, right: _Point) -> _Point:  # noqa: PLR0914
+    """Add ECgFp5 points with the official complete projective formula.
+
+    :param left: Left point in ``(x, z, u, t)`` projective coordinates.
+    :param right: Right point in ``(x, z, u, t)`` projective coordinates.
+    :return: Sum in projective coordinates.
+    """
+    x1, z1, u1, t1_source = left
+    x2, z2, u2, t2_source = right
+    t1 = _fp5_mul(x1, x2)
+    t2 = _fp5_mul(z1, z2)
+    t3 = _fp5_mul(u1, u2)
+    t4 = _fp5_mul(t1_source, t2_source)
+    t5 = _fp5_sub(_fp5_mul(_fp5_add(x1, z1), _fp5_add(x2, z2)), _fp5_add(t1, t2))
+    t6 = _fp5_sub(_fp5_mul(_fp5_add(u1, t1_source), _fp5_add(u2, t2_source)), _fp5_add(t3, t4))
+    t7 = _fp5_add(t1, _fp5_mul(t2, _B))
+    t8 = _fp5_mul(t4, t7)
+    t9 = _fp5_mul(t3, _fp5_add(_fp5_mul(t5, _B_MUL2), _fp5_add(t7, t7)))
+    t10 = _fp5_mul(_fp5_add(t4, _fp5_add(t3, t3)), _fp5_add(t5, t7))
+    return (
+        _fp5_mul(_fp5_sub(t10, t8), _B),
+        _fp5_sub(t8, t9),
+        _fp5_mul(t6, _fp5_sub(_fp5_mul(t2, _B), t1)),
+        _fp5_add(t8, t9),
+    )
+
+
+def _point_double(point: _Point) -> _Point:
+    """Double an ECgFp5 point with the official projective formula.
+
+    :param point: Point in ``(x, z, u, t)`` projective coordinates.
+    :return: Doubled point in projective coordinates.
+    """
+    x, z, u, t = point
+    t1 = _fp5_mul(z, t)
+    t2 = _fp5_mul(t1, t)
+    x1 = _fp5_square(t2)
+    z1 = _fp5_mul(t1, u)
+    t3 = _fp5_square(u)
+    w1 = _fp5_sub(t2, _fp5_mul(t3, _fp5_add(_fp5_add(x, z), _fp5_add(x, z))))
+    t4 = _fp5_square(z1)
+    z_new = _fp5_square(w1)
+    return (
+        _fp5_mul(t4, _B_MUL4),
+        z_new,
+        _fp5_sub(_fp5_square(_fp5_add(w1, z1)), _fp5_add(t4, z_new)),
+        _fp5_sub(_fp5_add(x1, x1), _fp5_add(_fp5_mul(t4, _FOUR), z_new)),
+    )
+
+
+def _derive_public_key(private_scalar: int) -> bytes:
+    """Derive a canonical 40-byte Lighter public key from a private scalar.
+
+    :param private_scalar: Secret scalar within the ECgFp5 group order.
+    :return: Affine public key as five little-endian Goldilocks limbs.
+    """
+    if not 0 < private_scalar < ECGFP5_SCALAR_ORDER:
+        message = "Lighter private scalar must be within the ECgFp5 group order"
+        raise ValueError(message)
+
+    result = _NEUTRAL
+    point = _GENERATOR
+    scalar = private_scalar
+    while scalar:
+        if scalar & 1:
+            result = _point_add(result, point)
+        point = _point_double(point)
+        scalar >>= 1
+
+    _, _, u, t = result
+    encoded = _fp5_mul(t, _fp5_inverse(u))
+    return b"".join(limb.to_bytes(8, "little") for limb in encoded)
+
+
+def generate_lighter_api_key(api_key_index: int = MIN_API_KEY_INDEX) -> LighterApiKey:
+    """Generate a Lighter API-key pair for deployment registration.
+
+    Uses Python's cryptographic random source for a non-zero scalar and derives
+    only its public key locally. The caller must register the public key on
+    L1 before using the private key for Lighter trading.
+
+    :param api_key_index:
+        Lighter API-key slot in the user range 4 through 254.
+
+    :return:
+        A private/public API-key pair. Its private key is not included in
+        ``repr()``.
+    """
+    if not MIN_API_KEY_INDEX <= api_key_index <= MAX_API_KEY_INDEX:
+        raise ValueError(f"api_key_index must be {MIN_API_KEY_INDEX}..{MAX_API_KEY_INDEX}, got {api_key_index}")
+
+    private_scalar = secrets.randbelow(ECGFP5_SCALAR_ORDER - 1) + 1
+    private_key = "0x" + private_scalar.to_bytes(40, "little").hex()
+    public_key_bytes = _derive_public_key(private_scalar)
+    validate_lighter_pubkey(public_key_bytes)
+    return LighterApiKey(
+        api_key_index=api_key_index,
+        private_key=private_key,
+        public_key="0x" + public_key_bytes.hex(),
+    )

--- a/eth_defi/lighter/deployment.py
+++ b/eth_defi/lighter/deployment.py
@@ -9,9 +9,11 @@ is called both by the Lagoon vault deployment flow
 (:py:mod:`eth_defi.erc_4626.vault_protocol.lagoon.deployment`) and by the
 Anvil-fork tests (via :py:mod:`eth_defi.lighter.testing`).
 
-The on-chain scope is the L1 custody flow only: ``deposit`` /
-``withdraw`` / ``withdrawPendingBalance``. Account registration is off-chain
-(EIP-712 / EIP-1271 Safe signature) and does not go through the guard.
+The onchain asset-manager scope is the L1 custody flow only: ``deposit`` /
+``withdraw`` / ``withdrawPendingBalance``. Safe-owned account key registration
+uses a direct L1 ``changePubKey`` Safe transaction: it bypasses the asset-manager
+module, while the installed Safe guard permits it through the intentional
+governance bypass. Subsequent trading is offchain.
 
 See ``eth_defi/lighter/README-lighter-guard.md`` for the architecture and
 security model.
@@ -52,7 +54,7 @@ class LighterDeployment:
     .. note::
 
         **USDC-only.** This integration currently whitelists a single Lighter
-        deposit asset — USDC — whose on-chain asset index is read from
+        deposit asset — USDC — whose onchain asset index is read from
         ``ZkLighter.USDC_ASSET_INDEX()`` at whitelist time. Multiple deposit
         assets / asset indexes are not yet supported (unlike Hypercore, which
         whitelists multiple vaults via a single multicall). Adding more assets

--- a/eth_defi/lighter/lagoon.py
+++ b/eth_defi/lighter/lagoon.py
@@ -1,32 +1,27 @@
-"""Lagoon vault helpers for Lighter L1 custody.
+"""Lagoon Safe helpers for Lighter L1 deposits.
 
-This module contains reusable helpers for moving USDC between a Lagoon Safe and
-the Lighter L1 contract. It deliberately does not cover Lagoon deployment or
-share redemption orchestration; those remain protocol/vault concerns.
+The deployment flow transfers the minimum accounted USDC balance from a Lagoon
+Safe to Lighter through ``TradingStrategyModuleV0``. Trading and withdrawals
+are intentionally outside this custody helper.
 
-Authoritative documentation:
-
-- Lighter deposits and withdrawals:
-  https://apidocs.lighter.xyz/docs/deposits-transfers-and-withdrawals
-- Lighter L1 proxy:
-  https://etherscan.io/address/0x3b4d794a66304f130a4db8f2551b0070dfcf5ca7
+Authoritative Lighter deposit documentation:
+https://apidocs.lighter.xyz/docs/deposits-transfers-and-withdrawals
 """
 
 import logging
-import time
 from decimal import Decimal
 
 from eth_typing import HexAddress
 from web3 import Web3
+from web3.contract.contract import ContractFunction
 
 from eth_defi.abi import get_deployed_contract
 from eth_defi.confirmation import broadcast_and_wait_transactions_to_complete
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.gas import apply_gas, estimate_gas_price
 from eth_defi.hotwallet import HotWallet
-from eth_defi.lighter.api import LIGHTER_MIN_MAINNET_USDC, LIGHTER_STATE_POLL_SECONDS
+from eth_defi.lighter.api import LIGHTER_MIN_MAINNET_USDC
 from eth_defi.lighter.constants import LIGHTER_L1_CONTRACT
-from eth_defi.safe.execute import execute_safe_tx
 from eth_defi.token import TokenDetails
 
 logger = logging.getLogger(__name__)
@@ -38,74 +33,79 @@ LIGHTER_ROUTE_PERP = 0
 def broadcast_tx(
     web3: Web3,
     hot_wallet: HotWallet,
-    bound_func,
+    bound_func: ContractFunction,
     description: str,
     gas_limit: int = 1_000_000,
 ) -> str:
-    """Sign, broadcast and wait for a transaction.
+    """Sign, broadcast and wait for one transaction.
 
     :param web3:
         Web3 connection.
     :param hot_wallet:
         Transaction signer.
     :param bound_func:
-        Bound contract function.
+        Bound contract function to execute.
     :param description:
-        Human-readable transaction description.
+        Human-readable transaction description for logs.
     :param gas_limit:
-        Gas limit.
+        Transaction gas limit.
     :return:
-        Transaction hash hex string.
+        Confirmed transaction hash in hexadecimal form.
     """
     gas_price_suggestion = estimate_gas_price(web3)
     tx_params = apply_gas({"gas": gas_limit}, gas_price_suggestion)
     tx = hot_wallet.sign_bound_call_with_new_nonce(bound_func, tx_params=tx_params)
-
-    logger.info(f"  Broadcasting: {description}")
-    logger.info(f"    TX hash: {tx.hash.hex()}")
+    logger.info("Broadcasting: %s", description)
+    logger.info("Transaction hash: %s", tx.hash.hex())
     broadcast_and_wait_transactions_to_complete(web3, [tx])
     receipt = web3.eth.get_transaction_receipt(tx.hash)
     if receipt["status"] != 1:
         raise RuntimeError(f"Transaction failed: {description} ({tx.hash.hex()})")
-    logger.info(f"    Gas used: {receipt['gasUsed']:,}")
-    return tx.hash.hex()
+    logger.info("Gas used: %s", receipt["gasUsed"])
+    return Web3.to_hex(tx.hash)
 
 
 def deposit_usdc_from_lagoon_safe_into_lighter(
     web3: Web3,
     hot_wallet: HotWallet,
+    *,
     vault: LagoonVault,
     usdc: TokenDetails,
     deposit_usdc: Decimal,
-) -> None:
-    """Approve and deposit USDC from a Lagoon Safe into Lighter.
+    zk_lighter: HexAddress | str = LIGHTER_L1_CONTRACT,
+) -> str:
+    """Approve and deposit Safe-owned USDC into Lighter through the guard.
+
+    The caller must fund the Safe through Lagoon settlement before this call;
+    direct USDC donations are not an accounted Lagoon subscription.
 
     :param web3:
         Web3 connection.
     :param hot_wallet:
-        Asset-manager wallet.
+        Whitelisted Lagoon asset-manager wallet.
     :param vault:
-        Lagoon vault.
+        Lagoon vault whose Safe owns the Lighter account.
     :param usdc:
-        USDC token details.
+        Configured native Ethereum USDC token details.
     :param deposit_usdc:
-        Human-readable USDC amount.
+        Human-readable USDC amount to deposit.
+    :param zk_lighter:
+        Whitelisted ZkLighter L1 contract address.
+    :return:
+        Confirmed Lighter deposit transaction hash.
     """
+    if deposit_usdc < LIGHTER_MIN_MAINNET_USDC:
+        raise ValueError(f"Lighter Ethereum deposits have a {LIGHTER_MIN_MAINNET_USDC} USDC minimum, got {deposit_usdc}")
+
+    zk_lighter = Web3.to_checksum_address(zk_lighter)
     safe = vault.safe_address
-    zk = get_deployed_contract(web3, "lighter/ZkLighter.json", LIGHTER_L1_CONTRACT)
+    zk = get_deployed_contract(web3, "lighter/ZkLighter.json", zk_lighter)
     asset_index = zk.functions.USDC_ASSET_INDEX().call()
     amount_raw = usdc.convert_to_raw(deposit_usdc)
     module = get_deployed_contract(web3, "safe-integration/TradingStrategyModuleV0.json", vault.trading_strategy_module_address)
 
-    if deposit_usdc < LIGHTER_MIN_MAINNET_USDC:
-        raise ValueError(f"Lighter Ethereum deposits have a {LIGHTER_MIN_MAINNET_USDC} USDC minimum, got {deposit_usdc}")
-
-    logger.info(f"\nDepositing {deposit_usdc} USDC from Safe into Lighter...")
-    logger.info(f"  Lighter contract: {LIGHTER_L1_CONTRACT}")
-    logger.info(f"  Safe / Lighter owner: {safe}")
-    logger.info(f"  USDC asset index: {asset_index}")
-
-    approve_data = usdc.contract.functions.approve(LIGHTER_L1_CONTRACT, amount_raw)._encode_transaction_data()
+    logger.info("Depositing %s USDC from Safe %s into Lighter %s", deposit_usdc, safe, zk_lighter)
+    approve_data = usdc.contract.functions.approve(zk_lighter, amount_raw)._encode_transaction_data()
     broadcast_tx(
         web3,
         hot_wallet,
@@ -114,144 +114,11 @@ def deposit_usdc_from_lagoon_safe_into_lighter(
     )
 
     deposit_data = zk.functions.deposit(safe, asset_index, LIGHTER_ROUTE_PERP, amount_raw)._encode_transaction_data()
-    broadcast_tx(
+    tx_hash = broadcast_tx(
         web3,
         hot_wallet,
-        module.functions.performCall(LIGHTER_L1_CONTRACT, deposit_data, 0),
+        module.functions.performCall(zk_lighter, deposit_data, 0),
         "Deposit USDC from Safe to Lighter",
     )
-    logger.info(f"  Safe USDC balance after Lighter deposit: {usdc.fetch_balance_of(safe)}")
-
-
-def fetch_lighter_pending_balance(web3: Web3, owner: HexAddress, asset_index: int) -> int:
-    """Fetch pending Lighter L1 withdrawal balance.
-
-    :param web3:
-        Web3 connection.
-    :param owner:
-        L1 account owner.
-    :param asset_index:
-        Lighter asset index.
-    :return:
-        Pending raw token amount.
-    """
-    abi = [
-        {
-            "inputs": [
-                {"internalType": "address", "name": "_owner", "type": "address"},
-                {"internalType": "uint16", "name": "_assetIndex", "type": "uint16"},
-            ],
-            "name": "getPendingBalance",
-            "outputs": [{"internalType": "uint128", "name": "", "type": "uint128"}],
-            "stateMutability": "view",
-            "type": "function",
-        }
-    ]
-    contract = web3.eth.contract(address=Web3.to_checksum_address(LIGHTER_L1_CONTRACT), abi=abi)
-    return contract.functions.getPendingBalance(owner, asset_index).call()
-
-
-def claim_lighter_pending_balance(  # noqa: PLR0917
-    web3: Web3,
-    hot_wallet: HotWallet,
-    vault: LagoonVault,
-    usdc: TokenDetails,
-    expected_raw_amount: int,
-    timeout: int,
-) -> None:
-    """Claim Lighter pending withdrawal balance back to a Lagoon Safe.
-
-    :param web3:
-        Web3 connection.
-    :param hot_wallet:
-        Asset-manager wallet.
-    :param vault:
-        Lagoon vault.
-    :param usdc:
-        USDC token details.
-    :param expected_raw_amount:
-        Expected raw USDC amount.
-    :param timeout:
-        Maximum wait in seconds.
-    """
-    zk = get_deployed_contract(web3, "lighter/ZkLighter.json", LIGHTER_L1_CONTRACT)
-    module = get_deployed_contract(web3, "safe-integration/TradingStrategyModuleV0.json", vault.trading_strategy_module_address)
-    asset_index = zk.functions.USDC_ASSET_INDEX().call()
-    deadline = time.monotonic() + timeout
-    acceptable_shortfall_raw = max(10, expected_raw_amount // 1000)
-    claim_raw_amount = 0
-
-    logger.info("\nWaiting for Lighter withdrawal to become claimable on L1...")
-    while True:
-        pending_raw = fetch_lighter_pending_balance(web3, vault.safe_address, asset_index)
-        pending_usdc = usdc.convert_to_decimals(pending_raw)
-        if pending_raw >= expected_raw_amount:
-            logger.info(f"  Pending claimable balance: {pending_usdc} USDC")
-            claim_raw_amount = expected_raw_amount
-            break
-        if expected_raw_amount - acceptable_shortfall_raw <= pending_raw < expected_raw_amount:
-            shortfall_raw = expected_raw_amount - pending_raw
-            logger.info(f"  Pending claimable balance: {pending_usdc} USDC; accepting {usdc.convert_to_decimals(shortfall_raw)} USDC shortfall")
-            claim_raw_amount = pending_raw
-            break
-        if time.monotonic() >= deadline:
-            raise TimeoutError(f"Lighter pending withdrawal did not reach {usdc.convert_to_decimals(expected_raw_amount)} USDC within {timeout} seconds; current pending {pending_usdc}")
-        logger.info(f"  Pending claimable balance: {pending_usdc} USDC; polling again in {LIGHTER_STATE_POLL_SECONDS}s")
-        time.sleep(LIGHTER_STATE_POLL_SECONDS)
-
-    before = usdc.fetch_balance_of(vault.safe_address)
-    before_raw = usdc.convert_to_raw(before)
-    claim_data = zk.functions.withdrawPendingBalance(vault.safe_address, asset_index, claim_raw_amount)._encode_transaction_data()
-    broadcast_tx(
-        web3,
-        hot_wallet,
-        module.functions.performCall(LIGHTER_L1_CONTRACT, claim_data, 0),
-        "Claim Lighter pending balance to Safe",
-        gas_limit=250_000,
-    )
-    expected_safe_raw_balance = before_raw + claim_raw_amount
-    deadline = time.monotonic() + 120
-    while True:
-        after = usdc.fetch_balance_of(vault.safe_address)
-        if usdc.convert_to_raw(after) >= expected_safe_raw_balance:
-            break
-        if time.monotonic() >= deadline:
-            raise TimeoutError(f"Lighter pending balance claim was mined, but Safe USDC balance did not reach {usdc.convert_to_decimals(expected_safe_raw_balance)} within 120 seconds; current balance {after}")
-        logger.info(f"  Waiting for claimed USDC to be visible on Safe; current {after}")
-        time.sleep(5)
-    logger.info(f"  Safe USDC after Lighter claim: {before} -> {after}")
-
-
-def sweep_safe_usdc_to_hot_wallet(web3: Web3, hot_wallet: HotWallet, vault: LagoonVault) -> None:
-    """Sweep any residual Lagoon Safe USDC directly to the hot wallet.
-
-    :param web3:
-        Web3 connection.
-    :param hot_wallet:
-        Deployer and 1-of-1 Safe owner.
-    :param vault:
-        Lagoon vault whose Safe holds residual USDC.
-    """
-    usdc = vault.underlying_token
-    safe_usdc = usdc.fetch_balance_of(vault.safe_address)
-    if safe_usdc <= 0:
-        return
-
-    logger.info(f"\nSweeping {safe_usdc} residual USDC from Safe to hot wallet...")
-    transfer_data = usdc.contract.functions.transfer(hot_wallet.address, usdc.convert_to_raw(safe_usdc))._encode_transaction_data()
-    safe_tx = vault.safe.build_multisig_tx(usdc.address, 0, bytes.fromhex(transfer_data.removeprefix("0x")))
-    safe_tx.sign(hot_wallet.private_key.hex())
-    gas_price = max(web3.eth.gas_price * 2, 1_000_000_000)
-    tx_hash, tx = execute_safe_tx(
-        safe_tx,
-        tx_sender_private_key=hot_wallet.private_key.hex(),
-        tx_gas_price=gas_price,
-        tx_nonce=web3.eth.get_transaction_count(hot_wallet.address),
-    )
-    logger.info(f"  Direct Safe sweep tx: {tx_hash.hex()} (nonce {tx['nonce']}, gas price {tx['gasPrice']})")
-    receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=300)
-    if receipt["status"] != 1:
-        raise RuntimeError(f"Safe USDC dust sweep failed: {tx_hash.hex()}")
-    hot_wallet.sync_nonce(web3)
-    logger.info(f"  Hot wallet USDC balance: {usdc.fetch_balance_of(hot_wallet.address)}")
-    logger.info(f"  Safe USDC balance: {usdc.fetch_balance_of(vault.safe_address)}")
+    logger.info("Safe USDC balance after Lighter deposit: %s", usdc.fetch_balance_of(safe))
+    return tx_hash

--- a/eth_defi/lighter/pubkey.py
+++ b/eth_defi/lighter/pubkey.py
@@ -2,14 +2,14 @@
 
 Creating a Lighter API key is two steps:
 
-1. **Generate** the API keypair off-chain (the `lighter-python` SDK
-   ``SignerClient``; no L1 private key needed). Use indices 4-254 for automated
-   keys; Lighter's dedicated API-key documentation reserves indices 0-3 for the
-   web/mobile UI.
+1. **Generate** the API keypair off-chain with
+   :py:func:`eth_defi.lighter.api_key.generate_lighter_api_key`; no L1 private
+   key is needed. Use indices 4-254 for automated keys; Lighter's dedicated
+   API-key documentation reserves indices 0-3 for the web/mobile UI.
 2. **Register** its public key with the Lighter account on L1 via
    ``ZkLighter.changePubKey(accountIndex, apiKeyIndex, pubKey)``. For a Gnosis
    Safe / Lagoon vault this is done as a **Safe transaction** — Lighter
-   explicitly recommends the on-chain ``ChangePubKey`` "if you're running a
+   explicitly recommends the onchain ``ChangePubKey`` "if you're running a
    multi-sig" (the SDK's EOA ``sign_change_api_key`` path needs a raw private
    key, which a Safe does not have).
 
@@ -31,8 +31,6 @@ Transaction Builder.
 Authoritative docs:
 
 - Lighter API keys: https://apidocs.lighter.xyz/docs/api-keys
-- ``lighter-python`` ``SignerClient.sign_change_api_key``:
-  https://github.com/elliottech/lighter-python/blob/main/lighter/signer_client.py
 """
 
 import logging
@@ -76,13 +74,13 @@ MIN_API_KEY_INDEX = 4
 def validate_lighter_pubkey(pubkey: bytes) -> None:
     """Validate a Lighter API-key public key client-side.
 
-    Mirrors the on-chain checks in ``ZkLighter.changePubKey`` so callers fail
+    Mirrors the onchain checks in ``ZkLighter.changePubKey`` so callers fail
     fast before submitting a transaction: the pubkey must be exactly
     :py:data:`PUB_KEY_BYTES_SIZE` bytes, each 8-byte little-endian limb must be
     strictly below :py:data:`GOLDILOCKS_MODULUS`, and it must not be all-zero.
 
     :param pubkey:
-        The API-key public key, as produced by the Lighter SDK.
+        The API-key public key produced by the native key generator.
 
     :raises ValueError:
         If the pubkey is malformed.
@@ -152,9 +150,9 @@ def build_change_pubkey_safe_tx(  # noqa: PLR0917
 ) -> SafeTx:
     """Build an (unsigned) Safe transaction calling ``ZkLighter.changePubKey``.
 
-    The Safe is the Lighter account's L1 owner. Sign + execute it with the Safe
-    owners, or post it to the Safe Transaction Service via
-    :py:func:`propose_change_pubkey`.
+    The Safe is the Lighter account's L1 owner. Sign and execute the result with
+    the Safe owners, or submit the encoded transaction through the Safe
+    Transaction Service.
 
     :return:
         An unsigned :class:`~safe_eth.safe.safe_tx.SafeTx`.
@@ -181,7 +179,8 @@ def execute_change_pubkey(  # noqa: PLR0917
     signatures in the Safe UI.
 
     :param owner_private_key:
-        The executing owner's private key (``0x``-prefixed).
+        The executing owner's hexadecimal private key, with or without a
+        ``0x`` prefix.
 
     :param hot_wallet:
         Optional owner wallet for nonce allocation. Use this in scripts that

--- a/scripts/hyperliquid/manual-test-lagoon-account-mode-roundtrip.py
+++ b/scripts/hyperliquid/manual-test-lagoon-account-mode-roundtrip.py
@@ -56,8 +56,7 @@ from eth_typing import HexAddress, HexStr
 from safe_eth.safe.safe import Safe
 from tabulate import tabulate
 from web3 import Web3
-from web3.contract.contract import ContractFunction
-from web3.contract.contract import Contract
+from web3.contract.contract import Contract, ContractFunction
 from web3.exceptions import ContractLogicError
 
 from eth_defi.erc_4626.classification import create_vault_instance
@@ -69,10 +68,8 @@ from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
     LagoonDeploymentParameters,
     deploy_automated_lagoon_vault,
 )
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import (
-    fund_lagoon_vault,
-    redeem_vault_shares,
-)
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.testing import redeem_vault_shares
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.gas import estimate_gas_price
 from eth_defi.hotwallet import HotWallet

--- a/scripts/lagoon/deploy-lagoon-gmx-market.py
+++ b/scripts/lagoon/deploy-lagoon-gmx-market.py
@@ -90,7 +90,7 @@ from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
     LagoonDeploymentParameters,
     deploy_automated_lagoon_vault,
 )
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import fund_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.gmx.contracts import NETWORK_TOKENS, get_contract_addresses
 from eth_defi.gmx.lagoon.approvals import UNLIMITED, approve_gmx_collateral_via_vault
@@ -107,7 +107,6 @@ from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, WRAPPED_NATIVE_TOKEN, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.utils import setup_console_logging
-
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/lagoon/deploy-lagoon-multichain.py
+++ b/scripts/lagoon/deploy-lagoon-multichain.py
@@ -152,7 +152,7 @@ from eth_defi.erc_4626.classification import create_vault_instance, detect_vault
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.lagoon.config_event_scanner import build_multichain_guard_config, fetch_guard_config_events, format_guard_config_report
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonConfig, LagoonDeploymentParameters, LagoonMultichainDeployment, deploy_multichain_lagoon_vault
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import fund_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3

--- a/scripts/lagoon/lagoon-gmx-example.py
+++ b/scripts/lagoon/lagoon-gmx-example.py
@@ -174,7 +174,8 @@ from eth_defi.chain import get_chain_name
 from eth_defi.confirmation import broadcast_and_wait_transactions_to_complete
 from eth_defi.erc_4626.vault_protocol.lagoon.config_event_scanner import build_multichain_guard_config, fetch_guard_config_events, format_guard_config_report
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import fund_lagoon_vault, redeem_vault_shares
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.testing import redeem_vault_shares
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.gas import apply_gas, estimate_gas_price
 from eth_defi.gmx.ccxt import GMX
@@ -726,7 +727,7 @@ def deposit_to_vault(
 ) -> None:
     """Deposit USDC into the Lagoon vault.
 
-    Uses :func:`~eth_defi.erc_4626.vault_protocol.lagoon.testing.fund_lagoon_vault`
+    Uses :func:`~eth_defi.erc_4626.vault_protocol.lagoon.funding.fund_lagoon_vault`
     to handle the full ERC-7540 async deposit flow (request → settle → finalise).
 
     :param web3: Web3 instance

--- a/scripts/lagoon/lagoon-lighter-example.py
+++ b/scripts/lagoon/lagoon-lighter-example.py
@@ -1,95 +1,11 @@
-"""Manual test: trade Lighter perpetuals through a Lagoon vault.
+"""Deploy and activate a Lighter-enabled Lagoon vault on Ethereum mainnet.
 
-This script demonstrates the complete Lagoon + Lighter lifecycle on Ethereum
-mainnet:
-
-1. Deploy a Lagoon vault with a 1-of-1 Safe owned by the deployer hot key
-2. Deposit USDC into the vault
-3. Deposit USDC from the Safe into Lighter's L1 contract
-4. Wait for Lighter to create the Safe-owned account
-5. Generate and register a Lighter API key with ``changePubKey`` via the Safe
-6. Open an ETH long position
-7. Close the ETH position
-8. Request a secure Lighter USDC withdrawal
-9. Claim the pending L1 withdrawal back to the Safe
-10. Redeem vault shares and return USDC to the deployer hot wallet
-
-Lighter has no production-like testnet for this full custody flow. The default
-mode therefore runs against Ethereum mainnet and spends real ETH / USDC. Use a
-small prefunded key and verify all addresses before running.
-
-Funding estimate
-----------------
-
-The deployer hot wallet should be prefunded with both ETH and Ethereum mainnet
-USDC:
-
-- **USDC:** Lighter's Ethereum-mainnet deposit minimum is **1 USDC** and secure
-  withdrawals also have a **1 USDC** minimum:
-  https://apidocs.lighter.xyz/docs/deposits-transfers-and-withdrawals. The
-  script reads the live ETH perpetual market from
-  https://mainnet.zklighter.elliot.ai/api/v1/orderBookDetails?market_id=0 and
-  uses its ``min_quote_amount`` and ``min_base_amount`` fields. At the time of
-  writing, ETH has ``min_quote_amount=10 USDC`` and
-  ``min_base_amount=0.005 ETH``. Therefore the theoretical minimum deposit to
-  open the smallest ETH position is about **10 USDC**. The script defaults to
-  the live minimum position size plus **5 USDC** of buffer; **16-20 USDC** is a
-  practical minimum for this full deposit/trade/withdraw/redeem lifecycle.
-- **ETH:** this script pays Ethereum mainnet gas for Safe/Lagoon deployment,
-  guard/module configuration, ERC-7540 deposit/redeem transactions and the
-  Lighter ``deposit`` / ``changePubKey`` / ``withdrawPendingBalance`` calls.
-  Treat this as a gas-budget calculation, not a fixed ETH amount. A practical
-  planning range is about **5-10 million gas** for the full run:
-  **0.025-0.05 ETH at 5 gwei**, **0.05-0.10 ETH at 10 gwei** and
-  **0.10-0.20 ETH at 20 gwei**. Use **0.10 ETH as a practical minimum when
-  gas is quiet** and increase it if mainnet gas is busy or you expect retries.
-
-Rough mainnet delays
---------------------
-
-These are observed timings from a 2026-06-26 Ethereum mainnet run during quiet
-gas conditions. Treat them as order-of-magnitude planning numbers, not protocol
-service-level agreements:
-
-- Safe deployment: 20-30 seconds, including the deliberate Safe state
-  propagation sleep.
-- Lagoon vault, module, guard and Lighter whitelist deployment: 3-5 minutes.
-- Lagoon USDC deposit, valuation, settlement and share claim: 1-3 minutes.
-- Safe USDC approval and Lighter L1 deposit: 20-60 seconds.
-- Lighter account creation after deposit: 1-3 minutes.
-- Safe ``changePubKey`` transaction and API-key activation: 2-5 minutes.
-- ETH position open and close round trip: 30-90 seconds.
-- Lighter secure withdrawal request: accepted by the API immediately, but the
-  L1 pending balance may take more than one hour to become claimable. The
-  2026-06-26 run observed about 61 minutes.
-- Claiming the pending Lighter balance, redeeming Lagoon shares and sweeping
-  residual Safe USDC: 1-3 minutes after the L1 pending balance is claimable.
-
-Example::
-
-    JSON_RPC_ETHEREUM="https://..." \\
-    LIGHTER_TEST_PRIVATE_KEY="0x..." \\
-    poetry run python scripts/lagoon/lagoon-lighter-example.py
-
-Simulation mode
----------------
-
-Set ``SIMULATE=true`` to run only the L1 custody smoke test against an Anvil
-Ethereum-mainnet fork. This covers Lagoon deployment, vault deposit and the
-guarded ``ZkLighter.deposit`` call. It cannot create a real Lighter account,
-register an API key, trade, or complete a withdrawal proof.
-
-Example::
-
-    SIMULATE=true JSON_RPC_ETHEREUM="https://..." \\
-        poetry run python scripts/lagoon/lagoon-lighter-example.py
-
-Resume example::
-
-    JSON_RPC_ETHEREUM="https://..." \\
-    LIGHTER_TEST_PRIVATE_KEY="0x..." \\
-    LIGHTER_TUTORIAL_DEPLOYMENT_FILE=~/.tradingstrategy/examples/lighter-tutorial-1.json \\
-    poetry run python scripts/lagoon/lagoon-lighter-example.py
+This is a one-shot manual provider check for the package deployment path. It
+creates a fresh Lagoon vault, makes the fixed 1 USDC accounted activation
+deposit, registers a Lighter API key before the requested Safe owners and
+threshold are configured, writes the secret-bearing report with mode ``0600``,
+and prints only a redacted summary. It does not trade, withdraw, resume a
+previous run, or attempt recovery.
 
 Environment variables
 ---------------------
@@ -97,112 +13,36 @@ Environment variables
 ``JSON_RPC_ETHEREUM``
     Ethereum mainnet RPC endpoint. Required.
 ``LIGHTER_TEST_PRIVATE_KEY``
-    Funded deployer, Safe owner, depositor and asset-manager key. Required for
-    mainnet mode. Must hold ETH and enough USDC.
-``LIGHTER_DEPOSIT_USDC``
-    Optional. USDC amount deposited into Lagoon and then Lighter. Defaults to
-    an amount derived from Lighter's documented minimum deposit and the ETH
-    market's minimum order size.
-``LIGHTER_POSITION_USDC``
-    Optional. ETH long notional in USDC. Defaults to Lighter's ETH market
-    minimum quote amount with a small buffer.
+    Funded deployer, Safe owner, depositor and asset-manager key. Required. It
+    needs ETH for deployment gas and at least 1 native Ethereum USDC for
+    Lighter activation.
 ``LIGHTER_API_KEY_INDEX``
-    Optional. API-key slot to register. Defaults to 4. Lighter's dedicated
-    API-key documentation reserves indices 0..3 for its web/mobile interfaces,
-    https://apidocs.lighter.xyz/docs/api-keys,
-    although its Get Started page currently says 0..1; the script uses the
-    conservative range to avoid overwriting front-end keys.
-``LIGHTER_WITHDRAW_TIMEOUT``
-    Optional. Seconds to wait for the secure withdrawal to become claimable.
-    Defaults to 14400 because Lighter secure withdrawals may take more than one
-    hour to become claimable on L1.
-``LIGHTER_RECOVERY_WITHDRAW_USDC``
-    Optional. Claim/redeem recovery mode for a run that already requested a
-    Lighter withdrawal but timed out before the L1 pending balance became
-    claimable. Set this to the expected human-readable USDC withdrawal amount
-    together with ``LIGHTER_TUTORIAL_DEPLOYMENT_FILE``. The script skips
-    deploy/deposit/trade/withdraw and only claims from Lighter, redeems Lagoon
-    shares, and sweeps residual Safe USDC.
-``LIGHTER_TUTORIAL_DEPLOYMENT_FILE``
-    Optional. Path to a previously saved Lagoon deployment JSON file. When set,
-    the script reads the Lagoon deployment info back from this file and
-    continues with vault deposit / Lighter account / trading lifecycle. Fresh
-    mainnet deployments are saved automatically as
-    ``~/.tradingstrategy/examples/lighter-tutorial-{counter}.json``.
-``LAGOON_VAULT_ADDRESS`` and ``TRADING_STRATEGY_MODULE_ADDRESS``
-    Optional. Use both together to resume after a successful Lagoon deployment
-    instead of deploying a new vault. The script reconstructs the
-    :class:`LagoonVault` from ``LAGOON_VAULT_ADDRESS``, injects the existing
-    module address, verifies the module is enabled on the Safe, and continues
-    with the vault deposit / Lighter account / trading lifecycle. Prefer
-    ``LIGHTER_TUTORIAL_DEPLOYMENT_FILE`` when the automatic JSON file is
-    available.
-``SIMULATE``
-    Optional. ``true`` for Anvil custody-only mode.
-``SIMULATE_FORK_BLOCK``
-    Optional. Fork block for simulation mode. Default 25000000.
+    Optional Lighter API-key slot. Defaults to 4.
+``LIGHTER_DEPLOYMENT_REPORT``
+    Optional file for the secret-bearing deployment report. Defaults below
+    ``~/.tradingstrategy/examples``.
 ``ETHERSCAN_API_KEY``
-    Optional. Used by Lagoon deployment for source verification.
+    Optional contract-verification key.
 """
 
-import asyncio
-import json
 import logging
 import os
-import time
-from decimal import Decimal
 from pathlib import Path
-from typing import Any
 
-from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.erc_4626.classification import create_vault_instance
-from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
-    LagoonAutomatedDeployment,
-    LagoonDeploymentParameters,
-    deploy_automated_lagoon_vault,
-)
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import fund_lagoon_vault
-from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.hotwallet import HotWallet
-from eth_defi.lighter.api import (
-    LIGHTER_MIN_MAINNET_USDC,
-    LighterTradeAmounts,
-    import_lighter,
-    register_lighter_api_key,
-    resolve_eth_trade_amounts,
-    trade_eth_roundtrip,
-    wait_for_lighter_account,
-    wait_for_lighter_collateral,
-    withdraw_from_lighter,
-)
-from eth_defi.lighter.constants import LIGHTER_USDC_ETHEREUM
+from eth_defi.lighter.constants import LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID, LIGHTER_USDC_ETHEREUM
 from eth_defi.lighter.deployment import LighterDeployment
-from eth_defi.lighter.lagoon import broadcast_tx, claim_lighter_pending_balance, deposit_usdc_from_lagoon_safe_into_lighter, sweep_safe_usdc_to_hot_wallet
 from eth_defi.lighter.pubkey import MIN_API_KEY_INDEX
 from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.valuation import fetch_lighter_total_equity
-from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, set_balance
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
-
-#: Environment variable for resuming from a saved deployment file.
-LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV = "LIGHTER_TUTORIAL_DEPLOYMENT_FILE"
-
-#: Directory for automatically saved manual-test deployment files.
-LIGHTER_TUTORIAL_DEPLOYMENT_DIR = Path("~/.tradingstrategy/examples").expanduser()
-
-#: File name prefix for automatically saved deployment files.
-LIGHTER_TUTORIAL_DEPLOYMENT_FILE_PREFIX = "lighter-tutorial"
-
-#: Default wait for Lighter secure withdrawals to become claimable on L1.
-DEFAULT_LIGHTER_WITHDRAW_TIMEOUT = 14_400
 
 
 def require_env(name: str) -> str:
@@ -210,9 +50,8 @@ def require_env(name: str) -> str:
 
     :param name:
         Environment variable name.
-
     :return:
-        Environment variable value.
+        Non-empty environment variable value.
     """
     value = os.environ.get(name)
     if not value:
@@ -220,464 +59,89 @@ def require_env(name: str) -> str:
     return value
 
 
-def parse_decimal_env(name: str, default: Decimal | None) -> Decimal | None:
-    """Parse an optional decimal environment variable.
-
-    :param name:
-        Environment variable name.
-
-    :param default:
-        Default value when the environment variable is unset.
+def resolve_report_path() -> Path:
+    """Resolve the private deployment-report path.
 
     :return:
-        Parsed :class:`~decimal.Decimal`, or ``None``.
+        Not-yet-existing report path below the configured or default directory.
     """
-    raw_value = os.environ.get(name)
-    return Decimal(raw_value) if raw_value else default
+    configured = os.environ.get("LIGHTER_DEPLOYMENT_REPORT")
+    if configured:
+        return Path(configured).expanduser()
+    directory = Path("~/.tradingstrategy/examples").expanduser()
+    timestamp = native_datetime_utc_now().strftime("%Y%m%dT%H%M%SZ")
+    return directory / f"lighter-lagoon-deployment-{timestamp}.json"
 
 
-def setup_simulation_environment(json_rpc_url: str, fork_block: int) -> tuple:
-    """Fork Ethereum mainnet and create a funded test wallet.
-
-    :param json_rpc_url:
-        Ethereum mainnet RPC to fork from.
-
-    :param fork_block:
-        Fixed fork block.
-
-    :return:
-        ``(web3, hot_wallet, anvil_launch)``.
-    """
-    print("\nStarting Anvil fork of Ethereum mainnet...")
-    anvil_launch = fork_network_anvil(json_rpc_url, fork_block_number=fork_block)
-    web3 = create_multi_provider_web3(anvil_launch.json_rpc_url, default_http_timeout=(3.0, 180.0))
-    assert web3.eth.chain_id == 1, f"Expected Ethereum mainnet, got chain {web3.eth.chain_id}"
-
-    hot_wallet = HotWallet.create_for_testing(web3, test_account_n=0, eth_amount=0)
-    hot_wallet.sync_nonce(web3)
-
-    set_balance(web3, hot_wallet.address, 10 * 10**18)
-    fund_erc20_on_anvil(web3, LIGHTER_USDC_ETHEREUM, hot_wallet.address, 100 * 10**6)
-
-    print(f"  Fork running at: {anvil_launch.json_rpc_url}")
-    print(f"  Forked at block: {web3.eth.block_number:,}")
-    print(f"  Simulation wallet: {hot_wallet.address} (10 ETH, 100 USDC)")
-    return web3, hot_wallet, anvil_launch
-
-
-def deploy_lighter_vault(
-    web3: Web3,
-    hot_wallet: HotWallet,
-    etherscan_api_key: str | None,
-) -> LagoonAutomatedDeployment:
-    """Deploy a Lagoon vault with Lighter L1 deposit whitelisting.
+def deploy_lighter_vault(web3: Web3, hot_wallet: HotWallet, etherscan_api_key: str | None, api_key_index: int) -> LagoonAutomatedDeployment:
+    """Deploy and activate a fresh Lighter-enabled Lagoon vault.
 
     :param web3:
-        Web3 connection.
-
+        Ethereum mainnet Web3 connection.
     :param hot_wallet:
-        Deployer, Safe owner and asset-manager wallet.
-
+        Deployer, activation depositor and initial Safe owner.
     :param etherscan_api_key:
-        Optional Etherscan API key for source verification.
-
+        Optional source-verification key.
+    :param api_key_index:
+        Lighter API-key slot to register.
     :return:
-        Lagoon automated deployment information.
+        Deployment report containing the registered Lighter key.
     """
     parameters = LagoonDeploymentParameters(
         underlying=LIGHTER_USDC_ETHEREUM,
         name="Lighter Trading Vault Manual Test",
         symbol="LIGHTER-TEST",
     )
-
-    print("\nDeploying Lagoon vault with Lighter integration...")
-    print(f"  Deployer / Safe owner / asset manager: {hot_wallet.address}")
-
-    deploy_info = deploy_automated_lagoon_vault(
+    return deploy_automated_lagoon_vault(
         web3=web3,
         deployer=hot_wallet,
         asset_manager=hot_wallet.address,
         parameters=parameters,
         safe_owners=[hot_wallet.address],
         safe_threshold=1,
-        any_asset=False,
         lighter_deployment=LighterDeployment.create_ethereum(),
+        generate_lighter_api_key=True,
+        lighter_api_key_index=api_key_index,
         use_forge=True,
         assets=[LIGHTER_USDC_ETHEREUM],
         etherscan_api_key=etherscan_api_key,
         between_contracts_delay_seconds=0.0,
     )
-    vault = deploy_info.vault
-    print("  Vault deployed")
-    print(f"    Vault:  {vault.address}")
-    print(f"    Safe:   {vault.safe_address}")
-    print(f"    Module: {vault.trading_strategy_module_address}")
-    return deploy_info
-
-
-def load_existing_lagoon_vault(
-    web3: Web3,
-    vault_address: HexAddress | str,
-    trading_strategy_module_address: HexAddress | str,
-) -> LagoonVault:
-    """Load an already deployed Lagoon vault and its trading module.
-
-    :param web3:
-        Web3 connection.
-
-    :param vault_address:
-        Existing Lagoon vault address.
-
-    :param trading_strategy_module_address:
-        Existing ``TradingStrategyModuleV0`` address enabled on the vault Safe.
-
-    :return:
-        Configured Lagoon vault object.
-    """
-    vault_address = Web3.to_checksum_address(vault_address)
-    trading_strategy_module_address = Web3.to_checksum_address(trading_strategy_module_address)
-    vault = create_vault_instance(
-        web3,
-        vault_address,
-        features={ERC4626Feature.lagoon_like, ERC4626Feature.erc_7540_like},
-        default_block_identifier="latest",
-        require_denomination_token=True,
-    )
-    if not isinstance(vault, LagoonVault):
-        raise TypeError(f"{vault_address} is not a Lagoon vault: {vault}")
-
-    vault.trading_strategy_module_address = trading_strategy_module_address
-    if not vault.is_safe_trading_strategy_module_enabled():
-        raise RuntimeError(f"TradingStrategyModuleV0 {trading_strategy_module_address} is not enabled on Safe {vault.safe_address}")
-
-    print("\nUsing existing Lagoon vault deployment...")
-    print(f"  Vault:  {vault.address}")
-    print(f"  Safe:   {vault.safe_address}")
-    print(f"  Module: {vault.trading_strategy_module_address}")
-    return vault
-
-
-def resolve_next_lagoon_deployment_file(directory: Path = LIGHTER_TUTORIAL_DEPLOYMENT_DIR) -> Path:
-    """Find the next automatic Lagoon deployment JSON file path.
-
-    The file name uses an incrementing counter so that repeated manual-test
-    runs do not overwrite earlier mainnet deployment information.
-
-    :param directory:
-        Directory where tutorial deployment files are stored.
-
-    :return:
-        Next available deployment file path.
-    """
-    directory.mkdir(parents=True, exist_ok=True)
-    counter = 1
-    while True:
-        path = directory / f"{LIGHTER_TUTORIAL_DEPLOYMENT_FILE_PREFIX}-{counter}.json"
-        if not path.exists():
-            return path
-        counter += 1
-
-
-def build_lighter_tutorial_deployment_json(deploy_info: LagoonAutomatedDeployment) -> dict[str, Any]:
-    """Build the JSON payload for a saved Lighter tutorial deployment.
-
-    The Lagoon deployment data is stored directly at the top level so it can
-    be passed back to
-    :py:meth:`eth_defi.erc_4626.vault_protocol.lagoon.deployment.LagoonAutomatedDeployment.from_json_friendly_dict`.
-    The ``metadata`` entry is informational and does not contain secrets.
-
-    :param deploy_info:
-        Lagoon deployment information to serialise.
-
-    :return:
-        JSON-serialisable deployment payload.
-    """
-    data = deploy_info.as_json_friendly_dict()
-    data["metadata"] = {
-        "script": "scripts/lagoon/lagoon-lighter-example.py",
-        "created_at": native_datetime_utc_now().isoformat(),
-        "resume_environment_variable": LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV,
-    }
-    return data
-
-
-def print_lagoon_deployment_json(path: Path, data: dict[str, Any], action: str) -> None:
-    """Print saved or loaded Lagoon deployment JSON.
-
-    :param path:
-        Deployment JSON file path.
-
-    :param data:
-        Deployment JSON data.
-
-    :param action:
-        Human-readable action label, e.g. ``"Saved"`` or ``"Loaded"``.
-    """
-    print(f"\n{action} Lagoon deployment JSON:")
-    print(f"  File: {path}")
-    print(json.dumps(data, indent=2, sort_keys=True))
-
-
-def save_lagoon_deployment_file(deploy_info: LagoonAutomatedDeployment) -> Path:
-    """Save Lagoon deployment information to an automatic tutorial file.
-
-    :param deploy_info:
-        Lagoon deployment information to write.
-
-    :return:
-        Written JSON file path.
-    """
-    path = resolve_next_lagoon_deployment_file()
-    data = build_lighter_tutorial_deployment_json(deploy_info)
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print_lagoon_deployment_json(path, data, "Saved")
-    print(f"\nContinue a failed run with {LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV}={path}")
-    return path
-
-
-def load_lagoon_deployment_file(web3: Web3, path: Path) -> LagoonAutomatedDeployment:
-    """Load Lagoon deployment information from a tutorial JSON file.
-
-    :param web3:
-        Web3 connection.
-
-    :param path:
-        Deployment JSON file path.
-
-    :return:
-        Hydrated Lagoon deployment information.
-    """
-    path = path.expanduser()
-    data = json.loads(path.read_text(encoding="utf-8"))
-    deploy_info = LagoonAutomatedDeployment.from_json_friendly_dict(web3, data)
-    print_lagoon_deployment_json(path, data, "Loaded")
-    return deploy_info
-
-
-def deposit_to_vault(
-    web3: Web3,
-    hot_wallet: HotWallet,
-    vault: LagoonVault,
-    deposit_usdc: Decimal,
-) -> None:
-    """Deposit USDC into the Lagoon vault.
-
-    :param web3:
-        Web3 connection.
-
-    :param hot_wallet:
-        Depositor and asset-manager wallet.
-
-    :param vault:
-        Lagoon vault.
-
-    :param deposit_usdc:
-        Human-readable USDC amount.
-    """
-    print(f"\nDepositing {deposit_usdc} USDC into Lagoon vault...")
-    fund_lagoon_vault(
-        web3,
-        vault_address=vault.address,
-        asset_manager=hot_wallet.address,
-        test_account_with_balance=hot_wallet.address,
-        trading_strategy_module_address=vault.trading_strategy_module_address,
-        amount=deposit_usdc,
-        hot_wallet=hot_wallet,
-    )
-    usdc = fetch_erc20_details(web3, vault.underlying_token.address)
-    print(f"  Safe USDC balance: {usdc.fetch_balance_of(vault.safe_address)}")
-    print(f"  Hot wallet shares: {vault.share_token.fetch_balance_of(hot_wallet.address)}")
-
-
-def redeem_back_to_hot_wallet(web3: Web3, hot_wallet: HotWallet, vault: LagoonVault) -> None:
-    """Redeem all Lagoon shares back to the deployer hot wallet.
-
-    :param web3:
-        Web3 connection.
-
-    :param hot_wallet:
-        Deployer and share holder.
-
-    :param vault:
-        Lagoon vault.
-    """
-    print("\nRedeeming Lagoon vault shares back to the hot wallet...")
-    usdc = vault.underlying_token
-    share_token = vault.share_token
-    raw_shares = share_token.fetch_raw_balance_of(hot_wallet.address)
-    if raw_shares <= 0:
-        raise RuntimeError(f"{hot_wallet.address} has no Lagoon shares to redeem")
-
-    human_shares = share_token.convert_to_decimals(raw_shares)
-    broadcast_tx(
-        web3,
-        hot_wallet,
-        share_token.approve(vault.address, human_shares),
-        f"Approve {human_shares} shares for redemption",
-        gas_limit=100_000,
-    )
-    broadcast_tx(
-        web3,
-        hot_wallet,
-        vault.request_redeem(hot_wallet.address, raw_shares),
-        f"Request redemption of {human_shares} shares",
-        gas_limit=250_000,
-    )
-
-    safe_usdc_balance = usdc.fetch_balance_of(vault.safe_address)
-
-    broadcast_tx(web3, hot_wallet, vault.post_new_valuation(safe_usdc_balance), "Post vault valuation", gas_limit=200_000)
-    broadcast_tx(web3, hot_wallet, vault.settle_via_trading_strategy_module(safe_usdc_balance), "Settle vault redemption", gas_limit=450_000)
-    deadline = time.monotonic() + 120
-    while True:
-        claimable_raw_shares = vault.vault_contract.functions.maxRedeem(hot_wallet.address).call()
-        if claimable_raw_shares > 0:
-            break
-        if time.monotonic() >= deadline:
-            raise TimeoutError(f"Lagoon redemption settlement was mined, but maxRedeem({hot_wallet.address}) stayed zero for 120 seconds")
-        print("  Waiting for Lagoon redemption to become claimable...")
-        time.sleep(5)
-    broadcast_tx(web3, hot_wallet, vault.finalise_redeem(hot_wallet.address, raw_amount=claimable_raw_shares), "Claim redeemed USDC", gas_limit=150_000)
-
-    print(f"  Hot wallet USDC balance: {usdc.fetch_balance_of(hot_wallet.address)}")
-    print(f"  Remaining shares: {vault.share_token.fetch_balance_of(hot_wallet.address)}")
-
-
-async def run_mainnet() -> None:  # noqa: PLR0914
-    """Run the full mainnet manual test."""
-    lighter = import_lighter()
-    json_rpc_url = require_env("JSON_RPC_ETHEREUM")
-    private_key = require_env("LIGHTER_TEST_PRIVATE_KEY")
-    etherscan_api_key = os.environ.get("ETHERSCAN_API_KEY")
-    api_key_index = int(os.environ.get("LIGHTER_API_KEY_INDEX", str(MIN_API_KEY_INDEX)))
-    withdraw_timeout = int(os.environ.get("LIGHTER_WITHDRAW_TIMEOUT", str(DEFAULT_LIGHTER_WITHDRAW_TIMEOUT)))
-    recovery_withdraw_usdc = parse_decimal_env("LIGHTER_RECOVERY_WITHDRAW_USDC", None)
-    deployment_file = os.environ.get(LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV)
-    existing_vault_address = os.environ.get("LAGOON_VAULT_ADDRESS")
-    existing_module_address = os.environ.get("TRADING_STRATEGY_MODULE_ADDRESS")
-
-    if deployment_file and (existing_vault_address or existing_module_address):
-        msg = f"{LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV} cannot be combined with LAGOON_VAULT_ADDRESS or TRADING_STRATEGY_MODULE_ADDRESS"
-        raise ValueError(msg)
-
-    if bool(existing_vault_address) != bool(existing_module_address):
-        msg = "Set both LAGOON_VAULT_ADDRESS and TRADING_STRATEGY_MODULE_ADDRESS to resume an existing deployment"
-        raise ValueError(msg)
-
-    web3 = create_multi_provider_web3(json_rpc_url, default_http_timeout=(3.0, 180.0))
-    assert web3.eth.chain_id == 1, "Lighter deposits and withdrawals are on Ethereum mainnet"
-
-    hot_wallet = HotWallet.from_private_key(private_key)
-    hot_wallet.sync_nonce(web3)
-    usdc = fetch_erc20_details(web3, LIGHTER_USDC_ETHEREUM)
-
-    usdc_balance = usdc.fetch_balance_of(hot_wallet.address)
-    eth_balance = Decimal(web3.eth.get_balance(hot_wallet.address)) / Decimal(10**18)
-    if eth_balance <= 0:
-        raise RuntimeError(f"{hot_wallet.address} has no ETH for mainnet gas")
-
-    print("\nMainnet wallet:")
-    print(f"  Address: {hot_wallet.address}")
-    print(f"  ETH:     {eth_balance}")
-    print(f"  USDC:    {usdc_balance}")
-
-    amounts: LighterTradeAmounts | None = None
-    if recovery_withdraw_usdc is None:
-        amounts = await resolve_eth_trade_amounts(
-            lighter,
-            deposit_usdc=parse_decimal_env("LIGHTER_DEPOSIT_USDC", None),
-            position_usdc=parse_decimal_env("LIGHTER_POSITION_USDC", None),
-        )
-        if usdc_balance < amounts.deposit_usdc:
-            raise RuntimeError(f"{hot_wallet.address} has {usdc_balance} USDC but needs {amounts.deposit_usdc}")
-
-    if deployment_file:
-        deploy_info = load_lagoon_deployment_file(web3, Path(deployment_file))
-        vault = deploy_info.vault
-        if not isinstance(vault, LagoonVault):
-            msg = f"{deployment_file} describes a satellite deployment, but the Lighter manual test needs a Lagoon vault"
-            raise TypeError(msg)
-    elif existing_vault_address:
-        vault = load_existing_lagoon_vault(web3, existing_vault_address, existing_module_address)
-    else:
-        deploy_info = deploy_lighter_vault(web3, hot_wallet, etherscan_api_key)
-        saved_path = save_lagoon_deployment_file(deploy_info)
-        deploy_info = load_lagoon_deployment_file(web3, saved_path)
-        vault = deploy_info.vault
-        if not isinstance(vault, LagoonVault):
-            msg = f"{saved_path} describes a satellite deployment, but the Lighter manual test needs a Lagoon vault"
-            raise TypeError(msg)
-
-    if recovery_withdraw_usdc is not None:
-        if not deployment_file and not existing_vault_address:
-            msg = f"LIGHTER_RECOVERY_WITHDRAW_USDC needs {LIGHTER_TUTORIAL_DEPLOYMENT_FILE_ENV} or LAGOON_VAULT_ADDRESS/TRADING_STRATEGY_MODULE_ADDRESS"
-            raise ValueError(msg)
-        expected_raw_amount = usdc.convert_to_raw(recovery_withdraw_usdc)
-        claim_lighter_pending_balance(web3, hot_wallet, vault, usdc, expected_raw_amount, withdraw_timeout)
-        redeem_back_to_hot_wallet(web3, hot_wallet, vault)
-        sweep_safe_usdc_to_hot_wallet(web3, hot_wallet, vault)
-        print("\nLighter + Lagoon recovery completed.")
-        return
-
-    assert amounts is not None
-
-    deposit_to_vault(web3, hot_wallet, vault, amounts.deposit_usdc)
-    deposit_usdc_from_lagoon_safe_into_lighter(web3, hot_wallet, vault, usdc, amounts.deposit_usdc)
-
-    account_index = await wait_for_lighter_account(lighter, vault.safe_address)
-    await wait_for_lighter_collateral(lighter, account_index, amounts.deposit_usdc)
-    api_private_key = await register_lighter_api_key(lighter, web3, vault.safe, hot_wallet, account_index, api_key_index)
-    await trade_eth_roundtrip(lighter, account_index, api_private_key, api_key_index, amounts)
-
-    lighter_session = create_lighter_session()
-    try:
-        equity = fetch_lighter_total_equity(lighter_session, account_index)
-    finally:
-        lighter_session.close()
-
-    withdraw_usdc = equity.available_balance.quantize(Decimal("0.000001"))
-    print("\nLighter valuation after ETH round-trip:")
-    print(f"  NAV:            {equity.get_total()} USDC")
-    print(f"  Collateral:     {equity.collateral} USDC")
-    print(f"  Unrealised PnL: {equity.unrealised_pnl} USDC")
-    print(f"  Available:      {equity.available_balance} USDC")
-    print(f"  Withdrawal:     {withdraw_usdc} USDC")
-    if withdraw_usdc < LIGHTER_MIN_MAINNET_USDC:
-        raise RuntimeError(f"Lighter available balance {withdraw_usdc} USDC is below the secure withdrawal minimum {LIGHTER_MIN_MAINNET_USDC} USDC")
-    await withdraw_from_lighter(lighter, account_index, api_private_key, api_key_index, withdraw_usdc)
-    claim_lighter_pending_balance(web3, hot_wallet, vault, usdc, usdc.convert_to_raw(withdraw_usdc), withdraw_timeout)
-    redeem_back_to_hot_wallet(web3, hot_wallet, vault)
-    sweep_safe_usdc_to_hot_wallet(web3, hot_wallet, vault)
-
-    print("\nFull Lighter + Lagoon manual test completed.")
-
-
-def run_simulation() -> None:
-    """Run the Anvil custody-only smoke test."""
-    json_rpc_url = require_env("JSON_RPC_ETHEREUM")
-    fork_block = int(os.environ.get("SIMULATE_FORK_BLOCK", "25000000"))
-    etherscan_api_key = os.environ.get("ETHERSCAN_API_KEY")
-    anvil_launch = None
-    try:
-        web3, hot_wallet, anvil_launch = setup_simulation_environment(json_rpc_url, fork_block)
-        usdc = fetch_erc20_details(web3, LIGHTER_USDC_ETHEREUM)
-        deploy_info = deploy_lighter_vault(web3, hot_wallet, etherscan_api_key)
-        deposit_to_vault(web3, hot_wallet, deploy_info.vault, Decimal(100))
-        deposit_usdc_from_lagoon_safe_into_lighter(web3, hot_wallet, deploy_info.vault, usdc, Decimal(100))
-        print("\nCustody-only simulation completed. Mainnet mode is required for account creation, API-key registration, trading and withdrawal proofs.")
-    finally:
-        if anvil_launch is not None:
-            anvil_launch.close()
 
 
 def main() -> None:
-    """Script entry point."""
+    """Run the one-shot Ethereum mainnet deployment check.
+
+    :return:
+        ``None`` after the deployment report and public NAV check succeed.
+    """
     setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "INFO"))
-    simulate = os.environ.get("SIMULATE", "").lower() in {"true", "1", "yes"}
-    if simulate:
-        run_simulation()
-    else:
-        asyncio.run(run_mainnet())
+    web3 = create_multi_provider_web3(require_env("JSON_RPC_ETHEREUM"), default_http_timeout=(3.0, 180.0))
+    assert web3.eth.chain_id == LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID, "Lighter activation requires Ethereum mainnet"
+
+    hot_wallet = HotWallet.from_private_key(require_env("LIGHTER_TEST_PRIVATE_KEY"))
+    hot_wallet.sync_nonce(web3)
+    report_path = resolve_report_path()
+    if report_path.exists():
+        raise FileExistsError(f"Deployment report already exists: {report_path}")
+    deployment = deploy_lighter_vault(
+        web3,
+        hot_wallet,
+        os.environ.get("ETHERSCAN_API_KEY"),
+        int(os.environ.get("LIGHTER_API_KEY_INDEX", str(MIN_API_KEY_INDEX))),
+    )
+    assert deployment.lighter_account_setup is not None
+
+    deployment.write_json_file(report_path, include_secrets=True)
+    logger.info("Saved secret deployment report: %s", report_path)
+    logger.info("Deployment summary:\n%s", deployment.pformat())
+
+    session = create_lighter_session()
+    try:
+        equity = fetch_lighter_total_equity(session, deployment.lighter_account_setup.account_index)
+    finally:
+        session.close()
+    logger.info("Lighter account %d NAV: %s USDC", equity.account_index, equity.get_total())
 
 
 if __name__ == "__main__":

--- a/scripts/lagoon/lagoon-lighter-trade-example.py
+++ b/scripts/lagoon/lagoon-lighter-trade-example.py
@@ -1,0 +1,592 @@
+"""Deploy a Lagoon vault and trade an ETH perpetual using a Lighter API key.
+
+This is a minimal, one-shot Ethereum mainnet tutorial. It:
+
+1. deploys a Lagoon vault and Lighter guard;
+2. makes the accounted 1 USDC deposit needed to activate the Lighter account;
+3. generates and registers API key slot 4 (or ``LIGHTER_API_KEY_INDEX``)
+   during deployment;
+4. adds enough accounted collateral for a conservative small ETH position;
+5. opens an ETH-USD perpetual long with the API key and closes the filled size;
+6. reads the resulting Lighter account NAV.
+
+The official Lighter SDK is intentionally not an ``eth-defi`` package
+dependency. Install the GitHub revision used by this tutorial separately into
+the same Python environment before running it. This revision is the latest
+upstream ``main`` commit at the time of writing. Its setuptools metadata still
+pins an old ``urllib3`` version that conflicts with ``eth-defi``, although the
+SDK is compatible with the newer runtime. Install its missing transport
+helper, then install the SDK itself without applying that stale transitive
+pin::
+
+    poetry run pip install aiohttp-retry
+    poetry run pip install --force-reinstall --no-deps "lighter-sdk @ git+https://github.com/elliottech/lighter-python.git@fd4ee2530f78940cbed3dd80131d0fa66f74ad2a"
+
+Installing it this way does not add it to ``pyproject.toml`` or Poetry's lock
+file. The immutable Git revision keeps the tutorial reproducible; update it
+deliberately when adopting a newer upstream SDK. The SDK supplies Lighter's
+native order signing and nonce management; Lagoon deployment and account
+activation remain implemented by ``eth-defi``. Until upstream fixes
+``setup.py``, ``pip check`` will still report its declared urllib3 conflict;
+this installation is therefore tutorial-only.
+
+Lighter has no production-like testnet for this custody flow. The script
+therefore spends real ETH for Ethereum mainnet gas and real USDC. It does not
+withdraw funds, redeem Lagoon shares, resume a failed run, or perform automatic
+recovery. If execution stops after opening the position, inspect and close the
+position manually before reusing the account. Collateral remains in the
+Safe-owned Lighter account after a successful run; recover it with the
+governance-controlled two-phase L1 withdrawal flow documented in
+``eth_defi/lighter/README-lighter-guard.md``.
+
+Example::
+
+    JSON_RPC_ETHEREUM="https://..." \
+    LIGHTER_TEST_PRIVATE_KEY="0x..." \
+    poetry run python scripts/lagoon/lagoon-lighter-trade-example.py
+
+Environment variables
+---------------------
+
+``JSON_RPC_ETHEREUM``
+    Ethereum mainnet RPC endpoint. Required.
+``LIGHTER_TEST_PRIVATE_KEY``
+    Funded deployer, Safe owner, Lagoon depositor and asset-manager key.
+    Required. It needs deployment gas and enough native Ethereum USDC for the
+    selected total collateral.
+``LIGHTER_DEPOSIT_USDC``
+    Optional total Lighter collateral. By default this is the conservatively
+    sized ETH position notional plus a 5 USDC buffer.
+``LIGHTER_POSITION_USDC``
+    Optional target ETH perpetual notional. Defaults to the reported quote
+    minimum plus 1 USDC. The reported base minimum may make the effective
+    notional larger. Lighter documents these minimum fields for maker orders;
+    this tutorial also uses them as a conservative floor for its IOC order.
+``LIGHTER_MAX_SLIPPAGE``
+    Optional maximum price slippage for both market orders. Defaults to 0.02
+    (2%).
+``LIGHTER_API_KEY_INDEX``
+    Optional API-key slot. Defaults to 4. Slots 0 through 3 are reserved by
+    Lighter's user interfaces.
+``LIGHTER_DEPLOYMENT_REPORT``
+    Optional secret-bearing deployment-report path. The default is a new file
+    below ``~/.tradingstrategy/examples``. It is created with mode ``0600``.
+``ETHERSCAN_API_KEY``
+    Optional contract-verification key.
+
+Authoritative Lighter documentation:
+
+- API keys: https://apidocs.lighter.xyz/docs/api-keys
+- Python SDK: https://github.com/elliottech/lighter-python
+- Create orders: https://apidocs.lighter.xyz/docs/create-orders
+"""
+
+import asyncio
+import importlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+from decimal import ROUND_CEILING, Decimal
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, LighterAccountSetup, deploy_automated_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.funding import fund_lagoon_vault
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.lighter.api import LIGHTER_MIN_MAINNET_USDC, wait_for_lighter_collateral
+from eth_defi.lighter.constants import LIGHTER_API_URL, LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID, LIGHTER_USDC_ETHEREUM
+from eth_defi.lighter.deployment import LighterDeployment
+from eth_defi.lighter.lagoon import deposit_usdc_from_lagoon_safe_into_lighter
+from eth_defi.lighter.pubkey import MIN_API_KEY_INDEX
+from eth_defi.lighter.session import LighterSession, create_lighter_session
+from eth_defi.lighter.valuation import fetch_lighter_account_by_index, fetch_lighter_total_equity
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import fetch_erc20_details
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+#: ETH-USD perpetual market index on Lighter mainnet.
+LIGHTER_ETH_PERP_MARKET_INDEX = 0
+
+#: Extra collateral above the effective minimum ETH position.
+DEFAULT_COLLATERAL_BUFFER = Decimal("5")
+
+#: Default maximum execution slippage for the round trip.
+DEFAULT_MAX_SLIPPAGE = Decimal("0.02")
+
+#: Public-account state polling interval.
+LIGHTER_POSITION_POLL_SECONDS = 5
+
+
+@dataclass(slots=True, frozen=True)
+class EthTradePlan:
+    """Resolved ETH perpetual order and collateral sizes.
+
+    :param deposit_usdc:
+        Total target Lighter collateral.
+    :param position_usdc:
+        Approximate ETH position notional at the reference price.
+    :param base_amount:
+        Integer base amount passed to the SDK signer.
+    :param base_size:
+        Human-readable ETH base size.
+    :param size_decimals:
+        Lighter integer base-amount scale.
+    :param min_quote_amount:
+        Reported ETH maker-order quote minimum.
+    :param min_base_amount:
+        Reported ETH maker-order base minimum.
+    """
+
+    deposit_usdc: Decimal
+    position_usdc: Decimal
+    base_amount: int
+    base_size: Decimal
+    size_decimals: int
+    min_quote_amount: Decimal
+    min_base_amount: Decimal
+
+
+def require_env(name: str) -> str:
+    """Read a required environment variable.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Non-empty environment variable value.
+    """
+    value = os.environ.get(name)
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def parse_decimal_env(name: str) -> Decimal | None:
+    """Read an optional decimal environment variable.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Parsed value, or ``None`` when unset.
+    """
+    value = os.environ.get(name)
+    return Decimal(value) if value else None
+
+
+def import_lighter_sdk() -> ModuleType:
+    """Import the separately installed official Lighter SDK.
+
+    :return:
+        Imported ``lighter`` module.
+    :raises ImportError:
+        If the operator has not installed the tutorial-only dependency.
+    """
+    try:
+        return importlib.import_module("lighter")
+    except ImportError as error:
+        message = "Install the separately pinned Lighter SDK as described in this script's module documentation"
+        raise ImportError(message) from error
+
+
+def calculate_eth_trade_plan(
+    market: Any,
+    deposit_usdc: Decimal | None = None,
+    position_usdc: Decimal | None = None,
+) -> EthTradePlan:
+    """Resolve a conservative small ETH position from SDK market details.
+
+    The SDK signs integer base amounts using ``size_decimals``. Order sizes are
+    rounded up to ``supported_size_decimals``. Lighter documents the reported
+    base and quote minimums for maker orders; the tutorial deliberately applies
+    them to its IOC order as a conservative sizing floor as well.
+
+    :param market:
+        Lighter SDK ETH perpetual market-detail model.
+    :param deposit_usdc:
+        Optional total collateral override.
+    :param position_usdc:
+        Optional target notional override.
+    :return:
+        Validated order and collateral plan.
+    """
+    if str(market.symbol).upper() != "ETH" or str(market.market_type).lower() != "perp":
+        raise ValueError(f"Market {market.market_id} is not the ETH perpetual market")
+
+    min_quote_amount = Decimal(str(market.min_quote_amount))
+    min_base_amount = Decimal(str(market.min_base_amount))
+    reference_price = Decimal(str(market.last_trade_price))
+    size_decimals = int(market.size_decimals)
+    supported_size_decimals = int(market.supported_size_decimals)
+    if reference_price <= 0:
+        raise ValueError(f"Invalid ETH reference price: {reference_price}")
+    if supported_size_decimals > size_decimals:
+        raise ValueError(f"ETH supported_size_decimals {supported_size_decimals} exceeds size_decimals {size_decimals}")
+
+    conservative_minimum = max(min_quote_amount, min_base_amount * reference_price)
+    if position_usdc is not None and position_usdc < conservative_minimum:
+        raise ValueError(f"LIGHTER_POSITION_USDC={position_usdc} is below the tutorial's conservative sizing floor {conservative_minimum}")
+
+    target_notional = position_usdc if position_usdc is not None else min_quote_amount + Decimal("1")
+    base_size = max(min_base_amount, target_notional / reference_price)
+    size_step = Decimal(1).scaleb(-supported_size_decimals)
+    base_size = (base_size / size_step).to_integral_value(rounding=ROUND_CEILING) * size_step
+    base_amount = int(base_size * Decimal(10**size_decimals))
+    effective_notional = base_size * reference_price
+    if effective_notional < min_quote_amount:
+        raise ValueError(f"Resolved ETH position {effective_notional} USDC is below the conservative quote floor {min_quote_amount} USDC")
+
+    resolved_deposit = deposit_usdc if deposit_usdc is not None else effective_notional + DEFAULT_COLLATERAL_BUFFER
+    if resolved_deposit < LIGHTER_MIN_MAINNET_USDC:
+        raise ValueError(f"Lighter collateral must be at least {LIGHTER_MIN_MAINNET_USDC} USDC")
+    if resolved_deposit <= effective_notional:
+        raise ValueError(f"LIGHTER_DEPOSIT_USDC={resolved_deposit} must exceed the effective ETH notional {effective_notional}")
+
+    return EthTradePlan(
+        deposit_usdc=resolved_deposit,
+        position_usdc=effective_notional,
+        base_amount=base_amount,
+        base_size=base_size,
+        size_decimals=size_decimals,
+        min_quote_amount=min_quote_amount,
+        min_base_amount=min_base_amount,
+    )
+
+
+async def fetch_eth_trade_plan(
+    lighter: ModuleType,
+    deposit_usdc: Decimal | None,
+    position_usdc: Decimal | None,
+) -> EthTradePlan:
+    """Fetch live ETH market details through the SDK and build a trade plan.
+
+    :param lighter:
+        Official Lighter SDK module.
+    :param deposit_usdc:
+        Optional total collateral override.
+    :param position_usdc:
+        Optional target notional override.
+    :return:
+        Resolved trade plan.
+    """
+    api_client = lighter.ApiClient(configuration=lighter.Configuration(host=LIGHTER_API_URL))
+    try:
+        details = await lighter.OrderApi(api_client).order_book_details(market_id=LIGHTER_ETH_PERP_MARKET_INDEX)
+        markets = details.order_book_details
+        if len(markets) != 1:
+            raise RuntimeError(f"Expected one ETH market detail, received {len(markets)}")
+        return calculate_eth_trade_plan(markets[0], deposit_usdc, position_usdc)
+    finally:
+        await api_client.close()
+
+
+def resolve_report_path() -> Path:
+    """Resolve a new secret deployment-report path.
+
+    :return:
+        Configured path or a timestamped default path.
+    """
+    configured = os.environ.get("LIGHTER_DEPLOYMENT_REPORT")
+    if configured:
+        return Path(configured).expanduser()
+    timestamp = native_datetime_utc_now().strftime("%Y%m%dT%H%M%SZ")
+    return Path("~/.tradingstrategy/examples").expanduser() / f"lighter-lagoon-trade-{timestamp}.json"
+
+
+def deploy_lighter_vault(web3: Web3, hot_wallet: HotWallet, api_key_index: int) -> LagoonAutomatedDeployment:
+    """Deploy and activate a Lagoon vault with a registered Lighter API key.
+
+    :param web3:
+        Ethereum mainnet connection.
+    :param hot_wallet:
+        Deployer, Safe owner and asset manager.
+    :param api_key_index:
+        Lighter API-key slot registered during deployment.
+    :return:
+        Deployment report containing the in-memory API private key.
+    """
+    parameters = LagoonDeploymentParameters(
+        underlying=LIGHTER_USDC_ETHEREUM,
+        name="Lighter ETH Perpetual Trading Vault",
+        symbol="LIGHTER-ETH",
+    )
+    return deploy_automated_lagoon_vault(
+        web3=web3,
+        deployer=hot_wallet,
+        asset_manager=hot_wallet.address,
+        parameters=parameters,
+        safe_owners=[hot_wallet.address],
+        safe_threshold=1,
+        lighter_deployment=LighterDeployment.create_ethereum(),
+        generate_lighter_api_key=True,
+        lighter_api_key_index=api_key_index,
+        use_forge=True,
+        assets=[LIGHTER_USDC_ETHEREUM],
+        etherscan_api_key=os.environ.get("ETHERSCAN_API_KEY"),
+        between_contracts_delay_seconds=0.0,
+    )
+
+
+def add_lighter_collateral(
+    web3: Web3,
+    hot_wallet: HotWallet,
+    deployment: LagoonAutomatedDeployment,
+    target_collateral: Decimal,
+) -> Decimal:
+    """Subscribe more USDC to Lagoon and deposit it into Lighter.
+
+    The deployer already deposited one accounted USDC during activation. This
+    function performs one further Lagoon subscription only when the tutorial's
+    conservative trade sizing needs more collateral.
+
+    :param web3:
+        Ethereum mainnet connection.
+    :param hot_wallet:
+        Lagoon depositor and asset manager.
+    :param deployment:
+        Activated Lagoon and Lighter deployment.
+    :param target_collateral:
+        Desired total Lighter collateral.
+    :return:
+        Collateral observed after the additional L1 deposit.
+    """
+    setup = deployment.lighter_account_setup
+    assert setup is not None
+    vault = deployment.vault
+    if not isinstance(vault, LagoonVault):
+        message = "Lighter trading requires a primary-chain Lagoon vault"
+        raise TypeError(message)
+
+    additional_deposit = target_collateral - setup.observed_collateral
+    if additional_deposit <= 0:
+        return setup.observed_collateral
+    if additional_deposit < LIGHTER_MIN_MAINNET_USDC:
+        raise ValueError(f"Additional Lighter deposit {additional_deposit} USDC is below the {LIGHTER_MIN_MAINNET_USDC} USDC L1 minimum")
+
+    logger.info("Adding %s USDC through the Lagoon subscription lifecycle", additional_deposit)
+    fund_lagoon_vault(
+        web3=web3,
+        vault_address=vault.address,
+        asset_manager=hot_wallet.address,
+        test_account_with_balance=hot_wallet.address,
+        trading_strategy_module_address=vault.trading_strategy_module_address,
+        amount=additional_deposit,
+        nav=setup.observed_collateral,
+        hot_wallet=hot_wallet,
+    )
+    usdc = fetch_erc20_details(web3, LIGHTER_USDC_ETHEREUM)
+    deposit_usdc_from_lagoon_safe_into_lighter(
+        web3=web3,
+        hot_wallet=hot_wallet,
+        vault=vault,
+        usdc=usdc,
+        deposit_usdc=additional_deposit,
+    )
+
+    session = create_lighter_session()
+    try:
+        return wait_for_lighter_collateral(session, setup.account_index, target_collateral)
+    finally:
+        session.close()
+
+
+def get_signed_eth_position(account: dict[str, Any]) -> Decimal:
+    """Read the signed ETH perpetual size from a public account response.
+
+    :param account:
+        Raw Lighter ``/api/v1/account`` item.
+    :return:
+        Positive long size, negative short size, or zero.
+    """
+    for position in account.get("positions") or ():
+        if int(position["market_id"]) == LIGHTER_ETH_PERP_MARKET_INDEX:
+            size = Decimal(str(position["position"]))
+            return size if int(position["sign"]) >= 0 else -size
+    return Decimal(0)
+
+
+async def wait_for_eth_position(
+    session: LighterSession,
+    account_index: int,
+    *,
+    open_position: bool,
+    timeout: int = 300,
+    poll_seconds: float = LIGHTER_POSITION_POLL_SECONDS,
+) -> Decimal:
+    """Wait for the ETH position to become open or flat.
+
+    :param session:
+        Public Lighter REST session.
+    :param account_index:
+        Lighter account index.
+    :param open_position:
+        Wait for a positive long when true, or an exactly flat position when
+        false.
+    :param timeout:
+        Maximum wait in seconds.
+    :param poll_seconds:
+        Delay between observable account reads.
+    :return:
+        Matching signed ETH position.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        position = get_signed_eth_position(fetch_lighter_account_by_index(session, account_index))
+        if (open_position and position > 0) or (not open_position and position == 0):
+            return position
+        if time.monotonic() >= deadline:
+            state = "open" if open_position else "flat"
+            raise TimeoutError(f"ETH position did not become {state} within {timeout} seconds; current position {position}")
+        logger.info("Waiting for ETH position update; current position %s ETH", position)
+        await asyncio.sleep(poll_seconds)
+
+
+async def trade_eth_roundtrip(
+    lighter: ModuleType,
+    session: LighterSession,
+    setup: LighterAccountSetup,
+    plan: EthTradePlan,
+    max_slippage: Decimal,
+) -> None:
+    """Open and close an ETH perpetual long with the deployment API key.
+
+    The official SDK signs both orders and manages their Lighter nonces. The
+    close is ``reduce_only`` and uses the position size observed after the IOC
+    open order, so a partial fill cannot accidentally create a short.
+
+    :param lighter:
+        Official Lighter SDK module.
+    :param session:
+        Public REST session used to observe fills.
+    :param setup:
+        Deployment-created account and API-key material.
+    :param plan:
+        Resolved ETH order size.
+    :param max_slippage:
+        Maximum fractional price slippage for each market order.
+    :return:
+        ``None`` once the public account reports a flat ETH position.
+    """
+    if setup.private_key is None:
+        message = "The in-memory or secret-bearing deployment report does not contain the Lighter API private key"
+        raise ValueError(message)
+    if not Decimal(0) < max_slippage < Decimal(1):
+        raise ValueError(f"LIGHTER_MAX_SLIPPAGE must be between 0 and 1, got {max_slippage}")
+
+    client = lighter.SignerClient(
+        url=LIGHTER_API_URL,
+        account_index=setup.account_index,
+        api_private_keys={setup.api_key_index: setup.private_key},
+    )
+    try:
+        error = client.check_client()
+        if error is not None:
+            raise RuntimeError(f"Lighter SDK rejected the deployment API key: {error}")
+
+        client_order_index = int(time.time() * 1_000)
+        logger.info("Opening %s ETH long on Lighter with API key slot %d", plan.base_size, setup.api_key_index)
+        open_order, open_response, error = await client.create_market_order_limited_slippage(
+            market_index=LIGHTER_ETH_PERP_MARKET_INDEX,
+            client_order_index=client_order_index,
+            base_amount=plan.base_amount,
+            max_slippage=float(max_slippage),
+            is_ask=False,
+            api_key_index=setup.api_key_index,
+        )
+        if error is not None:
+            raise RuntimeError(f"Opening the ETH perpetual failed: {error}")
+        logger.info("ETH open order accepted: order=%s response=%s", open_order, open_response)
+
+        opened_position = await wait_for_eth_position(session, setup.account_index, open_position=True)
+        close_base_amount = int((abs(opened_position) * Decimal(10**plan.size_decimals)).to_integral_value(rounding=ROUND_CEILING))
+        logger.info("Closing observed ETH long of %s ETH", opened_position)
+        close_order, close_response, error = await client.create_market_order_limited_slippage(
+            market_index=LIGHTER_ETH_PERP_MARKET_INDEX,
+            client_order_index=client_order_index + 1,
+            base_amount=close_base_amount,
+            max_slippage=float(max_slippage),
+            is_ask=True,
+            reduce_only=True,
+            api_key_index=setup.api_key_index,
+        )
+        if error is not None:
+            raise RuntimeError(f"Closing the ETH perpetual failed: {error}")
+        logger.info("ETH close order accepted: order=%s response=%s", close_order, close_response)
+        await wait_for_eth_position(session, setup.account_index, open_position=False)
+    finally:
+        await client.close()
+
+
+async def main() -> None:
+    """Run the deployment, collateral deposit and API-key trade tutorial.
+
+    :return:
+        ``None`` after the ETH position is closed and final NAV is logged.
+    """
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "INFO"))
+    lighter = import_lighter_sdk()
+    plan = await fetch_eth_trade_plan(
+        lighter,
+        deposit_usdc=parse_decimal_env("LIGHTER_DEPOSIT_USDC"),
+        position_usdc=parse_decimal_env("LIGHTER_POSITION_USDC"),
+    )
+    configured_slippage = parse_decimal_env("LIGHTER_MAX_SLIPPAGE")
+    max_slippage = configured_slippage if configured_slippage is not None else DEFAULT_MAX_SLIPPAGE
+    logger.info(
+        "ETH perpetual plan: collateral=%s USDC, position=%s USDC (%s ETH), reported maker minimums=%s USDC/%s ETH",
+        plan.deposit_usdc,
+        plan.position_usdc,
+        plan.base_size,
+        plan.min_quote_amount,
+        plan.min_base_amount,
+    )
+
+    web3 = create_multi_provider_web3(require_env("JSON_RPC_ETHEREUM"), default_http_timeout=(3.0, 180.0))
+    assert web3.eth.chain_id == LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID, "Lagoon Lighter activation requires Ethereum mainnet"
+    hot_wallet = HotWallet.from_private_key(require_env("LIGHTER_TEST_PRIVATE_KEY"))
+    hot_wallet.sync_nonce(web3)
+
+    usdc = fetch_erc20_details(web3, LIGHTER_USDC_ETHEREUM)
+    usdc_balance = usdc.fetch_balance_of(hot_wallet.address)
+    eth_balance = Decimal(web3.eth.get_balance(hot_wallet.address)) / Decimal(10**18)
+    if eth_balance <= 0:
+        raise RuntimeError(f"{hot_wallet.address} has no ETH for deployment gas")
+    if usdc_balance < plan.deposit_usdc:
+        raise RuntimeError(f"{hot_wallet.address} has {usdc_balance} USDC but the tutorial needs {plan.deposit_usdc}")
+    logger.info("Deployer %s balances: %s ETH, %s USDC", hot_wallet.address, eth_balance, usdc_balance)
+
+    report_path = resolve_report_path()
+    if report_path.exists():
+        raise FileExistsError(f"Deployment report already exists: {report_path}")
+    deployment = deploy_lighter_vault(
+        web3,
+        hot_wallet,
+        int(os.environ.get("LIGHTER_API_KEY_INDEX", str(MIN_API_KEY_INDEX))),
+    )
+    setup = deployment.lighter_account_setup
+    assert setup is not None and setup.private_key is not None
+
+    deployment.write_json_file(report_path, include_secrets=True)
+    logger.info("Saved secret deployment report with mode 0600: %s", report_path)
+    logger.info("Deployed Lagoon vault %s with Lighter account %d and API key slot %d", deployment.vault.address, setup.account_index, setup.api_key_index)
+
+    collateral = add_lighter_collateral(web3, hot_wallet, deployment, plan.deposit_usdc)
+    logger.info("Lighter collateral ready: %s USDC", collateral)
+
+    session = create_lighter_session()
+    try:
+        await trade_eth_roundtrip(lighter, session, setup, plan, max_slippage)
+        equity = fetch_lighter_total_equity(session, setup.account_index)
+    finally:
+        session.close()
+    logger.info("ETH perpetual round trip complete; Lighter account NAV: %s USDC", equity.get_total())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/lighter/lagoon-lighter-change-pubkey.py
+++ b/scripts/lighter/lagoon-lighter-change-pubkey.py
@@ -1,11 +1,13 @@
 """Print a Lighter ``changePubKey`` (API-key registration) transaction for the Safe Transaction Builder.
 
 Registering a Lighter API key for a Safe-controlled (Lagoon vault) account is an
-on-chain ``ZkLighter.changePubKey(accountIndex, apiKeyIndex, pubKey)`` call made
-**from the Safe** (Lighter recommends the on-chain ChangePubKey for multisigs).
+onchain ``ZkLighter.changePubKey(accountIndex, apiKeyIndex, pubKey)`` call made
+**from the Safe** (Lighter recommends the onchain ChangePubKey for multisigs).
 This is a privileged setup action by the Safe owners (governance) — it is *not*
 part of the asset-manager guard whitelist, so it goes directly through the Safe,
-not the ``TradingStrategyModule``'s restricted ``performCall`` path.
+not the ``TradingStrategyModule``'s restricted ``performCall`` path. The Safe
+guard sees the direct transaction and permits it through its intentional
+governance bypass.
 
 This CLI does **not** sign or send anything. It prints the transaction so you
 can paste it into the Safe{Wallet} **Transaction Builder** (use "Custom data":
@@ -13,14 +15,15 @@ the ``To`` address, ``ETH value`` 0, and the raw ``Data`` hex), then collect the
 multisig signatures in the Safe UI. (Same idea as the manual guard-migration
 instructions printed by trade-executor's ``lagoon-deploy-vault`` command.)
 
-Generate the API keypair off-chain first (the ``lighter-python`` SDK); pass the
-resulting public key as ``PUB_KEY`` (40-byte hex).
+Generate the API keypair first with
+``eth_defi.lighter.api_key.generate_lighter_api_key``; pass its public key as
+``PUB_KEY`` (40-byte hex).
 
 Example::
 
     SAFE_ADDRESS=0xYourSafe ACCOUNT_INDEX=12345 API_KEY_INDEX=4 \
         PUB_KEY=0x0101...<40 bytes> \
-        python scripts/lighter/lagoon-lighter-change-pubkey.py
+        poetry run python scripts/lighter/lagoon-lighter-change-pubkey.py
 
 Environment variables
 ---------------------
@@ -46,13 +49,18 @@ ETHEREUM_CHAIN_ID = 1
 
 
 def _require(name: str) -> str:
+    """Read a required environment variable.
+
+    :param name: Environment variable name.
+    :return: Non-empty environment variable value.
+    """
     value = os.environ.get(name)
     if not value:
         raise ValueError(f"{name} is required")
     return value
 
 
-def _change_pubkey_abi() -> dict:
+def _change_pubkey_abi() -> dict[str, object]:
     """Return the ``changePubKey`` ABI fragment (for the Safe Transaction Builder)."""
     abi = get_abi_by_filename("lighter/ZkLighter.json")["abi"]
     for entry in abi:
@@ -62,7 +70,11 @@ def _change_pubkey_abi() -> dict:
     raise RuntimeError(msg)
 
 
-def main():
+def main() -> None:
+    """Print an unsigned Lighter key-registration transaction.
+
+    :return: ``None`` after printing the Safe Transaction Builder payload.
+    """
     safe_address = Web3.to_checksum_address(_require("SAFE_ADDRESS"))
     account_index = int(_require("ACCOUNT_INDEX"))
     api_key_index = int(os.environ.get("API_KEY_INDEX", "4"))

--- a/tests/lagoon/test_lagoon_deployment_json.py
+++ b/tests/lagoon/test_lagoon_deployment_json.py
@@ -1,16 +1,28 @@
 import json
 from decimal import Decimal
+from inspect import signature
+from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+from hexbytes import HexBytes
 from web3 import Web3
 
 import eth_defi.erc_4626.vault_protocol.lagoon.deployment as lagoon_deployment
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
     LagoonAutomatedDeployment,
     LagoonDeploymentParameters,
+    LighterAccountSetup,
     WhitelistEntry,
 )
+from eth_defi.hotwallet import HotWallet
+from eth_defi.lighter.api_key import LighterApiKey
+from eth_defi.lighter.deployment import LighterDeployment
 
 CHAIN_ID = 1
+ACCOUNT_INDEX = 123
+API_KEY_INDEX = 4
+PRIVATE_FILE_MODE = 0o600
 VAULT = Web3.to_checksum_address("0x0000000000000000000000000000000000000011")
 SAFE = Web3.to_checksum_address("0x0000000000000000000000000000000000000022")
 MODULE = Web3.to_checksum_address("0x0000000000000000000000000000000000000033")
@@ -28,25 +40,25 @@ class FakeWeb3:
 
 
 class FakeContract:
-    def __init__(self, address: str):
+    def __init__(self, address: str) -> None:
         self.address = Web3.to_checksum_address(address)
 
 
 class FakeToken:
-    def __init__(self, address: str, symbol: str):
+    def __init__(self, address: str, symbol: str) -> None:
         self.address = Web3.to_checksum_address(address)
         self.symbol = symbol
 
 
 class FakeVault:
-    def __init__(self):
+    def __init__(self) -> None:
         self.address = VAULT
         self.underlying_token = FakeToken(UNDERLYING, "USDC")
         self.share_token = FakeToken(SHARE, "LIGHTER-TEST")
 
 
 class FakeHydratedVault(FakeVault):
-    def __init__(self, web3, spec, **kwargs):
+    def __init__(self, web3: FakeWeb3, spec: object, **kwargs: str) -> None:
         super().__init__()
         self.web3 = web3
         self.spec = spec
@@ -54,9 +66,9 @@ class FakeHydratedVault(FakeVault):
         self.vault_abi = kwargs["vault_abi"]
 
 
-def test_lagoon_automated_deployment_json_roundtrip(monkeypatch):
-    """Lagoon deployment info is JSON-serialisable and can be hydrated."""
-    deploy_info = LagoonAutomatedDeployment(
+def create_deploy_info() -> LagoonAutomatedDeployment:
+    """Create deployment metadata shared by serialisation tests."""
+    return LagoonAutomatedDeployment(
         chain_id=CHAIN_ID,
         vault=FakeVault(),
         trading_strategy_module=FakeContract(MODULE),
@@ -75,7 +87,22 @@ def test_lagoon_automated_deployment_json_roundtrip(monkeypatch):
         beacon_proxy_factory=None,
         gas_used=Decimal("0.01"),
         whitelisted_items=(WhitelistEntry(kind="Lighter", name="ZkLighter", address=MODULE),),
+        lighter_account_setup=LighterAccountSetup(
+            account_index=ACCOUNT_INDEX,
+            api_key_index=API_KEY_INDEX,
+            private_key="0xprivate-key",
+            public_key="0x" + "01" * 40,
+            activation_amount=Decimal("1"),
+            deposit_tx_hash="0xdeposit",
+            change_pubkey_tx_hash="0xchange",
+            observed_collateral=Decimal("1"),
+        ),
     )
+
+
+def test_lagoon_automated_deployment_json_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lagoon deployment info is JSON-serialisable and can be hydrated."""
+    deploy_info = create_deploy_info()
 
     data = deploy_info.as_json_friendly_dict()
     decoded = json.loads(json.dumps(data, allow_nan=False))
@@ -91,3 +118,221 @@ def test_lagoon_automated_deployment_json_roundtrip(monkeypatch):
     assert hydrated.trading_strategy_module.address == MODULE
     assert hydrated.parameters.underlying == UNDERLYING
     assert hydrated.whitelisted_items[0].address == MODULE
+    assert hydrated.lighter_account_setup is not None
+    assert hydrated.lighter_account_setup.private_key is None
+    assert "0xprivate-key" not in json.dumps(decoded)
+
+    secret_data = deploy_info.as_json_friendly_dict(include_secrets=True)
+    secret_hydrated = LagoonAutomatedDeployment.from_json_friendly_dict(FakeWeb3(), secret_data)
+    assert secret_hydrated.lighter_account_setup is not None
+    assert secret_hydrated.lighter_account_setup.private_key == "0xprivate-key"
+    assert "0xprivate-key" not in deploy_info.pformat()
+
+
+def test_lagoon_deployment_report_is_private_and_exclusive(tmp_path: Path) -> None:
+    """Secret deployment reports use mode 0600 and are never overwritten."""
+    report_path = tmp_path / "deployment.json"
+    deploy_info = create_deploy_info()
+
+    deploy_info.write_json_file(report_path, include_secrets=True)
+
+    assert report_path.stat().st_mode & 0o777 == PRIVATE_FILE_MODE
+    assert json.loads(report_path.read_text())["lighter_account_setup"]["private_key"] == "0xprivate-key"
+    with pytest.raises(FileExistsError):
+        deploy_info.write_json_file(report_path, include_secrets=True)
+
+
+def test_activate_lighter_account_registers_key_after_minimum_deposit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deployment ceremony deposits, observes and registers one API key."""
+    events: list[object] = []
+    balances = iter((Decimal(0), Decimal(0), Decimal(1)))
+    token = SimpleNamespace(
+        address=UNDERLYING,
+        symbol="USDC",
+        fetch_balance_of=lambda _address: next(balances),
+        convert_to_raw=lambda amount: int(amount * 10**6),
+    )
+    session = SimpleNamespace(close=lambda: events.append("close"))
+    deployer = SimpleNamespace(
+        address=ASSET_MANAGER,
+        private_key=HexBytes("0x" + "11" * 32),
+    )
+    safe = SimpleNamespace(address=SAFE)
+    web3 = SimpleNamespace(eth=FakeEth())
+    generated_key = LighterApiKey(
+        api_key_index=API_KEY_INDEX,
+        private_key="0x" + "22" * 40,
+        public_key="0x" + "33" * 40,
+    )
+    deployment = LighterDeployment(zk_lighter=MODULE, usdc=UNDERLYING)
+
+    monkeypatch.setattr(lagoon_deployment, "LagoonVault", lambda *_args, **_kwargs: "lagoon-vault")
+    monkeypatch.setattr(lagoon_deployment.time, "sleep", lambda seconds: events.append(("sleep", seconds)))
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: token)
+    monkeypatch.setattr(lagoon_deployment, "fund_lagoon_vault", lambda **kwargs: events.append(("fund", kwargs["amount"])))
+    monkeypatch.setattr(
+        lagoon_deployment,
+        "deposit_usdc_from_lagoon_safe_into_lighter",
+        lambda **kwargs: events.append(("deposit", kwargs["deposit_usdc"], kwargs["zk_lighter"])) or "0xdeposit",
+    )
+    monkeypatch.setattr(lagoon_deployment, "create_lighter_session", lambda: session)
+    monkeypatch.setattr(
+        lagoon_deployment,
+        "wait_for_lighter_account",
+        lambda _session, address: events.append(("account", address)) or ACCOUNT_INDEX,
+    )
+    monkeypatch.setattr(
+        lagoon_deployment,
+        "wait_for_lighter_collateral",
+        lambda _session, account_index, amount: events.append(("collateral", account_index, amount)) or Decimal(1),
+    )
+    monkeypatch.setattr(lagoon_deployment, "generate_lighter_api_key_pair", lambda index: events.append(("generate", index)) or generated_key)
+    monkeypatch.setattr(
+        lagoon_deployment,
+        "execute_change_pubkey",
+        lambda **kwargs: events.append(("register", kwargs["account_index"], kwargs["api_key_index"], kwargs["pubkey"])) or HexBytes("0xdead"),
+    )
+    monkeypatch.setattr(
+        lagoon_deployment,
+        "wait_for_lighter_api_key",
+        lambda _session, account_index, key_index, public_key, **_kwargs: events.append(("verify", account_index, key_index, public_key)),
+    )
+
+    setup = lagoon_deployment._activate_lighter_account(
+        web3=web3,
+        deployer=deployer,
+        safe=safe,
+        vault_address=VAULT,
+        module_address=MODULE,
+        vault_abi="lagoon/v0.5.0/Vault.json",
+        lighter_deployment=deployment,
+        api_key_index=API_KEY_INDEX,
+    )
+
+    assert events == [
+        ("fund", Decimal(1)),
+        ("sleep", lagoon_deployment.LIGHTER_ACTIVATION_BALANCE_POLL_SECONDS),
+        ("deposit", Decimal(1), MODULE),
+        ("account", SAFE),
+        ("collateral", ACCOUNT_INDEX, Decimal(1)),
+        ("generate", API_KEY_INDEX),
+        ("register", ACCOUNT_INDEX, API_KEY_INDEX, bytes.fromhex("33" * 40)),
+        ("verify", ACCOUNT_INDEX, API_KEY_INDEX, generated_key.public_key),
+        "close",
+    ]
+    assert setup.account_index == ACCOUNT_INDEX
+    assert setup.activation_amount == Decimal(1)
+    assert setup.deposit_tx_hash == "0xdeposit"
+    assert setup.change_pubkey_tx_hash == "0xdead"
+
+
+def test_lagoon_deployer_exposes_opt_in_lighter_activation_flags() -> None:
+    """Lighter activation remains an explicit deployer option."""
+    parameters = signature(lagoon_deployment.deploy_automated_lagoon_vault).parameters
+
+    assert parameters["generate_lighter_api_key"].default is False
+    assert parameters["lighter_api_key_index"].default == API_KEY_INDEX
+
+
+def create_valid_lighter_config() -> tuple[dict[str, object], HotWallet]:
+    """Create a valid, network-free input set for activation validation."""
+    deployer = HotWallet.from_private_key("0x" + "11" * 32)
+    canonical_lighter = LighterDeployment.create_ethereum()
+    parameters = LagoonDeploymentParameters(
+        underlying=canonical_lighter.usdc,
+        name="Lighter test",
+        symbol="LIGHTER-TEST",
+        valuationManager=deployer.address,
+    )
+    kwargs: dict[str, object] = {
+        "web3": SimpleNamespace(eth=SimpleNamespace(chain_id=CHAIN_ID)),
+        "deployer": deployer,
+        "parameters": parameters,
+        "primary_asset_manager": deployer.address,
+        "lighter_deployment": canonical_lighter,
+        "generate_lighter_api_key": True,
+        "lighter_api_key_index": API_KEY_INDEX,
+        "guard_only": False,
+        "satellite_chain": False,
+        "existing_vault_address": None,
+        "existing_safe_address": None,
+        "max_settlement_amount": None,
+    }
+    return kwargs, deployer
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error_type", "match"),
+    [
+        ({"web3": SimpleNamespace(eth=SimpleNamespace(chain_id=2))}, ValueError, "Ethereum chain ID 1"),
+        ({"lighter_deployment": None}, ValueError, "requires lighter_deployment"),
+        ({"lighter_deployment": LighterDeployment(zk_lighter=MODULE, usdc=LighterDeployment.create_ethereum().usdc)}, ValueError, "canonical Ethereum Lighter"),
+        ({"parameters": LagoonDeploymentParameters(underlying=UNDERLYING, name="Wrong asset", symbol="WRONG")}, ValueError, "native Ethereum USDC"),
+        ({"guard_only": True}, ValueError, "new full Lagoon vault"),
+        ({"satellite_chain": True}, ValueError, "new full Lagoon vault"),
+        ({"existing_vault_address": VAULT}, ValueError, "new full Lagoon vault"),
+        ({"existing_safe_address": SAFE}, ValueError, "new full Lagoon vault"),
+        ({"primary_asset_manager": ASSET_MANAGER}, ValueError, "primary asset manager"),
+        ({"lighter_api_key_index": 255}, ValueError, "lighter_api_key_index"),
+        ({"max_settlement_amount": Decimal("0.5")}, ValueError, "at least 1"),
+    ],
+)
+def test_validate_lighter_api_key_deployment_rejects_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, object],
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    """Activation validation rejects unsupported topology before network reads."""
+    kwargs, _deployer = create_valid_lighter_config()
+    kwargs.update(overrides)
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: SimpleNamespace(symbol="USDC", fetch_balance_of=lambda _address: Decimal("1")))
+
+    with pytest.raises(error_type, match=match):
+        lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)
+
+
+def test_validate_lighter_api_key_deployment_checks_deployer_balance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activation validation requires the fixed one-USDC activation amount."""
+    kwargs, _deployer = create_valid_lighter_config()
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: SimpleNamespace(symbol="USDC", fetch_balance_of=lambda _address: Decimal("0.99")))
+
+    with pytest.raises(ValueError, match="at least 1 USDC"):
+        lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)
+
+
+def test_validate_lighter_api_key_deployment_accepts_canonical_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canonical Ethereum USDC deployment configuration passes validation."""
+    kwargs, _deployer = create_valid_lighter_config()
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: SimpleNamespace(symbol="USDC", fetch_balance_of=lambda _address: Decimal("1")))
+
+    lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)
+
+
+def test_validate_lighter_api_key_deployment_checks_signer_and_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activation requires one deployer to retain all ceremony permissions."""
+    kwargs, deployer = create_valid_lighter_config()
+    kwargs["parameters"] = LagoonDeploymentParameters(
+        underlying=LighterDeployment.create_ethereum().usdc,
+        name="Wrong manager",
+        symbol="WRONG",
+        valuationManager=ASSET_MANAGER,
+    )
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: SimpleNamespace(symbol="USDC", fetch_balance_of=lambda _address: Decimal("1")))
+
+    with pytest.raises(ValueError, match="valuation manager"):
+        lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)
+
+    kwargs["parameters"].valuationManager = deployer.address
+    kwargs["deployer"] = SimpleNamespace(address=deployer.address)
+    with pytest.raises(TypeError, match="HotWallet"):
+        lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)
+
+
+def test_validate_lighter_api_key_deployment_flag_is_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The disabled activation flag does not perform Lighter network reads."""
+    kwargs, _deployer = create_valid_lighter_config()
+    kwargs["generate_lighter_api_key"] = False
+    monkeypatch.setattr(lagoon_deployment, "fetch_erc20_details", lambda *_args, **_kwargs: pytest.fail("unexpected token read"))
+
+    lagoon_deployment._validate_lighter_api_key_deployment_config(**kwargs)

--- a/tests/lighter/test_lagoon_lighter_trade_example.py
+++ b/tests/lighter/test_lagoon_lighter_trade_example.py
@@ -1,0 +1,196 @@
+"""Tests for the Lagoon + Lighter API-key trading tutorial."""
+
+import asyncio
+import importlib.util
+import sys
+from decimal import Decimal
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LighterAccountSetup
+
+API_KEY_INDEX = 4
+OPEN_BASE_AMOUNT = 50
+FILLED_BASE_AMOUNT = 49
+
+
+def load_tutorial_module() -> ModuleType:
+    """Load the hyphenated tutorial script as a test module."""
+    script_path = Path(__file__).parents[2] / "scripts" / "lagoon" / "lagoon-lighter-trade-example.py"
+    spec = importlib.util.spec_from_file_location("lagoon_lighter_trade_example", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tutorial = load_tutorial_module()
+
+
+class FakeSignerClient:
+    """Minimal official-SDK signer client mock."""
+
+    instance = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.constructor_kwargs = kwargs
+        self.orders: list[dict] = []
+        self.closed = False
+        type(self).instance = self
+
+    @staticmethod
+    def check_client() -> None:
+        """Accept the registered mock API key."""
+        return None
+
+    async def create_market_order_limited_slippage(self, **kwargs: Any) -> tuple[SimpleNamespace, SimpleNamespace, None]:
+        """Record one signed market order."""
+        self.orders.append(kwargs)
+        return SimpleNamespace(order="signed"), SimpleNamespace(tx_hash="0x1234"), None
+
+    async def close(self) -> None:
+        """Record SDK client cleanup."""
+        self.closed = True
+
+
+def test_calculate_eth_trade_plan_honours_live_market_precision() -> None:
+    """Trade sizing rounds up to the ETH base minimum and leaves collateral buffer."""
+    market = SimpleNamespace(
+        symbol="ETH",
+        market_id=0,
+        market_type="perp",
+        min_quote_amount="10.000000",
+        min_base_amount="0.0050",
+        last_trade_price="3000.00",
+        size_decimals=4,
+        supported_size_decimals=4,
+    )
+
+    plan = tutorial.calculate_eth_trade_plan(market)
+
+    assert plan.base_size == Decimal("0.0050")
+    assert plan.base_amount == OPEN_BASE_AMOUNT
+    assert plan.position_usdc == Decimal("15.000000")
+    assert plan.deposit_usdc == Decimal("20.000000")
+
+
+def test_calculate_eth_trade_plan_rejects_silent_position_increase() -> None:
+    """An explicit position below the conservative floor fails visibly."""
+    market = SimpleNamespace(
+        symbol="ETH",
+        market_id=0,
+        market_type="perp",
+        min_quote_amount="10.000000",
+        min_base_amount="0.0050",
+        last_trade_price="3000.00",
+        size_decimals=4,
+        supported_size_decimals=4,
+    )
+
+    with pytest.raises(ValueError, match="conservative sizing floor"):
+        tutorial.calculate_eth_trade_plan(market, position_usdc=Decimal("5"))
+
+
+def test_calculate_eth_trade_plan_rejects_unsupported_precision() -> None:
+    """SDK base precision must fit the integer order-size scale."""
+    market = SimpleNamespace(
+        symbol="ETH",
+        market_id=0,
+        market_type="perp",
+        min_quote_amount="10",
+        min_base_amount="0.005",
+        last_trade_price="3000",
+        size_decimals=4,
+        supported_size_decimals=5,
+    )
+
+    with pytest.raises(ValueError, match="supported_size_decimals"):
+        tutorial.calculate_eth_trade_plan(market)
+
+
+def test_get_signed_eth_position() -> None:
+    """Public account positions preserve Lighter's direction sign."""
+    account = {
+        "positions": [
+            {"market_id": 1, "position": "0.2", "sign": 1},
+            {"market_id": 0, "position": "0.0050", "sign": -1},
+        ]
+    }
+
+    assert tutorial.get_signed_eth_position(account) == Decimal("-0.0050")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target", "positions", "expected"),
+    [
+        ("open", ("0", "0.005"), Decimal("0.005")),
+        ("flat", ("0.005", "0"), Decimal(0)),
+    ],
+)
+async def test_wait_for_eth_position_polls_public_account(
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+    positions: tuple[str, str],
+    expected: Decimal,
+) -> None:
+    """Position polling waits for either an open long or a flat account."""
+    responses = iter({"positions": [{"market_id": 0, "position": position, "sign": 0}]} for position in positions)
+    monkeypatch.setattr(tutorial, "fetch_lighter_account_by_index", lambda *_args: next(responses))
+
+    result = await tutorial.wait_for_eth_position(object(), 123, open_position=target == "open", poll_seconds=0)
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_trade_eth_roundtrip_uses_deployment_api_key_and_closes_fill(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock SDK signs the open and reduce-only close with the deployed API key."""
+    positions = iter((Decimal("0.0049"), Decimal(0)))
+
+    async def fake_wait_for_eth_position(*_args: Any, **_kwargs: Any) -> Decimal:
+        await asyncio.sleep(0)
+        return next(positions)
+
+    monkeypatch.setattr(tutorial, "wait_for_eth_position", fake_wait_for_eth_position)
+    lighter = SimpleNamespace(SignerClient=FakeSignerClient)
+    setup = LighterAccountSetup(
+        account_index=123,
+        api_key_index=API_KEY_INDEX,
+        private_key="0x" + "01" * 40,
+        public_key="0x" + "02" * 40,
+        activation_amount=Decimal("1"),
+        deposit_tx_hash="0xdeposit",
+        change_pubkey_tx_hash="0xchange",
+        observed_collateral=Decimal("1"),
+    )
+    plan = tutorial.EthTradePlan(
+        deposit_usdc=Decimal("20"),
+        position_usdc=Decimal("15"),
+        base_amount=OPEN_BASE_AMOUNT,
+        base_size=Decimal("0.0050"),
+        size_decimals=4,
+        min_quote_amount=Decimal("10"),
+        min_base_amount=Decimal("0.0050"),
+    )
+
+    await tutorial.trade_eth_roundtrip(lighter, object(), setup, plan, Decimal("0.02"))
+
+    client = FakeSignerClient.instance
+    assert client.constructor_kwargs == {
+        "url": tutorial.LIGHTER_API_URL,
+        "account_index": 123,
+        "api_private_keys": {API_KEY_INDEX: setup.private_key},
+    }
+    assert client.orders[0]["base_amount"] == OPEN_BASE_AMOUNT
+    assert client.orders[0]["is_ask"] is False
+    assert client.orders[0]["api_key_index"] == API_KEY_INDEX
+    assert client.orders[1]["base_amount"] == FILLED_BASE_AMOUNT
+    assert client.orders[1]["is_ask"] is True
+    assert client.orders[1]["reduce_only"] is True
+    assert client.orders[1]["api_key_index"] == API_KEY_INDEX
+    assert client.closed is True

--- a/tests/lighter/test_lighter_activation_api.py
+++ b/tests/lighter/test_lighter_activation_api.py
@@ -1,0 +1,192 @@
+"""Unit tests for Lighter account-activation REST helpers."""
+
+from decimal import Decimal
+
+import pytest
+from requests import HTTPError
+from requests.exceptions import JSONDecodeError
+
+import eth_defi.lighter.api as lighter_api
+from eth_defi.lighter.api import fetch_lighter_account_index, fetch_lighter_api_key, wait_for_lighter_api_key, wait_for_lighter_collateral
+
+LOWEST_ACCOUNT_INDEX = 3
+API_KEY_INDEX = 4
+EXPECTED_RETRY_CALL_COUNT = 2
+
+
+class FakeResponse:
+    """Minimal successful requests response."""
+
+    def __init__(self, data: dict, status_code: int = 200, *, json_error: bool = False) -> None:
+        self.data = data
+        self.status_code = status_code
+        self.json_error = json_error
+
+    def raise_for_status(self) -> None:
+        """Simulate a successful response."""
+        if self.status_code >= lighter_api.HTTP_BAD_REQUEST:
+            raise HTTPError(f"HTTP {self.status_code}", response=self)
+
+    def json(self) -> dict:
+        """Return response JSON."""
+        if self.json_error:
+            message = "Invalid JSON"
+            raise JSONDecodeError(message, "<html>", 0)
+        return self.data
+
+
+class FakeSession:
+    """Minimal Lighter session with queued response payloads."""
+
+    api_url = "https://lighter.example"
+
+    def __init__(self, responses: list[dict | tuple[int, dict] | FakeResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, params: dict, timeout: float) -> FakeResponse:
+        """Record one public API request and return the next payload."""
+        assert timeout > 0
+        self.calls.append((url, params))
+        response = self.responses.pop(0)
+        if isinstance(response, FakeResponse):
+            return response
+        if isinstance(response, tuple):
+            status_code, data = response
+            return FakeResponse(data, status_code=status_code)
+        return FakeResponse(response)
+
+
+def test_fetch_lighter_account_index_selects_lowest_index() -> None:
+    """Account discovery preserves the SDK's lowest-index selection rule."""
+    session = FakeSession([{"sub_accounts": [{"index": "9"}, {"index": "3"}]}])
+
+    account_index = fetch_lighter_account_index(session, "0x0000000000000000000000000000000000000001")  # type: ignore[arg-type]
+
+    assert account_index == LOWEST_ACCOUNT_INDEX
+    assert session.calls[0][1]["l1_address"] == "0x0000000000000000000000000000000000000001"
+
+
+def test_fetch_lighter_account_index_treats_not_found_as_pending() -> None:
+    """A fresh L1 deposit returns code 21100 until Lighter indexes its account."""
+    session = FakeSession([(400, {"code": 21100, "message": "account not found"})])
+
+    assert fetch_lighter_account_index(session, "0x0000000000000000000000000000000000000001") is None  # type: ignore[arg-type]
+
+
+def test_fetch_lighter_account_index_accepts_null_account_list() -> None:
+    """A null Go slice is treated as an account that is not visible yet."""
+    session = FakeSession([{"sub_accounts": None}])
+
+    assert fetch_lighter_account_index(session, "0x0000000000000000000000000000000000000001") is None  # type: ignore[arg-type]
+
+
+def test_fetch_lighter_account_index_preserves_non_json_http_error() -> None:
+    """A gateway HTML error is reported as HTTP failure, not malformed JSON."""
+    session = FakeSession([FakeResponse({}, status_code=400, json_error=True)])
+
+    with pytest.raises(HTTPError, match="HTTP 400"):
+        fetch_lighter_account_index(session, "0x0000000000000000000000000000000000000001")  # type: ignore[arg-type]
+
+
+def test_wait_for_lighter_collateral_accepts_display_rounding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 0.000010 USDC display shortfall activates the account."""
+    session = FakeSession(
+        [
+            {
+                "accounts": [
+                    {
+                        "account_index": 12,
+                        "collateral": "0.999990",
+                        "available_balance": "0.999990",
+                        "positions": [],
+                    }
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(lighter_api.time, "sleep", lambda _: None)
+
+    assert wait_for_lighter_collateral(session, 12, Decimal("1"), timeout=1) == Decimal("0.999990")  # type: ignore[arg-type]
+
+
+def test_wait_for_lighter_api_key_normalises_hex(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API-key verification accepts equivalent upper-case and prefixed hex."""
+    session = FakeSession(
+        [
+            {
+                "api_keys": [
+                    {
+                        "api_key_index": 4,
+                        "public_key": "AA" * 40,
+                    }
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(lighter_api.time, "sleep", lambda _: None)
+
+    wait_for_lighter_api_key(session, 12, 4, "0x" + "aa" * 40, timeout=1)  # type: ignore[arg-type]
+
+    assert session.calls == [
+        (
+            "https://lighter.example/api/v1/apikeys",
+            {"account_index": 12, "api_key_index": 4},
+        )
+    ]
+
+
+def test_wait_for_lighter_api_key_accepts_camel_case_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API-key polling accepts Lighter's alternative camel-case field names."""
+    session = FakeSession(
+        [
+            {
+                "apiKeys": [
+                    {
+                        "apiKeyIndex": API_KEY_INDEX,
+                        "publicKey": "aa" * 40,
+                    }
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(lighter_api.time, "sleep", lambda _: None)
+
+    wait_for_lighter_api_key(session, 12, API_KEY_INDEX, "0x" + "aa" * 40, timeout=1)  # type: ignore[arg-type]
+
+
+def test_wait_for_lighter_api_key_retries_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A changePubKey transaction returns code 21109 until Lighter indexes it."""
+    session = FakeSession(
+        [
+            (400, {"code": 21109, "message": "api key not found"}),
+            {"api_keys": [{"api_key_index": 4, "public_key": "aa" * 40}]},
+        ]
+    )
+    monkeypatch.setattr(lighter_api.time, "sleep", lambda _: None)
+
+    wait_for_lighter_api_key(session, 12, 4, "0x" + "aa" * 40, timeout=1)  # type: ignore[arg-type]
+
+    assert len(session.calls) == EXPECTED_RETRY_CALL_COUNT
+
+
+def test_wait_for_lighter_api_key_retries_transient_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API-key polling survives a server failure within its overall deadline."""
+    session = FakeSession(
+        [
+            FakeResponse({}, status_code=500),
+            {"api_keys": [{"api_key_index": API_KEY_INDEX, "public_key": "aa" * 40}]},
+        ]
+    )
+    monkeypatch.setattr(lighter_api.time, "sleep", lambda _: None)
+
+    wait_for_lighter_api_key(session, 12, API_KEY_INDEX, "0x" + "aa" * 40, timeout=1)  # type: ignore[arg-type]
+
+    assert len(session.calls) == EXPECTED_RETRY_CALL_COUNT
+
+
+def test_fetch_lighter_api_key_accepts_null_key_list() -> None:
+    """A null Go slice is treated as a key that is not visible yet."""
+    session = FakeSession([{"api_keys": None}])
+
+    assert fetch_lighter_api_key(session, 12, API_KEY_INDEX) is None  # type: ignore[arg-type]

--- a/tests/lighter/test_lighter_api_key.py
+++ b/tests/lighter/test_lighter_api_key.py
@@ -1,0 +1,62 @@
+"""Tests for native Lighter API-key generation."""
+
+import pytest
+
+from eth_defi.lighter import api_key
+from eth_defi.lighter.api_key import ECGFP5_SCALAR_ORDER, generate_lighter_api_key
+from eth_defi.lighter.pubkey import MAX_API_KEY_INDEX, MIN_API_KEY_INDEX, PUB_KEY_BYTES_SIZE
+
+#: Reference pairs emitted by the official Lighter signer built from
+#: poseidon_crypto commit ca0ad1bc8dfe822c61ba7556d1d4d5bcc2ea4a26.
+REFERENCE_VECTORS = (
+    (
+        "ed844875833f87e80ad26837653759ce9f5288a17758e7cd704aa16a1578b6b77c5e0670ba8ed96a",
+        "79eae45eeb0689a830214c2acc42f622e520d8b7eea30ecdaf826f0283cdc59d23300fb8f59515d9",
+    ),
+    (
+        "b4da53b9fd3759e03f92fd7f5eb7c1609a0e7b287e2622091f651f4e1dbb1c800236a2e443890f27",
+        "d301dc1580771e7a58b806b9ad791bc04764454cadf3bd442f9511b4706556a1e58666aa8de2cb93",
+    ),
+)
+
+
+@pytest.mark.parametrize(("private_key", "expected_public_key"), REFERENCE_VECTORS)
+def test_generate_lighter_api_key_matches_reference(monkeypatch: pytest.MonkeyPatch, private_key: str, expected_public_key: str) -> None:
+    """Generated ECgFp5 public keys match official signer vectors."""
+    private_scalar = int.from_bytes(bytes.fromhex(private_key), "little")
+    monkeypatch.setattr(api_key.secrets, "randbelow", lambda _: private_scalar - 1)
+
+    result = generate_lighter_api_key()
+
+    assert result.private_key == "0x" + private_key
+    assert result.public_key == "0x" + expected_public_key
+
+
+def test_generate_lighter_api_key_uses_little_endian_non_zero_scalar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generated private keys add one to the ``randbelow`` result."""
+    monkeypatch.setattr(api_key.secrets, "randbelow", lambda _: 0)
+
+    result = generate_lighter_api_key()
+
+    assert result.private_key == "0x" + "01" + "00" * 39
+    assert len(bytes.fromhex(result.public_key.removeprefix("0x"))) == PUB_KEY_BYTES_SIZE
+    assert int.from_bytes(bytes.fromhex(result.private_key.removeprefix("0x")), "little") == 1
+
+
+def test_generate_lighter_api_key_accepts_boundary_indices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """All user API-key slots can be generated without exposing the secret."""
+    monkeypatch.setattr(api_key.secrets, "randbelow", lambda _: ECGFP5_SCALAR_ORDER - 2)
+
+    low = generate_lighter_api_key(MIN_API_KEY_INDEX)
+    high = generate_lighter_api_key(MAX_API_KEY_INDEX)
+
+    assert low.api_key_index == MIN_API_KEY_INDEX
+    assert high.api_key_index == MAX_API_KEY_INDEX
+    assert low.private_key not in repr(low)
+
+
+@pytest.mark.parametrize("api_key_index", (MIN_API_KEY_INDEX - 1, MAX_API_KEY_INDEX + 1))
+def test_generate_lighter_api_key_rejects_reserved_or_invalid_index(api_key_index: int) -> None:
+    """Reserved and out-of-range Lighter API-key slots fail before randomness."""
+    with pytest.raises(ValueError, match="api_key_index"):
+        generate_lighter_api_key(api_key_index)

--- a/tests/lighter/test_valuation.py
+++ b/tests/lighter/test_valuation.py
@@ -1,22 +1,19 @@
 """Integration tests for Lighter account valuation."""
 
 import os
-import site
-import sys
 from decimal import Decimal
-from importlib import machinery, util
-from types import ModuleType
 
 import pytest
 
-from eth_defi.lighter.constants import LIGHTER_API_URL
+from eth_defi.lighter.api import fetch_lighter_api_key
+from eth_defi.lighter.pubkey import PUB_KEY_BYTES_SIZE
 from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.valuation import fetch_lighter_account_by_index, fetch_lighter_total_equity, parse_lighter_account_equity
 
 pytestmark = pytest.mark.timeout(60)
 
 ACCOUNT_INDEX = 731323
-API_KEY_INDEX = 4
+DEFAULT_API_KEY_INDEX = 4
 POSITION_COUNT = 2
 ROUNDING_TOLERANCE = Decimal("0.01")
 
@@ -72,28 +69,6 @@ def _require_env(name: str) -> str:
     if not value:
         pytest.skip(f"Set {name} to run Lighter valuation integration tests")
     return value
-
-
-def _import_lighter_sdk() -> ModuleType:
-    """Import the installed Lighter SDK, avoiding ``tests/lighter`` shadowing."""
-    existing = sys.modules.get("lighter")
-    if existing is not None and hasattr(existing, "SignerClient"):
-        return existing
-
-    for package_path in site.getsitepackages():
-        spec = machinery.PathFinder.find_spec("lighter", [package_path])
-        if spec is None or spec.loader is None:
-            continue
-        if not spec.origin or "site-packages" not in spec.origin:
-            continue
-
-        module = util.module_from_spec(spec)
-        sys.modules["lighter"] = module
-        spec.loader.exec_module(module)
-        if hasattr(module, "SignerClient"):
-            return module
-
-    pytest.skip("Install the Lighter SDK to run Lighter valuation integration tests")
 
 
 def test_parse_lighter_account_equity() -> None:
@@ -196,25 +171,9 @@ def test_parse_lighter_account_equity_rejects_non_finite_decimal() -> None:
         parse_lighter_account_equity(account)
 
 
-@pytest.mark.asyncio
-async def test_fetch_lighter_total_equity_with_registered_api_key() -> None:
-    """Fetch NAV for a real Lighter account with a registered API key."""
-    lighter = _import_lighter_sdk()
-
+def test_fetch_lighter_total_equity_for_real_account() -> None:
+    """Fetch NAV from Lighter's public API without a trading API key."""
     account_index = int(_require_env("LIGHTER_TEST_ACCOUNT_INDEX"))
-    api_private_key = _require_env("LIGHTER_TEST_ACCOUNT_API_KEY")
-    api_key_index = int(os.environ.get("LIGHTER_TEST_ACCOUNT_API_KEY_INDEX", str(API_KEY_INDEX)))
-
-    client = lighter.SignerClient(
-        url=LIGHTER_API_URL,
-        account_index=account_index,
-        api_private_keys={api_key_index: api_private_key},
-    )
-    try:
-        err = client.check_client()
-        assert err is None
-    finally:
-        await client.close()
 
     session = create_lighter_session()
     try:
@@ -227,3 +186,19 @@ async def test_fetch_lighter_total_equity_with_registered_api_key() -> None:
     assert equity.collateral >= Decimal("1")
     assert equity.available_balance >= Decimal(0)
     assert equity.calculate_total_from_parts() == pytest.approx(equity.get_total(), abs=ROUNDING_TOLERANCE)
+
+
+def test_fetch_lighter_api_key_for_real_account() -> None:
+    """Fetch the configured registered key through Lighter's public API."""
+    account_index = int(_require_env("LIGHTER_TEST_ACCOUNT_INDEX"))
+    api_key_index = int(os.environ.get("LIGHTER_TEST_ACCOUNT_API_KEY_INDEX", str(DEFAULT_API_KEY_INDEX)))
+
+    session = create_lighter_session()
+    try:
+        api_key = fetch_lighter_api_key(session, account_index, api_key_index)
+    finally:
+        session.close()
+
+    assert api_key is not None
+    assert int(api_key["api_key_index"]) == api_key_index
+    assert len(bytes.fromhex(api_key["public_key"].removeprefix("0x"))) == PUB_KEY_BYTES_SIZE


### PR DESCRIPTION
## Why

Lagoon vault deployment needs to activate a Safe-owned Lighter account and register a trading API key before governance ownership is finalised, while keeping the core `eth-defi` deployment independent of the separately installed Lighter SDK.

## Lessons learnt

Lighter account activation is a two-stage process: the Lagoon deposit must first account for the USDC in the Safe, then the Safe deposits the minimum collateral on Lighter before registering the key. Public Lighter state can lag the L1 transactions, so bounded polling must tolerate transient API failures without hiding permanent client errors. The latest GitHub SDK metadata is compatible with the project, although its legacy `setup.py` still carries an outdated urllib3 constraint, so the tutorial documents an isolated no-dependency installation.

## Summary

- Add an opt-in Lagoon deployment flow that funds and activates a Lighter account, generates an ECgFp5 API key without an SDK dependency, registers it through the Safe, and records the secret in a mode-0600 deployment report.
- Add shared public Lighter account, collateral, API-key and NAV reads with bounded retry handling.
- Promote Lagoon funding from test-only code into the package and retain a compatibility re-export.
- Add a deploy-only tutorial and a separately installable latest-GitHub-SDK tutorial that opens and closes an ETH perpetual using the generated key.
- Add mocked activation/API-key coverage, key derivation vectors, tutorial tests, deployment-report tests, and focused guard/key-registration integration coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.